### PR TITLE
Fix CI: install Qt system dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Qt dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libegl1 libxkbcommon0 libdbus-1-3
+
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -27,6 +32,8 @@ jobs:
           pip install -e .
 
       - name: Run tests with coverage
+        env:
+          QT_QPA_PLATFORM: offscreen
         run: coverage run -m pytest tests
 
       - name: Generate coverage report


### PR DESCRIPTION
## Summary
- Install `libegl1`, `libxkbcommon0`, `libdbus-1-3` for PySide6 on Ubuntu
- Set `QT_QPA_PLATFORM=offscreen` so tests run headless

Fixes CI failure from #27 where `libEGL.so.1` was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)