### PR TITLE
Add tests and coverage improvements (51% to 68%)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,3 +43,4 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 addopts = -s
 testpaths = tests
 pythonpath = src
+markers =
+    singleton: test that runs exclusively with no other tests concurrent

--- a/run_coverage.py
+++ b/run_coverage.py
@@ -1,0 +1,30 @@
+"""Run tests with coverage and generate an HTML report."""
+
+import subprocess
+import sys
+import webbrowser
+from pathlib import Path
+
+
+def main():
+    python = sys.executable
+
+    print("Running tests with coverage...")
+    result = subprocess.run([python, "-m", "coverage", "run", "--source=src", "-m", "pytest", "tests/", "-q"], cwd=str(Path(__file__).parent))
+
+    print("\nGenerating HTML report...")
+    subprocess.run([python, "-m", "coverage", "html", "--directory=htmlcov"], cwd=str(Path(__file__).parent))
+
+    print("\nSummary:")
+    subprocess.run([python, "-m", "coverage", "report", "--sort=cover"], cwd=str(Path(__file__).parent))
+
+    index = Path(__file__).parent / "htmlcov" / "index.html"
+    if index.exists():
+        print(f"\nOpening {index}")
+        webbrowser.open(index.as_uri())
+
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -62,6 +62,11 @@ class StatusWindow(QGroupBox):
                 overall_time = max_time_stamp - min_time_stamp
                 lines.append(f"Total time: {humanize.precisedelta(timedelta(seconds=overall_time))}")
 
+            # add current code coverage
+            if tick.coverage_history:
+                latest_coverage = tick.coverage_history[-1][1]
+                lines.append(f"Coverage: {latest_coverage:.1%}")
+
             # estimated time remaining based on prior run durations
             if tick.prior_durations and (counts[PytestRunnerState.QUEUED] + counts[PytestRunnerState.RUNNING]) > 0:
                 remaining_seconds = 0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ pytest_plugins = "pytester"
 
 @pytest.fixture(scope="session")
 def app():
-    return QApplication([])
+    return QApplication.instance() or QApplication([])
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_coverage_calculation.py
+++ b/tests/test_coverage_calculation.py
@@ -1,0 +1,37 @@
+"""Tests for coverage summary write/read functions."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from pytest_fly.pytest_runner.coverage import write_coverage_summary_file, read_most_recent_coverage_summary_file
+
+
+def test_write_and_read_coverage_summary():
+    """Round-trip: write a coverage value then read it back."""
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        write_coverage_summary_file(0.85, "test_module_a", tmp_path)
+
+        result = read_most_recent_coverage_summary_file(tmp_path)
+        assert result is not None
+        assert abs(result - 0.85) < 0.001
+
+
+def test_read_coverage_summary_missing():
+    """Should return None when no coverage summary file exists."""
+    with TemporaryDirectory() as tmp:
+        result = read_most_recent_coverage_summary_file(Path(tmp))
+        assert result is None
+
+
+def test_write_multiple_read_most_recent():
+    """When multiple summaries exist, should return the most recently written."""
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        write_coverage_summary_file(0.50, "test_a", tmp_path)
+        write_coverage_summary_file(0.75, "test_b", tmp_path)
+
+        result = read_most_recent_coverage_summary_file(tmp_path)
+        assert result is not None
+        # Should be one of the written values (the most recent file)
+        assert result in (0.50, 0.75)

--- a/tests/test_file_util.py
+++ b/tests/test_file_util.py
@@ -1,0 +1,52 @@
+"""Tests for file_util.find_most_recent_file."""
+
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from pytest_fly.file_util import find_most_recent_file
+
+
+def test_find_most_recent_file():
+    """Should return the most recently modified file matching the pattern."""
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        older = tmp_path / "older.txt"
+        older.write_text("old")
+        # Ensure a measurable time difference
+        time.sleep(0.05)
+        newer = tmp_path / "newer.txt"
+        newer.write_text("new")
+
+        result = find_most_recent_file(tmp_path, "*.txt")
+        assert result == newer
+
+
+def test_find_most_recent_file_nested():
+    """Should find files in subdirectories via rglob."""
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        f = sub / "data.txt"
+        f.write_text("hello")
+
+        result = find_most_recent_file(tmp_path, "*.txt")
+        assert result == f
+
+
+def test_find_most_recent_file_no_match():
+    """Should return None when no files match the pattern."""
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        (tmp_path / "file.log").write_text("log")
+
+        result = find_most_recent_file(tmp_path, "*.txt")
+        assert result is None
+
+
+def test_find_most_recent_file_empty_dir():
+    """Should return None for an empty directory."""
+    with TemporaryDirectory() as tmp:
+        result = find_most_recent_file(Path(tmp), "*.txt")
+        assert result is None

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -3,14 +3,27 @@ Tests that verify the GUI tabs display correct data when given TickData.
 """
 
 import time
+from pathlib import Path
 
 from pytest_fly.db import PytestProcessInfoDB
 from pytest_fly.gui.gui_main import build_tick_data
 from pytest_fly.gui.run_tab.status_window import StatusWindow
+from pytest_fly.gui.run_tab.control_window import ControlWindow
+from pytest_fly.gui.run_tab.control_pushbutton import ControlButton
+from pytest_fly.gui.run_tab.run_mode_control_box import RunModeControlBox
+from pytest_fly.gui.run_tab.parallelism_control_box import ParallelismControlBox
+from pytest_fly.gui.run_tab.run_tab import RunTab
+from pytest_fly.gui.run_tab.view_coverage import ViewCoverage
 from pytest_fly.gui.table_tab.table_tab import TableTab
 from pytest_fly.gui.graph_tab.graph_tab import GraphTab
+from pytest_fly.gui.graph_tab.progress_bar import PytestProgressBar
+from pytest_fly.gui.graph_tab.time_axis import TimeAxisWidget
+from pytest_fly.gui.coverage_tab import CoverageTab
+from pytest_fly.gui.configuration_tab.configuration import Configuration
+from pytest_fly.gui.about_tab.about import About
+from pytest_fly.gui.about_tab.project_info import get_project_info
 from pytest_fly.interfaces import PytestProcessInfo, PyTestFlyExitCode, PytestRunnerState, ScheduledTest
-from pytest_fly.pytest_runner.pytest_runner import PytestRunner
+from pytest_fly.pytest_runner.pytest_runner import PytestRunner, PytestRunState
 from pytest_fly.guid import generate_uuid
 
 from .paths import get_temp_dir
@@ -264,6 +277,296 @@ def test_coverage_tab_status_indicator(app):
     tick_done = build_tick_data(infos)
     tab.update_tick(tick_done)
     assert "Complete" in tab.chart._status_text
+
+
+# ---------------------------------------------------------------------------
+# ControlButton tests
+# ---------------------------------------------------------------------------
+
+
+def test_control_button(qtbot):
+    """ControlButton should set text and enabled state."""
+    btn = ControlButton(None, "Run", True)
+    qtbot.addWidget(btn)
+    assert btn.text() == "Run"
+    assert btn.isEnabled()
+
+    btn2 = ControlButton(None, "Stop", False)
+    qtbot.addWidget(btn2)
+    assert btn2.text() == "Stop"
+    assert not btn2.isEnabled()
+
+
+# ---------------------------------------------------------------------------
+# RunModeControlBox tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_mode_control_box(qtbot):
+    """RunModeControlBox should initialize with one radio button checked."""
+    box = RunModeControlBox(None)
+    qtbot.addWidget(box)
+    assert box.run_mode_restart.isChecked() or box.run_mode_resume.isChecked()
+
+
+def test_run_mode_control_box_toggle(qtbot):
+    """Toggling run mode radio buttons should update preferences."""
+    box = RunModeControlBox(None)
+    qtbot.addWidget(box)
+    box.run_mode_resume.setChecked(True)
+    box.update_preferences()
+    box.run_mode_restart.setChecked(True)
+    box.update_preferences()
+
+
+# ---------------------------------------------------------------------------
+# ParallelismControlBox tests
+# ---------------------------------------------------------------------------
+
+
+def test_parallelism_control_box(qtbot):
+    """ParallelismControlBox should initialize with one option checked."""
+    box = ParallelismControlBox(None)
+    qtbot.addWidget(box)
+    assert box.parallelism_serial.isChecked() or box.parallelism_parallel.isChecked()
+
+
+def test_parallelism_control_box_toggle(qtbot):
+    """Toggling parallelism radio buttons should update preferences."""
+    box = ParallelismControlBox(None)
+    qtbot.addWidget(box)
+    box.parallelism_parallel.setChecked(True)
+    box.update_preferences()
+    assert "Parallel" in box.parallelism_parallel.text()
+
+
+# ---------------------------------------------------------------------------
+# Configuration tests
+# ---------------------------------------------------------------------------
+
+
+def test_configuration_init(qtbot):
+    """Configuration tab should instantiate with all widgets."""
+    config = Configuration()
+    qtbot.addWidget(config)
+    assert config.verbose_checkbox is not None
+    assert config.processes_lineedit.text().isnumeric()
+    assert len(config.refresh_rate_lineedit.text()) > 0
+
+
+def test_configuration_update_methods(qtbot):
+    """Configuration update callbacks should not raise."""
+    config = Configuration()
+    qtbot.addWidget(config)
+    config.update_verbose()
+    config.update_processes("4")
+    config.update_processes("not_a_number")  # should handle gracefully
+    config.update_refresh_rate("2.0")
+    config.update_refresh_rate("invalid")  # should handle ValueError
+    config.update_utilization_high_threshold("0.9")
+    config.update_utilization_low_threshold("0.4")
+    config.update_utilization_high_threshold("invalid")  # ValueError path
+    config.update_utilization_low_threshold("invalid")  # ValueError path
+
+
+# ---------------------------------------------------------------------------
+# About / ProjectInfo tests
+# ---------------------------------------------------------------------------
+
+
+def test_project_info():
+    """get_project_info should return valid project metadata."""
+    info = get_project_info()
+    assert info.application_name != "Unknown"
+    assert info.version != "Unknown"
+    # covers __str__
+    s = str(info)
+    assert info.application_name in s
+    assert info.version in s
+
+
+def test_about(qtbot):
+    """About tab should load project and platform info in background."""
+    about = About(None)
+    qtbot.addWidget(about)
+    qtbot.waitUntil(lambda: not about.thread.isRunning(), timeout=10000)
+    text = about.about_box.toPlainText()
+    assert len(text) > 10
+
+
+# ---------------------------------------------------------------------------
+# RunTab / ControlWindow tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_tab(qtbot):
+    """RunTab should instantiate and accept tick data."""
+    data_dir = get_temp_dir("test_run_tab")
+    tab = RunTab(None, data_dir)
+    qtbot.addWidget(tab)
+    tick = _make_tick_data_with_tests()
+    tab.update_tick(tick)
+
+
+def test_control_window_update(qtbot):
+    """ControlWindow.update() should enable Run and disable Stop when idle."""
+    data_dir = get_temp_dir("test_control_window")
+    cw = ControlWindow(None, data_dir)
+    qtbot.addWidget(cw)
+    cw.update()
+    assert cw.run_button.isEnabled()
+    assert not cw.stop_button.isEnabled()
+
+
+# ---------------------------------------------------------------------------
+# ViewCoverage tests
+# ---------------------------------------------------------------------------
+
+
+def test_view_coverage_missing_dir():
+    """ViewCoverage.view() should not crash when directory doesn't exist."""
+    vc = ViewCoverage(Path("nonexistent_dir_xyz_12345"))
+    vc.view()  # should log warning, not raise
+
+
+# ---------------------------------------------------------------------------
+# StatusWindow ETA and coverage branches
+# ---------------------------------------------------------------------------
+
+
+def test_status_window_with_eta(app):
+    """StatusWindow should display estimated remaining time when prior durations are available."""
+    window = StatusWindow(None)
+    tick = _make_tick_data_with_tests()
+    tick.prior_durations = {"tests/test_a.py": 5.0, "tests/test_c.py": 3.0}
+    tick.num_processes = 2
+    window.update_tick(tick)
+    text = window.status_widget.toPlainText()
+    assert "Estimated remaining" in text
+
+
+def test_status_window_with_coverage(app):
+    """StatusWindow should display coverage percentage when history is available."""
+    window = StatusWindow(None)
+    tick = _make_tick_data_with_tests()
+    tick.coverage_history = [(time.time(), 0.75)]
+    window.update_tick(tick)
+    text = window.status_widget.toPlainText()
+    assert "Coverage: 75.0%" in text
+
+
+# ---------------------------------------------------------------------------
+# ProgressBar paint tests
+# ---------------------------------------------------------------------------
+
+
+def test_progress_bar_queued(qtbot):
+    """PytestProgressBar should render a queued test without errors."""
+    guid = "test-guid-bar"
+    now = time.time()
+    infos = [_make_process_info(guid, "tests/test_a.py", None, PyTestFlyExitCode.NONE, time_stamp=now)]
+    run_state = PytestRunState(infos)
+    bar = PytestProgressBar(infos, now - 1, now + 1, run_state)
+    qtbot.addWidget(bar)
+    bar.show()
+    bar.repaint()
+
+
+def test_progress_bar_pass(qtbot):
+    """PytestProgressBar should render a passed test with bar color."""
+    guid = "test-guid-bar-pass"
+    now = time.time()
+    infos = [
+        _make_process_info(guid, "tests/test_a.py", None, PyTestFlyExitCode.NONE, time_stamp=now - 5),
+        _make_process_info(guid, "tests/test_a.py", 1001, PyTestFlyExitCode.NONE, time_stamp=now - 4),
+        _make_process_info(guid, "tests/test_a.py", 1001, PyTestFlyExitCode.OK, output="1 passed", time_stamp=now - 1),
+    ]
+    run_state = PytestRunState(infos)
+    bar = PytestProgressBar(infos, now - 5, now, run_state)
+    qtbot.addWidget(bar)
+    bar.show()
+    bar.repaint()
+
+
+def test_progress_bar_update(qtbot):
+    """PytestProgressBar.update_pytest_process_info should accept new data."""
+    guid = "test-guid-bar-update"
+    now = time.time()
+    infos = [_make_process_info(guid, "tests/test_a.py", None, PyTestFlyExitCode.NONE, time_stamp=now)]
+    run_state = PytestRunState(infos)
+    bar = PytestProgressBar(infos, now - 1, now + 1, run_state)
+    qtbot.addWidget(bar)
+
+    # Update with completed state
+    infos2 = infos + [
+        _make_process_info(guid, "tests/test_a.py", 1001, PyTestFlyExitCode.NONE, time_stamp=now + 1),
+        _make_process_info(guid, "tests/test_a.py", 1001, PyTestFlyExitCode.OK, output="1 passed", time_stamp=now + 3),
+    ]
+    run_state2 = PytestRunState(infos2)
+    bar.update_pytest_process_info(infos2, now - 1, now + 3, run_state2)
+    bar.repaint()
+
+
+# ---------------------------------------------------------------------------
+# TimeAxisWidget paint tests
+# ---------------------------------------------------------------------------
+
+
+def test_time_axis_widget_paint(qtbot):
+    """TimeAxisWidget should render tick marks and labels."""
+    widget = TimeAxisWidget()
+    qtbot.addWidget(widget)
+    widget.update_time_window(1000.0, 1010.0)
+    widget.show()
+    widget.repaint()
+
+
+def test_time_axis_widget_no_data(qtbot):
+    """TimeAxisWidget should handle None timestamps gracefully."""
+    widget = TimeAxisWidget()
+    qtbot.addWidget(widget)
+    widget.update_time_window(None, None)
+    widget.show()
+    widget.repaint()
+
+
+# ---------------------------------------------------------------------------
+# CoverageTab paint tests
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_tab_paint_with_data(qtbot):
+    """CoverageTab chart should render the step-function line when data is present."""
+    tab = CoverageTab()
+    qtbot.addWidget(tab)
+    now = time.time()
+    tick = _make_tick_data_with_tests()
+    tick.coverage_history = [(now - 5, 0.3), (now - 2, 0.55), (now, 0.7)]
+    tab.update_tick(tick)
+    tab.chart.show()
+    tab.chart.repaint()
+
+
+def test_coverage_tab_paint_empty(qtbot):
+    """CoverageTab chart should render 'Waiting' message with no data."""
+    tab = CoverageTab()
+    qtbot.addWidget(tab)
+    tick = _make_tick_data_empty()
+    tab.update_tick(tick)
+    tab.chart.show()
+    tab.chart.repaint()
+
+
+def test_coverage_tab_paint_single_point(qtbot):
+    """CoverageTab chart should handle a single coverage data point."""
+    tab = CoverageTab()
+    qtbot.addWidget(tab)
+    now = time.time()
+    tick = _make_tick_data_with_tests()
+    tick.coverage_history = [(now, 0.42)]
+    tab.update_tick(tick)
+    tab.chart.show()
+    tab.chart.repaint()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,0 +1,74 @@
+"""Tests for ScheduledTest sorting and _lines_per_second."""
+
+from pytest_fly.interfaces import ScheduledTest, _lines_per_second
+
+
+def test_lines_per_second():
+    assert _lines_per_second(10.0, 0.5) == 0.05
+    assert _lines_per_second(1.0, 1.0) == 1.0
+    # near-zero duration should not divide by zero
+    result = _lines_per_second(0.0, 0.5)
+    assert result > 0
+
+
+def test_singleton_sorts_last():
+    """Singletons should always sort after non-singletons."""
+    normal = ScheduledTest("test_a", singleton=False, duration=None, coverage=None)
+    single = ScheduledTest("test_b", singleton=True, duration=None, coverage=None)
+
+    assert normal < single
+    assert single > normal
+    assert not (normal > single)
+    assert not (single < normal)
+
+
+def test_both_singletons_sort_by_node_id():
+    """Two singletons with no duration data sort alphabetically by node_id."""
+    a = ScheduledTest("aaa", singleton=True, duration=None, coverage=None)
+    b = ScheduledTest("zzz", singleton=True, duration=None, coverage=None)
+
+    assert a < b
+    assert b > a
+
+
+def test_none_duration_sorts_by_node_id():
+    """When duration or coverage is None, fallback to node_id comparison."""
+    a = ScheduledTest("test_a", singleton=False, duration=None, coverage=None)
+    b = ScheduledTest("test_b", singleton=False, duration=None, coverage=None)
+
+    assert a < b
+    assert b > a
+
+
+def test_coverage_efficiency_ordering():
+    """Higher coverage efficiency (lines/sec) should sort earlier."""
+    # fast_test: 0.8 coverage in 2s = 0.4 lines/sec
+    fast = ScheduledTest("fast", singleton=False, duration=2.0, coverage=0.8)
+    # slow_test: 0.8 coverage in 10s = 0.08 lines/sec
+    slow = ScheduledTest("slow", singleton=False, duration=10.0, coverage=0.8)
+
+    assert fast < slow  # fast should run earlier
+    assert slow > fast
+
+
+def test_sorted_list_order():
+    """Sorting a list of ScheduledTests should produce the correct execution order."""
+    tests = [
+        ScheduledTest("singleton_z", singleton=True, duration=None, coverage=None),
+        ScheduledTest("normal_b", singleton=False, duration=None, coverage=None),
+        ScheduledTest("normal_a", singleton=False, duration=None, coverage=None),
+        ScheduledTest("singleton_a", singleton=True, duration=None, coverage=None),
+    ]
+    result = sorted(tests)
+    # Non-singletons first (alphabetical), then singletons (alphabetical)
+    assert [t.node_id for t in result] == ["normal_a", "normal_b", "singleton_a", "singleton_z"]
+
+
+def test_mixed_none_and_data():
+    """A test with None duration should sort by node_id against another with None."""
+    a = ScheduledTest("test_a", singleton=False, duration=5.0, coverage=None)
+    b = ScheduledTest("test_b", singleton=False, duration=None, coverage=0.5)
+
+    # Both have partial None, so fallback to node_id
+    assert a < b
+    assert b > a

--- a/tests/test_pytest_process_info_db.py
+++ b/tests/test_pytest_process_info_db.py
@@ -43,3 +43,44 @@ def test_pytest_process_info_db_query_none():
         db.write(PytestProcessInfo(run_guid=guid, name=test_name, pid=pid, exit_code=PyTestFlyExitCode.NONE, output=output, time_stamp=time.time()))
         rows = db.query("I am not a valid guid")
         assert len(rows) == 0
+
+
+def test_pytest_process_info_db_delete_by_guid():
+    """Delete records for one guid and verify the other guid's records remain."""
+
+    test_name = "test_pytest_process_info_db_delete_by_guid"
+    db_dir = get_temp_dir(test_name)
+
+    guid_a = generate_uuid()
+    guid_b = generate_uuid()
+
+    with PytestProcessInfoDB(db_dir) as db:
+        db.write(PytestProcessInfo(run_guid=guid_a, name="test_a", pid=pid, exit_code=PyTestFlyExitCode.OK, output=output, time_stamp=time.time()))
+        db.write(PytestProcessInfo(run_guid=guid_b, name="test_b", pid=pid, exit_code=PyTestFlyExitCode.OK, output=output, time_stamp=time.time()))
+
+        db.delete(guid_a)
+
+        rows_a = db.query(guid_a)
+        assert len(rows_a) == 0
+
+        rows_b = db.query(guid_b)
+        assert len(rows_b) == 1
+        assert rows_b[0].name == "test_b"
+
+
+def test_pytest_process_info_db_query_most_recent():
+    """query(None) should return only the most recent run's records."""
+
+    test_name = "test_pytest_process_info_db_query_most_recent"
+    db_dir = get_temp_dir(test_name)
+
+    guid_old = "aaa-old"
+    guid_new = "zzz-new"
+
+    with PytestProcessInfoDB(db_dir) as db:
+        db.write(PytestProcessInfo(run_guid=guid_old, name="test_old", pid=pid, exit_code=PyTestFlyExitCode.OK, output=output, time_stamp=time.time()))
+        db.write(PytestProcessInfo(run_guid=guid_new, name="test_new", pid=pid, exit_code=PyTestFlyExitCode.OK, output=output, time_stamp=time.time()))
+
+        rows = db.query()  # None = most recent
+        assert len(rows) == 1
+        assert rows[0].run_guid == guid_new

--- a/tests/test_time_axis.py
+++ b/tests/test_time_axis.py
@@ -1,0 +1,73 @@
+"""Tests for time_axis pure utility functions."""
+
+from pytest_fly.gui.graph_tab.time_axis import _choose_interval, _format_tick_label, compute_grid_ticks
+
+
+def test_choose_interval_short():
+    """A 10-second window should use 1-second intervals."""
+    assert _choose_interval(10.0) == 1
+
+
+def test_choose_interval_medium():
+    """A 60-second window should pick an interval that yields 5-12 lines."""
+    interval = _choose_interval(60.0)
+    num_lines = 60.0 / interval
+    assert 5 <= num_lines <= 12
+
+
+def test_choose_interval_long():
+    """A 3600-second window should pick an interval that yields 5-12 lines."""
+    interval = _choose_interval(3600.0)
+    num_lines = 3600.0 / interval
+    assert 5 <= num_lines <= 12
+
+
+def test_choose_interval_very_long():
+    """Beyond all candidates, should return the largest interval."""
+    interval = _choose_interval(100000.0)
+    assert interval == 600
+
+
+def test_format_tick_label_seconds():
+    assert _format_tick_label(0) == "0s"
+    assert _format_tick_label(30) == "30s"
+    assert _format_tick_label(59) == "59s"
+
+
+def test_format_tick_label_minutes():
+    assert _format_tick_label(60) == "1m"
+    assert _format_tick_label(120) == "2m"
+    assert _format_tick_label(300) == "5m"
+
+
+def test_format_tick_label_mixed():
+    assert _format_tick_label(90) == "1m30s"
+    assert _format_tick_label(150) == "2m30s"
+
+
+def test_compute_grid_ticks_none_timestamps():
+    """Should return empty list when timestamps are None."""
+    assert compute_grid_ticks(None, None, 800) == []
+    assert compute_grid_ticks(100.0, None, 800) == []
+    assert compute_grid_ticks(None, 200.0, 800) == []
+
+
+def test_compute_grid_ticks_zero_width():
+    assert compute_grid_ticks(100.0, 200.0, 0) == []
+    assert compute_grid_ticks(100.0, 200.0, -1) == []
+
+
+def test_compute_grid_ticks_valid():
+    """Should return a list of (x_pixel, label) tuples."""
+    ticks = compute_grid_ticks(1000.0, 1010.0, 800)
+    assert len(ticks) > 0
+    # First tick should be at x=0 with label "0s"
+    assert ticks[0] == (0.0, "0s")
+    # All x values should be non-negative
+    assert all(x >= 0 for x, _ in ticks)
+
+
+def test_compute_grid_ticks_same_timestamp():
+    """When min == max, time_window is clamped to 1.0."""
+    ticks = compute_grid_ticks(1000.0, 1000.0, 800)
+    assert len(ticks) > 0


### PR DESCRIPTION
## Summary
- **49 new tests** (40→89 total), raising overall coverage from 51% to 68%
- **GUI tests** using `qtbot`: widget construction, preference syncing, paint events, About tab background thread, StatusWindow ETA/coverage display
- **Unit tests**: ScheduledTest sorting, time_axis utilities, file_util, coverage summary round-trip, DB delete/query-most-recent
- **Fix**: register `singleton` marker in `pytest.ini` (eliminates `PytestUnknownMarkWarning`)
- **Fix**: `conftest.py` app fixture coexists with qtbot's QApplication
- **CI**: add `CODECOV_TOKEN` to Codecov upload action
- **Feature**: display current code coverage in Status pane
- **Tooling**: `run_coverage.py` script for local HTML coverage reports

## Test plan
- [x] All 89 tests pass
- [x] No warnings
- [x] Coverage: 68% overall, 69% GUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)