### PR TITLE
Fix coverage: scope to src/ directory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests with coverage
         env:
           QT_QPA_PLATFORM: offscreen
-        run: coverage run -m pytest tests
+        run: coverage run --source=src -m pytest tests
 
       - name: Generate coverage report
         run: coverage xml


### PR DESCRIPTION
## Summary
- Add `--source=src` to `coverage run` to avoid picking up PySide6/shiboken internal files
- Fixes `No source for code: shibokensupport/__init__.py` error in coverage xml generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)