### PR TITLE
Sync graph tab ordering with table tab — v0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.2.2"
+version = "0.2.3"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/graph_tab/graph_tab.py
+++ b/src/pytest_fly/gui/graph_tab/graph_tab.py
@@ -37,6 +37,14 @@ class GraphTab(QGroupBox):
 
         self.time_axis.update_time_window(tick.min_time_stamp, tick.max_time_stamp)
 
+        # Remove bars for tests no longer in the current tick
+        removed_names = set(self.progress_bars) - set(tick.infos_by_name)
+        for name in removed_names:
+            bar = self.progress_bars.pop(name)
+            self._bar_layout.removeWidget(bar)
+            bar.deleteLater()
+
+        # Create or update bars
         for test_name, infos in tick.infos_by_name.items():
             run_state = tick.run_states[test_name]
             if test_name in self.progress_bars:
@@ -44,5 +52,10 @@ class GraphTab(QGroupBox):
                 progress_bar.update_pytest_process_info(infos, tick.min_time_stamp, tick.max_time_stamp, run_state)
             else:
                 progress_bar = PytestProgressBar(infos, tick.min_time_stamp, tick.max_time_stamp, run_state)
-                self._bar_layout.addWidget(progress_bar)
                 self.progress_bars[test_name] = progress_bar
+
+        # Ensure layout order matches tick.infos_by_name order (same as table tab)
+        while self._bar_layout.count():
+            self._bar_layout.takeAt(0)
+        for test_name in tick.infos_by_name:
+            self._bar_layout.addWidget(self.progress_bars[test_name])


### PR DESCRIPTION
## Summary
- Fix graph tab to reorder progress bars on each tick to match `tick.infos_by_name` order, ensuring consistent test ordering with the table tab
- Clean up stale progress bars for tests no longer present in the current tick (e.g. after a new run starts)
- Bump version to 0.2.3

## Test plan
- [x] All 57 existing tests pass
- [ ] Run the app, start a test suite, verify table and graph show tests in the same order
- [ ] Switch test ordering (PYTEST vs COVERAGE), restart, verify both tabs reflect the new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)