### PR TITLE
Fix Coverage tab sizing and visibility for large test suites — v0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/graph_tab/graph_tab.py
+++ b/src/pytest_fly/gui/graph_tab/graph_tab.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QGroupBox, QVBoxLayout
+from PySide6.QtWidgets import QGroupBox, QVBoxLayout, QWidget, QScrollArea
 from PySide6.QtCore import Qt
 
 from ...tick_data import TickData
@@ -14,19 +14,28 @@ class GraphTab(QGroupBox):
         self.setTitle("Progress")
         self.progress_bars: dict[str, PytestProgressBar] = {}
 
-        layout = QVBoxLayout()
-        layout.setAlignment(Qt.AlignmentFlag.AlignTop)
-        self.setLayout(layout)
+        outer_layout = QVBoxLayout()
+        self.setLayout(outer_layout)
 
         self.time_axis = TimeAxisWidget()
-        layout.addWidget(self.time_axis)
+        outer_layout.addWidget(self.time_axis)
+
+        # Scroll area for the progress bars so large test suites don't blow out the tab size
+        self._scroll_area = QScrollArea()
+        self._scroll_area.setWidgetResizable(True)
+        self._scroll_area.setFrameShape(QScrollArea.Shape.NoFrame)
+        outer_layout.addWidget(self._scroll_area, stretch=1)
+
+        self._bar_container = QWidget()
+        self._bar_layout = QVBoxLayout()
+        self._bar_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+        self._bar_container.setLayout(self._bar_layout)
+        self._scroll_area.setWidget(self._bar_container)
 
     def update_tick(self, tick: TickData) -> None:
         """Refresh the time axis and all progress bars from pre-computed tick data."""
 
         self.time_axis.update_time_window(tick.min_time_stamp, tick.max_time_stamp)
-
-        layout = self.layout()
 
         for test_name, infos in tick.infos_by_name.items():
             run_state = tick.run_states[test_name]
@@ -35,5 +44,5 @@ class GraphTab(QGroupBox):
                 progress_bar.update_pytest_process_info(infos, tick.min_time_stamp, tick.max_time_stamp, run_state)
             else:
                 progress_bar = PytestProgressBar(infos, tick.min_time_stamp, tick.max_time_stamp, run_state)
-                layout.addWidget(progress_bar)
+                self._bar_layout.addWidget(progress_bar)
                 self.progress_bars[test_name] = progress_bar

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -7,7 +7,6 @@ from PySide6.QtWidgets import (
     QMainWindow,
     QApplication,
     QTabWidget,
-    QScrollArea,
     QSizePolicy,
 )
 from PySide6.QtCore import QCoreApplication, QRect, QTimer
@@ -124,13 +123,7 @@ class FlyAppMainWindow(QMainWindow):
         self._total_lines: int = 0
         self._last_run_guid: str | None = None
 
-        # Wrap the tab widget in a scroll area so that very tall tab contents produce scrollbars
-        self.scroll_area = QScrollArea()
-        self.scroll_area.setWidgetResizable(True)
-        # QScrollArea takes ownership / reparents the widget
-        self.scroll_area.setWidget(self.tab_widget)
-
-        self.setCentralWidget(self.scroll_area)
+        self.setCentralWidget(self.tab_widget)
 
         # timer for periodic updates
         self.timer = QTimer(self, interval=int(round(pref.refresh_rate * 1000)))


### PR DESCRIPTION
## Summary
- Remove `QScrollArea` wrapping the entire `QTabWidget` — it caused the Coverage tab to be oversized with scrollbars and the chart to be painted across an enormous invisible area
- Move scrolling into the Graph tab itself (progress bars scroll independently while time axis stays fixed)
- Bump version to 0.2.1

## Test plan
- [x] All 95 tests pass
- [ ] Run against a large test suite and verify Coverage tab fits the window without scrollbars
- [ ] Verify coverage chart is visible and renders correctly
- [ ] Verify Graph tab scrolls properly with many test modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)