### PR TITLE
Implement estimated time remaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - Parallel test execution at the module level with configurable process count.
 - Graceful interruption — stop the test suite and resume where it left off.
 - Per-process resource monitoring — tracks peak CPU and memory usage for each test module.
+- Estimated time remaining based on prior run durations, accounting for parallelism.
 - Optional code coverage that runs in parallel across test modules.
 - Singleton test support via `@pytest.mark.singleton` — singleton tests run exclusively with no other tests 
 executing concurrently.

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -28,7 +28,7 @@ from .graph_tab import GraphTab
 log = get_logger()
 
 
-def build_tick_data(process_infos):
+def build_tick_data(process_infos, prior_durations=None, num_processes=1):
     """
     Build a :class:`TickData` bundle from a flat list of process info records.
 
@@ -48,6 +48,8 @@ def build_tick_data(process_infos):
         max_time_stamp=max_ts,
         min_time_stamp_started=min_ts_s,
         max_time_stamp_started=max_ts_s,
+        prior_durations=prior_durations if prior_durations is not None else {},
+        num_processes=num_processes,
     )
 
 
@@ -150,7 +152,8 @@ class FlyAppMainWindow(QMainWindow):
         with PytestProcessInfoDB(self.data_dir) as db:
             process_infos = db.query(self.run_tab.control_window.run_guid)
 
-        tick = build_tick_data(process_infos)
+        control = self.run_tab.control_window
+        tick = build_tick_data(process_infos, prior_durations=control.prior_durations, num_processes=control.num_processes)
 
         self.graph_tab.update_tick(tick)
         self.table_tab.update_tick(tick)

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -54,6 +54,8 @@ class ControlWindow(QGroupBox):
         layout.addWidget(self.run_mode_box)
 
         self.pytest_runner: PytestRunner | None = None
+        self.prior_durations: dict[str, float] = {}
+        self.num_processes: int = 1
 
         self.set_fixed_width()  # calculate and set the widget width
 
@@ -109,6 +111,23 @@ class ControlWindow(QGroupBox):
             prior_names = {r.name for r in prior_results}
             failed = prior_names - passed
             tests = sorted(tests, key=lambda t: (t.singleton, t.node_id not in failed))
+
+        # Compute prior durations for ETA estimation
+        self.prior_durations = {}
+        prior_by_name: dict[str, list] = {}
+        for r in prior_results:
+            prior_by_name.setdefault(r.name, []).append(r)
+        for name, infos in prior_by_name.items():
+            start = None
+            end = None
+            for info in infos:
+                if info.pid is not None and start is None:
+                    start = info.time_stamp
+                if info.exit_code != PyTestFlyExitCode.NONE:
+                    end = info.time_stamp
+            if start is not None and end is not None:
+                self.prior_durations[name] = end - start
+        self.num_processes = processes
 
         self.pytest_runner = PytestRunner(self.run_guid, tests, processes, self.data_dir, refresh_rate)
         self.pytest_runner.start()

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -1,3 +1,4 @@
+import time
 from collections import defaultdict
 from datetime import timedelta
 
@@ -60,6 +61,24 @@ class StatusWindow(QGroupBox):
             if min_time_stamp is not None and max_time_stamp is not None:
                 overall_time = max_time_stamp - min_time_stamp
                 lines.append(f"Total time: {humanize.precisedelta(timedelta(seconds=overall_time))}")
+
+            # estimated time remaining based on prior run durations
+            if tick.prior_durations and (counts[PytestRunnerState.QUEUED] + counts[PytestRunnerState.RUNNING]) > 0:
+                remaining_seconds = 0.0
+                now = time.time()
+                for test_name, run_state in tick.run_states.items():
+                    state = run_state.get_state()
+                    prior = tick.prior_durations.get(test_name, 0.0)
+                    if state == PytestRunnerState.QUEUED:
+                        remaining_seconds += prior
+                    elif state == PytestRunnerState.RUNNING:
+                        infos = tick.infos_by_name.get(test_name, [])
+                        started_at = next((i.time_stamp for i in infos if i.pid is not None), None)
+                        if started_at is not None:
+                            remaining_seconds += max(0.0, prior - (now - started_at))
+                if remaining_seconds > 0 and tick.num_processes > 0:
+                    wall_clock = remaining_seconds / tick.num_processes
+                    lines.append(f"Estimated remaining: {humanize.precisedelta(timedelta(seconds=wall_clock))}")
         else:
             lines = ["Tests not yet run. Please run the tests."]
 

--- a/src/pytest_fly/tick_data.py
+++ b/src/pytest_fly/tick_data.py
@@ -25,3 +25,5 @@ class TickData:
     # Time window considering only records where pid is set (process has started)
     min_time_stamp_started: float | None = None
     max_time_stamp_started: float | None = None
+    prior_durations: dict[str, float] = field(default_factory=dict)
+    num_processes: int = 1


### PR DESCRIPTION
## Summary
- Compute prior test durations from DB at run start and store on `ControlWindow`
- Add `prior_durations` and `num_processes` fields to `TickData`
- Thread data from `gui_main._update_tick()` through `build_tick_data()` into `TickData`
- `StatusWindow` computes ETA: sum remaining time for queued/running tests, divide by process count
- Update README to document the feature

## Test plan
- [x] Full test suite passes (36/36)
- [ ] Manual: complete a test run, run again — ETA appears and counts down

🤖 Generated with [Claude Code](https://claude.com/claude-code)