### PR TITLE
Re-run failed tests first on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ analogous to putting the tests in the same module in `pytest-fly`.
 
 `pytest-fly` orders tests to surface actionable information earlier:
 
-1. When prior run data is available, tests with higher coverage efficiency (lines/second) are run earlier. 
+1. Tests that failed in the prior run are re-run first, so developers get faster feedback on tests they are 
+likely fixing.
+2. When prior run data is available, tests with higher coverage efficiency (lines/second) are run earlier. 
 This way, if there is a problem in the code, it is more likely to be found earlier in the test run.
-2. `singleton` tests are run last to maximize parallel throughput before exclusive execution begins.
+3. `singleton` tests are run last to maximize parallel throughput before exclusive execution begins.

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -95,11 +95,20 @@ class ControlWindow(QGroupBox):
 
         tests = get_tests.get_tests()
 
+        # Query prior results once (used by both RESUME filtering and failed-first ordering)
+        with PytestProcessInfoDB(self.data_dir) as db:
+            prior_results = db.query()  # most recent run
+
         if pref.run_mode == RunMode.RESUME:
-            with PytestProcessInfoDB(self.data_dir) as db:
-                prior_results = db.query()  # most recent run
             passed = {r.name for r in prior_results if r.exit_code == PyTestFlyExitCode.OK}
             tests = [t for t in tests if t.node_id not in passed]
+
+        # Reorder so previously-failed tests run first (within their singleton group)
+        if prior_results:
+            passed = {r.name for r in prior_results if r.exit_code == PyTestFlyExitCode.OK}
+            prior_names = {r.name for r in prior_results}
+            failed = prior_names - passed
+            tests = sorted(tests, key=lambda t: (t.singleton, t.node_id not in failed))
 
         self.pytest_runner = PytestRunner(self.run_guid, tests, processes, self.data_dir, refresh_rate)
         self.pytest_runner.start()


### PR DESCRIPTION
## Summary
- Query DB for prior run results and stable-sort so previously-failed tests run first
- Preserves singleton-last ordering and coverage-efficiency order within each group
- Refactors RESUME DB query to be shared (avoids duplicate queries)
- Updates README to document failed-first scheduling

## Test plan
- [x] Full test suite passes (36/36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)