### PR TITLE
Remove invalid codecov action input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,4 +43,3 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: coverage.xml
-          fail_ci_if_not_uploaded: false


### PR DESCRIPTION
## Summary
- Remove `fail_ci_if_not_uploaded` which is not a valid input for `codecov/codecov-action@v4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)