### PR TITLE
Enforce singleton test exclusive execution and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,29 @@
 [![Python](https://img.shields.io/pypi/pyversions/pytest-fly)](https://pypi.org/project/pytest-fly/)
 [![License](https://img.shields.io/pypi/l/pytest-fly)](https://github.com/jamesabel/pytest-fly/blob/master/LICENSE)
 
-`pytest-fly` aides the development, debug, and execution of complex code bases and test suites.
+`pytest-fly` aids the development, debug, and execution of complex code bases and test suites.
 
-## Features of `pytest-fly`
+## Features
 
-- Real-time monitor test execution in a GUI. Displays what tests are currently running, what tests have completed,
-and what tests have failed. A time-based graph provides a visual representation of test progress.
-- Resumable test execution. Only runs tests that have not yet been run or have failed.
-- Graceful interruption of test execution. Allows the user to stop the test suite and then resume where it left off.
-- Checks the code under test and restarts the test run from scratch if the code has changed.
-- Optimally run tests in parallel. Monitors system resources and dynamically adjusts the number of 
-parallel tests accordingly.
-- Provides an estimate of the time remaining for the test suite to complete. Uses prior test run times to estimate 
-the time remaining.
-- Optional code coverage. Code coverage can also run tests in parallel.
-- Run specific tests as a singleton via pytest markers (pytest.marker.singleton).
+- Real-time monitoring of test execution in a GUI with five tabs:
+  - **Run** — start/stop controls and run mode selection
+  - **Table** — per-test status grid with elapsed time, peak CPU, and memory usage
+  - **Graph** — time-based progress chart
+  - **Configuration** — parallelism settings and resource thresholds
+  - **About** — system and project information
+- Parallel test execution at the module level with configurable process count.
+- Graceful interruption — stop the test suite and resume where it left off.
+- Per-process resource monitoring — tracks peak CPU and memory usage for each test module.
+- Optional code coverage that runs in parallel across test modules.
+- Singleton test support via `@pytest.mark.singleton` — singleton tests run exclusively with no other tests 
+executing concurrently.
 
 ## Installation
 
 You can install `pytest-fly` via `pip` from `PyPI`:
 
 ```
-    pip install pytest-fly
+pip install pytest-fly
 ```
 
 ## Parallelism
@@ -38,27 +39,20 @@ Functions *inside* a module are executed serially with respect to each other. No
 functions inside a module. For example, if a set of tests use a shared resource that does not support concurrent 
 access, putting those tests in the same module ensures the tests do not conflict.
 
-Functions can optionally be run as a singleton via the `pytest.mark.singleton` marker. No other tests are run 
-at the same time `singleton` functions are run.
+Modules can optionally be marked as a singleton via the `@pytest.mark.singleton` marker. When a singleton test 
+runs, all other workers wait until it completes before starting new tests. This is enforced at runtime, not 
+just by scheduling order.
 
-In `pytest` terms, each module will be run as a separate `session`. Therefore, a pytest fixture with a `session` scope 
-will actually be executed multiple times, once for each modulee.
+In `pytest` terms, each module is run in a separate subprocess. Therefore, a pytest fixture with a `session` scope 
+will actually be executed multiple times, once for each module.
 
 Note that test concurrency in `pytest-fly` is different from `pytest-xdist`. `group-by` in `pytest-xdist` is
 analogous to putting the tests in the same module in `pytest-fly`.
 
 ## Test Scheduling
 
-`pytest-fly` attempts to order tests to make the best use of the test developer's time. The goal is for the more 
-actionable and insightful information to appear earlier. In general, `pytest-fly` takes the following into account 
-when scheduling tests:
+`pytest-fly` orders tests to surface actionable information earlier:
 
-1. Failed tests are re-run first. This is beneficial when a test developer is fixing failed tests. Note that if a 
-test is *expected* to fail, it should be temporarily marked as such to avoid spending time re-running a test that 
-will merely fail.
-2. Tests with a higher coverage over time (i.e., lines/second) are run earlier. This way, if there is a problem in the 
-code, it is more likely to be found earlier in the test run.
-3. Tests are scheduled for maximum parallelism. Long-running tests are started earlier to minimize overall runtime. 
-Also, tests that consume large amounts of particular resources (e.g., memory, file system, etc.) tend to be paired 
-with other tests that do not use as much of those resources.
-4. `singleton` tests are run last. This is to attempt to get higher coverage earlier in the test run.
+1. When prior run data is available, tests with higher coverage efficiency (lines/second) are run earlier. 
+This way, if there is a problem in the code, it is more likely to be found earlier in the test run.
+2. `singleton` tests are run last to maximize parallel throughput before exclusive execution begins.

--- a/src/pytest_fly/pytest_runner/pytest_runner.py
+++ b/src/pytest_fly/pytest_runner/pytest_runner.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from queue import Queue, Empty
 from typing import Optional
-from threading import Event, Thread
+from threading import Event, Lock, Thread
 import time
 
 from typeguard import typechecked
@@ -96,12 +96,20 @@ class PytestRunner(Thread):
         test_queue = Queue()
         with PytestProcessInfoDB(self.data_dir) as db:
             for test in self.tests:
-                test_queue.put(test.node_id)
+                test_queue.put(test)
                 pytest_process_info = PytestProcessInfo(self.run_guid, test.node_id, None, PyTestFlyExitCode.NONE, None, time_stamp=time.time())  # queued
                 db.write(pytest_process_info)
 
+        # Singleton enforcement primitives (shared across all workers)
+        singleton_event = Event()
+        singleton_event.set()  # parallel execution allowed initially
+        active_count_lock = Lock()
+        active_workers = [0]  # mutable counter shared by reference
+        all_idle_event = Event()
+        all_idle_event.set()  # no workers active initially
+
         for thread_number in range(self.number_of_processes):
-            test_runner = _TestRunner(self.run_guid, test_queue, self.data_dir, self.update_rate)
+            test_runner = _TestRunner(self.run_guid, test_queue, self.data_dir, self.update_rate, singleton_event, active_count_lock, active_workers, all_idle_event)
             test_runner.start()
             self._test_runners[thread_number] = test_runner
         self._started_event.set()
@@ -135,17 +143,32 @@ class PytestRunner(Thread):
 
 class _TestRunner(Thread):
     """
-    Worker thread that pulls test names from a shared queue and runs each one
-    in a dedicated :class:`PytestProcess`.
+    Worker thread that pulls tests from a shared queue and runs each one
+    in a dedicated :class:`PytestProcess`.  Singleton tests are run exclusively —
+    no other workers execute concurrently.
     """
 
     @typechecked()
-    def __init__(self, run_guid: str, pytest_test_queue: Queue, data_dir: Path, update_rate: float) -> None:
+    def __init__(
+        self,
+        run_guid: str,
+        pytest_test_queue: Queue,
+        data_dir: Path,
+        update_rate: float,
+        singleton_event: Event,
+        active_count_lock: Lock,
+        active_workers: list,
+        all_idle_event: Event,
+    ) -> None:
         """
         :param run_guid: GUID identifying the overall test run.
-        :param pytest_test_queue: Shared queue of test node-IDs to execute.
+        :param pytest_test_queue: Shared queue of :class:`ScheduledTest` to execute.
         :param data_dir: Directory used for the results database.
         :param update_rate: Polling / process-monitor sample interval in seconds.
+        :param singleton_event: Cleared when a singleton is running to block other workers.
+        :param active_count_lock: Protects the *active_workers* counter.
+        :param active_workers: Single-element list ``[int]`` tracking how many workers are executing.
+        :param all_idle_event: Set when *active_workers* drops to zero.
         """
         super().__init__()
 
@@ -156,6 +179,29 @@ class _TestRunner(Thread):
 
         self.process: Optional[PytestProcess] = None
         self._stop_event = Event()
+
+        # Singleton enforcement (shared across all workers)
+        self._singleton_event = singleton_event
+        self._active_count_lock = active_count_lock
+        self._active_workers = active_workers
+        self._all_idle_event = all_idle_event
+
+    # ------------------------------------------------------------------
+    # Active-worker tracking
+    # ------------------------------------------------------------------
+
+    def _increment_active(self):
+        """Mark this worker as actively running a test."""
+        with self._active_count_lock:
+            self._active_workers[0] += 1
+            self._all_idle_event.clear()
+
+    def _decrement_active(self):
+        """Mark this worker as idle.  Signals *all_idle_event* when count hits zero."""
+        with self._active_count_lock:
+            self._active_workers[0] -= 1
+            if self._active_workers[0] == 0:
+                self._all_idle_event.set()
 
     # ------------------------------------------------------------------
     # Process lifecycle helpers
@@ -228,18 +274,14 @@ class _TestRunner(Thread):
             self._terminate_process(proc, proc_name, test)
 
     # ------------------------------------------------------------------
-    # Main loop
+    # Test execution
     # ------------------------------------------------------------------
 
-    def run(self):
-        """Consume test node-IDs from the queue until it is empty or a stop is requested."""
+    def _run_single_test(self, test: str):
+        """Run a single test process, tracking the active worker count."""
 
-        while not self._stop_event.is_set():
-            try:
-                test = self.pytest_test_queue.get(False)
-            except Empty:
-                break
-
+        self._increment_active()
+        try:
             self.process = PytestProcess(self.run_guid, test, self.data_dir, self.update_rate)
             log.info(f'Starting process for test "{test}" ({self.run_guid=})')
             self.process.start()
@@ -259,6 +301,45 @@ class _TestRunner(Thread):
                 log.warning(f'process for test "{self.process.name}" did not terminate ({self.run_guid=})')
             else:
                 log.info(f'process for test "{self.process.name}" completed ({self.run_guid=})')
+        finally:
+            self._decrement_active()
+
+    # ------------------------------------------------------------------
+    # Main loop
+    # ------------------------------------------------------------------
+
+    def run(self):
+        """Consume tests from the queue until it is empty or a stop is requested."""
+
+        while not self._stop_event.is_set():
+            try:
+                scheduled_test = self.pytest_test_queue.get(False)
+            except Empty:
+                break
+
+            test = scheduled_test.node_id
+
+            if scheduled_test.singleton:
+                # Singleton protocol: block others, drain active workers, run exclusively, resume.
+                self._singleton_event.clear()
+                while not self._all_idle_event.wait(timeout=self.update_rate):
+                    if self._stop_event.is_set():
+                        break
+                if self._stop_event.is_set():
+                    self._handle_stop_request(test)
+                    break
+                log.info(f'Running singleton test "{test}" ({self.run_guid=})')
+                self._run_single_test(test)
+                self._singleton_event.set()
+            else:
+                # Normal protocol: wait until no singleton is running.
+                while not self._singleton_event.wait(timeout=self.update_rate):
+                    if self._stop_event.is_set():
+                        break
+                if self._stop_event.is_set():
+                    self._handle_stop_request(test)
+                    break
+                self._run_single_test(test)
 
     def stop(self):
         """Signal all work to stop as soon as possible."""

--- a/tests/test_pytest_runner/test_pytest_runner_singleton.py
+++ b/tests/test_pytest_runner/test_pytest_runner_singleton.py
@@ -1,0 +1,62 @@
+from pytest_fly.pytest_runner import PytestRunner
+from pytest_fly.guid import generate_uuid
+from pytest_fly.interfaces import ScheduledTest, PyTestFlyExitCode
+from pytest_fly.db import PytestProcessInfoDB
+
+from ..paths import get_temp_dir
+
+
+def test_pytest_runner_singleton(app):
+    """Verify that a singleton test runs exclusively — not overlapping with other tests."""
+
+    test_name = "test_pytest_runner_singleton"
+
+    # Two normal tests (run in parallel) plus one singleton (must run alone).
+    # The singleton is last because ScheduledTest sorting puts singletons at the end.
+    scheduled_tests = sorted(
+        [
+            ScheduledTest(node_id="tests/test_no_operation.py", singleton=False, duration=None, coverage=None),
+            ScheduledTest(node_id="tests/test_3_sec_operation.py", singleton=False, duration=None, coverage=None),
+            ScheduledTest(node_id="tests/test_singleton.py", singleton=True, duration=None, coverage=None),
+        ]
+    )
+
+    run_guid = generate_uuid()
+    data_dir = get_temp_dir(test_name)
+
+    runner = PytestRunner(run_guid, scheduled_tests, number_of_processes=2, data_dir=data_dir, update_rate=1.0)
+    runner.start()
+    runner.join(120.0)
+    assert not runner.is_running()
+
+    with PytestProcessInfoDB(data_dir) as db:
+        query_results = db.query(run_guid)
+
+    # Each test produces 3 DB records: queued (no pid), running (has pid), completed (has exit code).
+    # 3 tests * 3 records = 9 total.
+    assert len(query_results) == 9
+
+    # Group results by test name
+    test_results = {}
+    for r in query_results:
+        test_results.setdefault(r.name, []).append(r)
+
+    assert len(test_results) == 3
+
+    # The singleton test must have started (its "running" record timestamp)
+    # AFTER all normal tests finished (their final record timestamp).
+    singleton_records = test_results["tests/test_singleton.py"]
+    singleton_running = [r for r in singleton_records if r.pid is not None and r.exit_code == PyTestFlyExitCode.NONE]
+    assert len(singleton_running) == 1
+    singleton_start_time = singleton_running[0].time_stamp
+
+    for test_name_key, records in test_results.items():
+        if test_name_key == "tests/test_singleton.py":
+            continue
+        # The final record for each normal test is the completion record
+        final_record = records[-1]
+        assert final_record.exit_code == PyTestFlyExitCode.OK, f"{test_name_key} did not pass: {final_record.exit_code}"
+        assert final_record.time_stamp <= singleton_start_time, (
+            f"Singleton test started at {singleton_start_time} but "
+            f"{test_name_key} finished at {final_record.time_stamp} — singleton was not exclusive"
+        )


### PR DESCRIPTION
## Summary
- **Singleton enforcement**: `@pytest.mark.singleton` tests now run exclusively at runtime — all other workers drain before a singleton starts and wait until it finishes. Uses shared `Event`/`Lock` primitives for coordination.
- **New test**: `test_pytest_runner_singleton.py` verifies exclusive execution via DB timestamp assertions.
- **README update**: Reflects current codebase accurately — removes claims about unimplemented features (dynamic parallelism, ETA, resume mode, code-change detection), fixes typos, documents GUI tabs and resource monitoring.

## Test plan
- [x] `pytest tests/test_pytest_runner/` — all 4 runner tests pass (3 existing + 1 new)
- [ ] Full test suite `pytest tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)