### PR TITLE
Add Python 3.13 and 3.14 version classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",
 ]


### PR DESCRIPTION
## Summary
- Add `Programming Language :: Python :: 3.13` and `3.14` classifiers
- PyPI version badge will show `3.12 | 3.13 | 3.14` after the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)