### PR TITLE
Fix CI: install pytest-qt for GUI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install coverage pytest
+          pip install coverage pytest pytest-qt
           pip install -e .
 
       - name: Run tests with coverage


### PR DESCRIPTION
## Summary
- Install `pytest-qt` in CI so `qtbot` fixture is available for GUI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)