### PR TITLE
Fix uuid7 compat: use uuid6 package for Python 3.12

### DIFF
--- a/src/pytest_fly/guid.py
+++ b/src/pytest_fly/guid.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime, timezone
 
 from typeguard import typechecked
+from uuid6 import uuid7
 
 
 @typechecked
@@ -9,7 +10,7 @@ def generate_uuid() -> str:
     """
     Generate a UUIDv7 (time-ordered, timestamp-encoded).
     """
-    u = str(uuid.uuid7())
+    u = str(uuid7())
     return u
 
 


### PR DESCRIPTION
## Summary
- Use `uuid6.uuid7()` instead of `uuid.uuid7()` in `guid.py`
- `uuid.uuid7()` was added in Python 3.14; Python 3.12 needs the `uuid6` package (already a dependency)
- Fixes all 9 test failures in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)