### PR TITLE
Add X-axis grid lines and time labels to Graph tab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.1.7"
+version = "0.1.8"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/graph_tab/graph_tab.py
+++ b/src/pytest_fly/gui/graph_tab/graph_tab.py
@@ -3,21 +3,28 @@ from PySide6.QtCore import Qt
 
 from ...tick_data import TickData
 from .progress_bar import PytestProgressBar
+from .time_axis import TimeAxisWidget
 
 
 class GraphTab(QGroupBox):
-    """Tab displaying a horizontal progress bar for each test module."""
+    """Tab displaying a horizontal progress bar for each test module with a shared time axis."""
 
     def __init__(self):
         super().__init__()
         self.setTitle("Progress")
         self.progress_bars: dict[str, PytestProgressBar] = {}
+
         layout = QVBoxLayout()
         layout.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.setLayout(layout)
 
+        self.time_axis = TimeAxisWidget()
+        layout.addWidget(self.time_axis)
+
     def update_tick(self, tick: TickData) -> None:
-        """Refresh all progress bars from pre-computed tick data."""
+        """Refresh the time axis and all progress bars from pre-computed tick data."""
+
+        self.time_axis.update_time_window(tick.min_time_stamp, tick.max_time_stamp)
 
         layout = self.layout()
 

--- a/src/pytest_fly/gui/graph_tab/progress_bar.py
+++ b/src/pytest_fly/gui/graph_tab/progress_bar.py
@@ -8,6 +8,7 @@ from typeguard import typechecked
 from ...interfaces import PytestProcessInfo, PytestRunnerState
 from ...pytest_runner.pytest_runner import PytestRunState
 from ..gui_util import get_text_dimensions, tool_tip_limiter
+from .time_axis import compute_grid_ticks, GRID_LINE_COLOR
 from ...logger import get_logger
 
 log = get_logger()
@@ -106,6 +107,12 @@ class PytestProgressBar(QWidget):
 
             painter = QPainter(self)
             painter.setRenderHint(QPainter.Antialiasing)
+
+            # Draw vertical grid lines (behind the bar)
+            grid_ticks = compute_grid_ticks(self.min_time_stamp, self.max_time_stamp, self.width())
+            painter.setPen(QPen(GRID_LINE_COLOR, 1))
+            for x, _label in grid_ticks:
+                painter.drawLine(int(x), 0, int(x), self.height())
 
             if pytest_run_state.get_state() == PytestRunnerState.QUEUED or len(self.status_list) < 2:
                 start_running_time = None

--- a/src/pytest_fly/gui/graph_tab/time_axis.py
+++ b/src/pytest_fly/gui/graph_tab/time_axis.py
@@ -1,0 +1,119 @@
+"""
+Time-axis header and grid-line utilities for the Graph tab.
+
+Provides :func:`compute_grid_ticks` (shared between the axis header and
+individual progress bars) and :class:`TimeAxisWidget` (the header painted
+at the top of the progress-bar list).
+"""
+
+from PySide6.QtWidgets import QWidget
+from PySide6.QtGui import QPainter, QPen, QColor, QPalette
+
+from ..gui_util import get_text_dimensions
+
+
+# Candidate intervals in seconds — chosen so labels stay readable.
+_INTERVALS = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600]
+
+
+def _choose_interval(time_window: float) -> float:
+    """Pick a tick interval that yields roughly 5-12 grid lines."""
+    for interval in _INTERVALS:
+        if time_window / interval <= 12:
+            return interval
+    return _INTERVALS[-1]
+
+
+def _format_tick_label(elapsed_seconds: float) -> str:
+    """Format an elapsed-time value into a compact label (e.g. ``'30s'``, ``'2m'``)."""
+    if elapsed_seconds < 60:
+        return f"{int(elapsed_seconds)}s"
+    minutes = int(elapsed_seconds // 60)
+    seconds = int(elapsed_seconds % 60)
+    if seconds == 0:
+        return f"{minutes}m"
+    return f"{minutes}m{seconds}s"
+
+
+def compute_grid_ticks(min_ts: float | None, max_ts: float | None, width_pixels: int) -> list[tuple[float, str]]:
+    """
+    Compute X-pixel positions and labels for time-axis grid lines.
+
+    Uses the same time-to-pixel mapping as :class:`PytestProgressBar`:
+    ``x = elapsed * (width / time_window)``.
+
+    :param min_ts: Earliest timestamp (epoch seconds), or ``None``.
+    :param max_ts: Latest timestamp (epoch seconds), or ``None``.
+    :param width_pixels: Widget width in pixels.
+    :return: List of ``(x_pixel, label_text)`` tuples.
+    """
+    if min_ts is None or max_ts is None or width_pixels <= 0:
+        return []
+
+    time_window = max(max_ts - min_ts, 1.0)
+    pixels_per_second = width_pixels / time_window
+    interval = _choose_interval(time_window)
+
+    ticks: list[tuple[float, str]] = []
+    elapsed = 0.0
+    while elapsed <= time_window:
+        x = elapsed * pixels_per_second
+        ticks.append((x, _format_tick_label(elapsed)))
+        elapsed += interval
+
+    return ticks
+
+
+# Grid line color — light gray, semi-transparent so bars remain readable.
+GRID_LINE_COLOR = QColor(180, 180, 180, 100)
+
+
+class TimeAxisWidget(QWidget):
+    """Compact header widget that draws time-axis labels and short tick marks."""
+
+    def __init__(self):
+        super().__init__()
+        char_dims = get_text_dimensions("X")
+        self._axis_height = char_dims.height() + 8  # text + small padding
+        self.setFixedHeight(self._axis_height)
+
+        self._min_ts: float | None = None
+        self._max_ts: float | None = None
+
+    def update_time_window(self, min_ts: float | None, max_ts: float | None):
+        """Store the current time window and schedule a repaint."""
+        if min_ts == self._min_ts and max_ts == self._max_ts:
+            return
+        self._min_ts = min_ts
+        self._max_ts = max_ts
+        self.update()
+
+    def paintEvent(self, event):
+        ticks = compute_grid_ticks(self._min_ts, self._max_ts, self.width())
+        if not ticks:
+            super().paintEvent(event)
+            return
+
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        h = self.height()
+        tick_height = 5  # short tick mark at the bottom of the axis
+
+        # Draw tick marks
+        painter.setPen(QPen(GRID_LINE_COLOR, 1))
+        for x, _label in ticks:
+            painter.drawLine(int(x), h - tick_height, int(x), h)
+
+        # Draw labels
+        palette = self.palette()
+        text_color = palette.color(QPalette.WindowText)
+        painter.setPen(QPen(text_color, 1))
+        for x, label in ticks:
+            label_width = get_text_dimensions(label).width()
+            # Center label on tick; clamp so it doesn't overflow the left edge
+            label_x = max(int(x) - label_width // 2, 0)
+            label_y = h - tick_height - 2  # just above the tick mark
+            painter.drawText(label_x, label_y, label)
+
+        painter.end()


### PR DESCRIPTION
## Summary
- Add `TimeAxisWidget` header at the top of the Graph tab with auto-scaled elapsed-time labels
- Draw faint vertical grid lines through all progress bars for visual time reference
- Grid interval adapts automatically (1s, 2s, 5s, 10s, 15s, 30s, 1m, 2m, 5m, 10m) based on the time window
- Shared `compute_grid_ticks()` function ensures perfect alignment between axis header and bar widgets
- Bump version to 0.1.8

## Test plan
- [x] All 35 tests pass (`pytest tests/ -x`)
- [x] No new flake8 warnings
- [ ] Launch app, click Run, verify time axis labels and grid lines appear on Graph tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)