### PR TITLE
Add coverage-efficiency test ordering option — v0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.2.1"
+version = "0.2.2"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -5,6 +5,7 @@ from PySide6.QtGui import QIntValidator, QDoubleValidator
 from tobool import to_bool_strict
 
 from pytest_fly.preferences import get_pref, refresh_rate_default, utilization_high_threshold_default, utilization_low_threshold_default
+from pytest_fly.interfaces import TestOrder
 from pytest_fly.platform.platform_info import get_performance_core_count
 from pytest_fly.logger import get_logger
 from pytest_fly.gui.gui_util import get_text_dimensions
@@ -33,6 +34,14 @@ class Configuration(QWidget):
         self.verbose_checkbox.setChecked(to_bool_strict(pref.verbose))
         self.verbose_checkbox.stateChanged.connect(self.update_verbose)
         layout.addWidget(self.verbose_checkbox)
+
+        layout.addWidget(QLabel(""))  # space
+
+        # Test order option
+        self.coverage_order_checkbox = QCheckBox("Order tests by coverage efficiency")
+        self.coverage_order_checkbox.setChecked(int(pref.test_order) == TestOrder.COVERAGE)
+        self.coverage_order_checkbox.stateChanged.connect(self.update_test_order)
+        layout.addWidget(self.coverage_order_checkbox)
 
         layout.addWidget(QLabel(""))  # space
 
@@ -85,6 +94,11 @@ class Configuration(QWidget):
         """Persist the verbose checkbox state to preferences."""
         pref = get_pref()
         pref.verbose = self.verbose_checkbox.isChecked()
+
+    def update_test_order(self):
+        """Persist the test order preference based on the checkbox state."""
+        pref = get_pref()
+        pref.test_order = TestOrder.COVERAGE if self.coverage_order_checkbox.isChecked() else TestOrder.PYTEST
 
     def update_processes(self, value: str):
         """Persist the process-count value to preferences."""

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -6,8 +6,9 @@ from typeguard import typechecked
 
 from ...pytest_runner.pytest_runner import PytestRunner
 from ...pytest_runner.test_list import GetTests
+from ...pytest_runner.coverage import compute_per_test_coverage
 from ...preferences import get_pref, ParallelismControl
-from ...interfaces import RunMode, PyTestFlyExitCode
+from ...interfaces import RunMode, TestOrder, PyTestFlyExitCode, ScheduledTest
 from ...db import PytestProcessInfoDB
 from ...logger import get_logger
 from ...guid import generate_uuid
@@ -111,6 +112,11 @@ class ControlWindow(QGroupBox):
         self.prior_durations = self._compute_prior_durations(prior_results)
         self.num_processes = processes
 
+        # Populate coverage/duration for coverage-efficiency ordering
+        if pref.test_order == TestOrder.COVERAGE:
+            tests = self._apply_coverage_order(tests)
+            tests.sort()
+
         self.pytest_runner = PytestRunner(self.run_guid, tests, processes, self.data_dir, refresh_rate)
         self.pytest_runner.start()
 
@@ -143,6 +149,27 @@ class ControlWindow(QGroupBox):
             failed = prior_names - passed
             tests = sorted(tests, key=lambda t: (t.singleton, t.node_id not in failed))
         return tests
+
+    def _apply_coverage_order(self, tests):
+        """Replace ScheduledTest objects with ones carrying prior duration and coverage data.
+
+        When both values are available the existing ``ScheduledTest.__lt__`` sorts
+        by lines-per-second efficiency.  Tests without prior data keep ``None``
+        and fall back to alphabetical ordering.
+
+        :param tests: List of scheduled tests.
+        :return: New list with duration/coverage populated where available.
+        """
+        per_test_cov = compute_per_test_coverage(self.data_dir, [t.node_id for t in tests])
+        return [
+            ScheduledTest(
+                node_id=t.node_id,
+                singleton=t.singleton,
+                duration=self.prior_durations.get(t.node_id),
+                coverage=per_test_cov.get(t.node_id),
+            )
+            for t in tests
+        ]
 
     def _compute_prior_durations(self, prior_results):
         """Compute durations from prior results for ETA estimation.

--- a/src/pytest_fly/interfaces.py
+++ b/src/pytest_fly/interfaces.py
@@ -64,6 +64,11 @@ class ScheduledTest:
             return _lines_per_second(self.duration, self.coverage) > _lines_per_second(other.duration, other.coverage)
 
 
+class TestOrder(IntEnum):
+    PYTEST = 0  # use pytest's default collection order (alphabetical by node_id)
+    COVERAGE = 1  # order by coverage efficiency (lines covered per second), falling back to node_id when no prior data
+
+
 class RunMode(IntEnum):
     RESTART = 0  # rerun all tests
     RESUME = 1  # resume test run, and run tests that either failed or were not run

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -5,7 +5,7 @@ from pref import Pref
 
 from .__version__ import application_name, author
 from .platform import get_performance_core_count
-from .interfaces import RunMode
+from .interfaces import RunMode, TestOrder
 
 preferences_file_name = f"{application_name}_preferences.db"
 
@@ -41,6 +41,8 @@ class FlyPreferences(Pref):
     utilization_low_threshold: float = attrib(default=utilization_low_threshold_default)  # below this threshold is considered low utilization
 
     run_mode: RunMode = attrib(default=RunMode.CHECK)  # 0=restart all tests, 1=resume, 2=resume if possible (i.e., the program version under test has not changed)
+
+    test_order: TestOrder = attrib(default=TestOrder.PYTEST)  # 0=pytest default order, 1=coverage efficiency order
 
 
 def get_pref() -> FlyPreferences:

--- a/src/pytest_fly/pytest_runner/coverage.py
+++ b/src/pytest_fly/pytest_runner/coverage.py
@@ -7,7 +7,7 @@ from coverage import Coverage
 from coverage.exceptions import NoDataError, DataError
 
 from ..logger import get_logger
-from ..file_util import find_most_recent_file
+from ..file_util import find_most_recent_file, sanitize_test_name
 from pytest_fly.__version__ import application_name
 
 log = get_logger(application_name)
@@ -134,3 +134,47 @@ def calculate_coverage(test_identifier: str, coverage_parent_directory: Path, wr
         log.info(f"{test_identifier},{e}")
 
     return coverage_value, covered_statements, total_statements
+
+
+def compute_per_test_coverage(data_dir: Path, test_names: list[str]) -> dict[str, float]:
+    """Compute per-test coverage fractions from stored per-test coverage files.
+
+    Loads each test's individual ``.coverage`` file, counts executed lines,
+    and divides by the total lines across all tests to produce a fraction.
+
+    :param data_dir: The application data directory containing the ``coverage/`` subdirectory.
+    :param test_names: List of test node_ids (e.g. ``"tests/test_foo.py"``).
+    :return: Mapping of test name to coverage fraction (0.0--1.0).  Tests
+             without a coverage file are omitted.
+    """
+    coverage_dir = Path(data_dir, "coverage")
+    if not coverage_dir.exists():
+        return {}
+
+    # Load each test's coverage data and count executed lines
+    per_test_lines: dict[str, int] = {}
+    all_file_lines: dict[str, set[int]] = {}  # source_file -> set of executed line numbers (union across all tests)
+
+    for test_name in test_names:
+        safe_name = sanitize_test_name(test_name)
+        cov_file = coverage_dir / f"{safe_name}.coverage"
+        if not cov_file.exists():
+            continue
+        try:
+            cov = Coverage(cov_file)
+            cov.load()
+            data = cov.get_data()
+            executed = 0
+            for f in data.measured_files():
+                lines = data.lines(f) or []
+                executed += len(lines)
+                all_file_lines.setdefault(f, set()).update(lines)
+            per_test_lines[test_name] = executed
+        except Exception as e:
+            log.info(f"per-test coverage load for {test_name} failed: {e}")
+
+    total_lines = sum(len(lines) for lines in all_file_lines.values())
+    if total_lines == 0:
+        return {}
+
+    return {name: executed / total_lines for name, executed in per_test_lines.items()}

--- a/src/pytest_fly/pytest_runner/test_list.py
+++ b/src/pytest_fly/pytest_runner/test_list.py
@@ -70,7 +70,7 @@ class GetTests(Process):
                 # Restore the original stdout
                 sys.stdout = original_stdout
 
-        # todo: add test execution time and coverage to enable proper sorting
+        # Duration and coverage are populated later by ControlWindow when coverage ordering is enabled.
         for node_id, singleton in pytest_tests.items():
             self._scheduled_tests_queue.put(ScheduledTest(node_id, singleton, None, None))
 


### PR DESCRIPTION
## Summary
- Add `TestOrder` enum (`PYTEST` / `COVERAGE`) and `test_order` preference
- Add "Order tests by coverage efficiency" checkbox in the Configuration tab
- When enabled, populate `ScheduledTest.duration` and `coverage` from prior run data so tests sort by lines-covered-per-second (high-coverage fast tests run first)
- Add `compute_per_test_coverage()` utility in `coverage.py` to load per-test coverage fractions from stored `.coverage` files

## Test plan
- [x] All 95 tests pass
- [ ] Verify checkbox appears in Configuration tab and persists across restarts
- [ ] Run a project twice with coverage ordering enabled — second run should reorder tests by efficiency
- [ ] Verify first run (no prior data) falls back gracefully to default order

🤖 Generated with [Claude Code](https://claude.com/claude-code)