### PR TITLE
Add Coverage tab with coverage-over-time chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,19 @@
 
 ## Features
 
-- Real-time monitoring of test execution in a GUI with five tabs:
+- Real-time monitoring of test execution in a GUI with six tabs:
   - **Run** — start/stop controls and run mode selection
-  - **Table** — per-test status grid with elapsed time, peak CPU, and memory usage
   - **Graph** — time-based progress chart
+  - **Table** — per-test status grid with elapsed time, peak CPU, and memory usage
+  - **Coverage** — line chart of combined code coverage over time
   - **Configuration** — parallelism settings and resource thresholds
   - **About** — system and project information
 - Parallel test execution at the module level with configurable process count.
 - Graceful interruption — stop the test suite and resume where it left off.
 - Per-process resource monitoring — tracks peak CPU and memory usage for each test module.
 - Estimated time remaining based on prior run durations, accounting for parallelism.
-- Optional code coverage that runs in parallel across test modules.
+- Code coverage tracking — each test writes its own coverage data, combined automatically as tests 
+complete. Coverage persists across restarts so previously-passed tests contribute to the total.
 - Singleton test support via `@pytest.mark.singleton` — singleton tests run exclusively with no other tests 
 executing concurrently.
 

--- a/src/pytest_fly/gui/coverage_tab/__init__.py
+++ b/src/pytest_fly/gui/coverage_tab/__init__.py
@@ -1,0 +1,1 @@
+from .coverage_tab import CoverageTab

--- a/src/pytest_fly/gui/coverage_tab/coverage_tab.py
+++ b/src/pytest_fly/gui/coverage_tab/coverage_tab.py
@@ -1,0 +1,164 @@
+"""
+Coverage tab — displays a step-function line chart of combined code coverage over time.
+"""
+
+from PySide6.QtWidgets import QGroupBox, QVBoxLayout, QWidget, QSizePolicy
+from PySide6.QtGui import QPainter, QPen, QColor, QPalette, QBrush, QPolygonF
+from PySide6.QtCore import Qt, QPointF
+
+from ...tick_data import TickData
+from ...interfaces import PytestRunnerState
+from ..graph_tab.time_axis import compute_grid_ticks
+from ..gui_util import get_text_dimensions
+
+GRID_LINE_COLOR = QColor(180, 180, 180, 100)
+COVERAGE_LINE_COLOR = QColor(34, 139, 34)  # forest green
+COVERAGE_FILL_COLOR = QColor(34, 139, 34, 40)  # translucent green fill
+
+# Horizontal grid lines at these percentages
+_Y_GRID_PCTS = [0.25, 0.50, 0.75, 1.00]
+
+
+class _CoverageChart(QWidget):
+    """Custom-painted widget that renders a coverage-over-time step chart."""
+
+    def __init__(self):
+        super().__init__()
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        self._coverage_history: list[tuple[float, float]] = []
+        self._min_ts: float | None = None
+        self._max_ts: float | None = None
+        self._status_text: str = ""
+
+    def update_data(self, coverage_history: list[tuple[float, float]], min_ts: float | None, max_ts: float | None, status_text: str):
+        self._coverage_history = coverage_history
+        self._min_ts = min_ts
+        self._max_ts = max_ts
+        self._status_text = status_text
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        w = self.width()
+        h = self.height()
+        margin_left = get_text_dimensions("100% ").width()
+        margin_top = get_text_dimensions("X").height() + 8  # room for coverage label and status
+        margin_bottom = get_text_dimensions("X").height() + 4
+        chart_w = w - margin_left
+        chart_h = h - margin_top - margin_bottom
+
+        if chart_w <= 0 or chart_h <= 0:
+            painter.end()
+            return
+
+        palette = self.palette()
+        text_color = palette.color(QPalette.WindowText)
+
+        # Draw Y-axis labels and horizontal grid lines
+        painter.setPen(QPen(GRID_LINE_COLOR, 1))
+        for pct in _Y_GRID_PCTS:
+            y = margin_top + int(chart_h * (1.0 - pct))
+            painter.drawLine(margin_left, y, w, y)
+
+        painter.setPen(QPen(text_color, 1))
+        for pct in _Y_GRID_PCTS:
+            y = margin_top + int(chart_h * (1.0 - pct))
+            label = f"{int(pct * 100)}%"
+            label_w = get_text_dimensions(label).width()
+            painter.drawText(margin_left - label_w - 4, y + 4, label)
+
+        # Draw vertical time grid lines
+        grid_ticks = compute_grid_ticks(self._min_ts, self._max_ts, chart_w)
+        painter.setPen(QPen(GRID_LINE_COLOR, 1))
+        for x, label in grid_ticks:
+            painter.drawLine(int(margin_left + x), margin_top, int(margin_left + x), margin_top + chart_h)
+            painter.setPen(QPen(text_color, 1))
+            painter.drawText(int(margin_left + x) - 8, h - 2, label)
+            painter.setPen(QPen(GRID_LINE_COLOR, 1))
+
+        # Draw status indicator
+        if self._status_text:
+            painter.setPen(QPen(text_color, 1))
+            status_x = w - get_text_dimensions(self._status_text).width() - 10
+            painter.drawText(status_x, get_text_dimensions("X").height(), self._status_text)
+
+        # Draw coverage step line
+        if not self._coverage_history or self._min_ts is None or self._max_ts is None:
+            painter.setPen(QPen(text_color, 1))
+            painter.drawText(margin_left + 10, margin_top + chart_h // 2, "Waiting for coverage data...")
+            painter.end()
+            return
+
+        time_window = max(self._max_ts - self._min_ts, 1.0)
+        px_per_sec = chart_w / time_window
+
+        def to_pixel(ts: float, pct: float) -> tuple[int, int]:
+            x = margin_left + int((ts - self._min_ts) * px_per_sec)
+            y = margin_top + int(chart_h * (1.0 - pct))
+            return x, y
+
+        # Build step-function points
+        points = []
+        for i, (ts, pct) in enumerate(self._coverage_history):
+            x, y = to_pixel(ts, pct)
+            if i > 0:
+                # horizontal step from previous y to current x
+                points.append((x, points[-1][1]))
+            points.append((x, y))
+
+        # Draw filled area under the line
+        if len(points) >= 2:
+            fill_points = [QPointF(px, py) for px, py in points]
+            # close the polygon along the bottom
+            fill_points.append(QPointF(points[-1][0], margin_top + chart_h))
+            fill_points.append(QPointF(points[0][0], margin_top + chart_h))
+            painter.setPen(Qt.NoPen)
+            painter.setBrush(QBrush(COVERAGE_FILL_COLOR))
+            painter.drawPolygon(QPolygonF(fill_points))
+
+        # Draw the line itself
+        painter.setPen(QPen(COVERAGE_LINE_COLOR, 2))
+        for i in range(len(points) - 1):
+            painter.drawLine(points[i][0], points[i][1], points[i + 1][0], points[i + 1][1])
+
+        # Draw current coverage label
+        latest_pct = self._coverage_history[-1][1]
+        label = f"Coverage: {latest_pct:.1%}"
+        painter.setPen(QPen(text_color, 1))
+        painter.drawText(margin_left + 10, get_text_dimensions("X").height(), label)
+
+        painter.end()
+
+
+class CoverageTab(QGroupBox):
+    """Tab displaying a line chart of combined code coverage over time."""
+
+    def __init__(self):
+        super().__init__()
+        self.setTitle("Coverage")
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        self.chart = _CoverageChart()
+        layout.addWidget(self.chart, stretch=1)
+
+    def update_tick(self, tick: TickData) -> None:
+        # Compute status indicator from run states
+        if tick.run_states:
+            total = len(tick.run_states)
+            running = sum(1 for rs in tick.run_states.values() if rs.get_state() == PytestRunnerState.RUNNING)
+            queued = sum(1 for rs in tick.run_states.values() if rs.get_state() == PytestRunnerState.QUEUED)
+            if running > 0 or queued > 0:
+                completed = total - running - queued
+                status_text = f"Running ({completed}/{total} complete)"
+            else:
+                status_text = f"Complete ({total}/{total} tests)"
+        else:
+            status_text = ""
+
+        self.chart.update_data(tick.coverage_history, tick.min_time_stamp, tick.max_time_stamp, status_text)

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -1,4 +1,5 @@
 # python
+import time
 from pathlib import Path
 
 from PySide6.QtWidgets import (
@@ -18,11 +19,14 @@ from ..gui.about_tab.about import About
 from ..preferences import get_pref
 from ..__version__ import application_name
 from ..tick_data import TickData
+from ..interfaces import PytestRunnerState
 from ..pytest_runner.pytest_runner import PytestRunState
+from ..pytest_runner.coverage import calculate_coverage
 from .gui_util import get_font, get_text_dimensions, group_process_infos_by_name, compute_time_window
 from .run_tab import RunTab
 from .table_tab import TableTab
 from .graph_tab import GraphTab
+from .coverage_tab import CoverageTab
 
 
 log = get_logger()
@@ -95,13 +99,20 @@ class FlyAppMainWindow(QMainWindow):
         self.run_tab = RunTab(self, self.data_dir)
         self.graph_tab = GraphTab()
         self.table_tab = TableTab()
+        self.coverage_tab = CoverageTab()
         self.configuration = Configuration()
         self.about = About(self)
         self.tab_widget.addTab(self.run_tab, "Run")
         self.tab_widget.addTab(self.graph_tab, "Graph")
         self.tab_widget.addTab(self.table_tab, "Table")
+        self.tab_widget.addTab(self.coverage_tab, "Coverage")
         self.tab_widget.addTab(self.configuration, "Configuration")
         self.tab_widget.addTab(self.about, "About")
+
+        # Coverage tracking state
+        self._completed_tests: set[str] = set()
+        self._coverage_history: list[tuple[float, float]] = []
+        self._last_run_guid: str | None = None
 
         # Wrap the tab widget in a scroll area so that very tall tab contents produce scrollbars
         self.scroll_area = QScrollArea()
@@ -155,9 +166,29 @@ class FlyAppMainWindow(QMainWindow):
         control = self.run_tab.control_window
         tick = build_tick_data(process_infos, prior_durations=control.prior_durations, num_processes=control.num_processes)
 
+        # Reset coverage state when a new run starts
+        current_guid = control.run_guid
+        if current_guid != self._last_run_guid:
+            self._last_run_guid = current_guid
+            self._completed_tests = set()
+            self._coverage_history = []
+
+        # Trigger coverage recalculation when new tests complete
+        current_completed = {name for name, rs in tick.run_states.items() if rs.get_state() in (PytestRunnerState.PASS, PytestRunnerState.FAIL)}
+        if current_completed and current_completed != self._completed_tests:
+            self._completed_tests = current_completed
+            try:
+                coverage_pct = calculate_coverage("current", self.data_dir, write_report=False)
+                if coverage_pct is not None:
+                    self._coverage_history.append((time.time(), coverage_pct))
+            except Exception as e:
+                log.warning(f"coverage calculation failed: {e}")
+        tick.coverage_history = self._coverage_history
+
         self.graph_tab.update_tick(tick)
         self.table_tab.update_tick(tick)
         self.run_tab.update_tick(tick)
+        self.coverage_tab.update_tick(tick)
 
 
 @typechecked()

--- a/src/pytest_fly/pytest_runner/coverage.py
+++ b/src/pytest_fly/pytest_runner/coverage.py
@@ -63,7 +63,7 @@ def read_most_recent_coverage_summary_file(coverage_parent_directory: Path) -> f
 class PytestFlyCoverage(Coverage):
 
     def __init__(self, data_file: Path) -> None:
-        super().__init__(data_file, timid=True, concurrency=["thread", "process"], check_preimported=True)
+        super().__init__(data_file, timid=True, concurrency=["thread", "multiprocessing"], check_preimported=True)
         # avoid: "CoverageWarning: Couldn't parse '...': No source for code: '...'. (couldnt-parse)"
         self._no_warn_slugs.add("couldnt-parse")
 

--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -58,8 +58,11 @@ class PytestProcess(Process):
         with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
 
             # create a temp coverage file and then move it so if the file exists, the content is complete (the save is not necessarily instantaneous and atomic)
-            coverage_file_path = Path(self.data_dir, f"{self.name}.coverage")
-            coverage_temp_file_path = Path(self.data_dir, f"{self.name}.temp")
+            coverage_dir = Path(self.data_dir, "coverage")
+            coverage_dir.mkdir(parents=True, exist_ok=True)
+            safe_name = self.name.replace("/", "_").replace("\\", "_")
+            coverage_file_path = Path(coverage_dir, f"{safe_name}.coverage")
+            coverage_temp_file_path = Path(coverage_dir, f"{safe_name}.temp")
             coverage_temp_file_path.unlink(missing_ok=True)
             coverage = Coverage(coverage_temp_file_path)
             coverage.start()

--- a/src/pytest_fly/tick_data.py
+++ b/src/pytest_fly/tick_data.py
@@ -27,3 +27,4 @@ class TickData:
     max_time_stamp_started: float | None = None
     prior_durations: dict[str, float] = field(default_factory=dict)
     num_processes: int = 1
+    coverage_history: list[tuple[float, float]] = field(default_factory=list)  # (timestamp, coverage_pct 0.0-1.0)

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -192,6 +192,81 @@ def test_graph_tab_reuses_bars(app):
 
 
 # ---------------------------------------------------------------------------
+# CoverageTab tests
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_tab_empty(app):
+    """CoverageTab should render without error when there is no coverage data."""
+    from pytest_fly.gui.coverage_tab import CoverageTab
+
+    tab = CoverageTab()
+    tick = _make_tick_data_empty()
+    tab.update_tick(tick)
+
+    assert tab.chart._coverage_history == []
+
+
+def test_coverage_tab_with_data(app):
+    """CoverageTab should store coverage history data for rendering."""
+    from pytest_fly.gui.coverage_tab import CoverageTab
+
+    tab = CoverageTab()
+    tick = _make_tick_data_with_tests()
+    now = time.time()
+    tick.coverage_history = [(now - 5, 0.25), (now - 2, 0.55), (now, 0.78)]
+    tab.update_tick(tick)
+
+    assert tab.chart._coverage_history == tick.coverage_history
+    assert len(tab.chart._coverage_history) == 3
+
+
+def test_coverage_tab_updates(app):
+    """CoverageTab should reflect new data when update_tick is called again."""
+    from pytest_fly.gui.coverage_tab import CoverageTab
+
+    tab = CoverageTab()
+    now = time.time()
+
+    # First tick: one data point
+    tick_1 = _make_tick_data_with_tests()
+    tick_1.coverage_history = [(now - 5, 0.30)]
+    tab.update_tick(tick_1)
+    assert len(tab.chart._coverage_history) == 1
+
+    # Second tick: two data points
+    tick_2 = _make_tick_data_with_tests()
+    tick_2.coverage_history = [(now - 5, 0.30), (now, 0.65)]
+    tab.update_tick(tick_2)
+    assert len(tab.chart._coverage_history) == 2
+    assert tab.chart._coverage_history[-1][1] == 0.65
+
+
+def test_coverage_tab_status_indicator(app):
+    """CoverageTab should show running/complete status based on test states."""
+    from pytest_fly.gui.coverage_tab import CoverageTab
+
+    tab = CoverageTab()
+
+    # With running and queued tests: shows "Running"
+    tick = _make_tick_data_with_tests()  # has PASS, FAIL, and QUEUED tests
+    tab.update_tick(tick)
+    assert "Running" in tab.chart._status_text
+
+    # All tests completed (no QUEUED or RUNNING)
+    guid = "test-guid-complete"
+    now = time.time()
+    infos = [
+        _make_process_info(guid, "tests/test_a.py", None, PyTestFlyExitCode.NONE, time_stamp=now - 5),
+        _make_process_info(guid, "tests/test_a.py", 1001, PyTestFlyExitCode.NONE, time_stamp=now - 4),
+        _make_process_info(guid, "tests/test_a.py", 1001, PyTestFlyExitCode.OK, output="1 passed", time_stamp=now - 1),
+    ]
+    tick_done = build_tick_data(infos)
+    tab.update_tick(tick_done)
+    assert "Complete" in tab.chart._status_text
+
+
+# ---------------------------------------------------------------------------
 # Integration test: real runner → DB → TickData → GUI tabs
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- **New Coverage tab**: step-function line chart showing combined code coverage over time, with running/complete status indicator
- **Fix coverage file paths**: write `.coverage` files to `{data_dir}/coverage/` subdirectory, aligning with `calculate_coverage()` expectations
- **Fix concurrency bug**: `"process"` -> `"multiprocessing"` in `PytestFlyCoverage` (coverage 7.x doesn't support `"process"`)
- **Wire up coverage combination**: track completed tests in `gui_main._update_tick()`, trigger `calculate_coverage()` on new completions, pass history through `TickData`
- **4 new tests**: empty tab, data rendering, tick updates, status indicator

## Test plan
- [x] All 13 GUI display tests pass
- [x] Full test suite passes (36/36)
- [ ] Manual: run pytest-fly, switch to Coverage tab, verify chart updates as tests complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)