### PR TITLE
Add Stop (soft) and Force Stop (hard) buttons — v0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.2.3"
+version = "0.2.4"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/colors.py
+++ b/src/pytest_fly/colors.py
@@ -17,6 +17,7 @@ BAR_COLORS: dict[PytestRunnerState, QColor] = {
     PytestRunnerState.PASS: QColor("lightgreen"),
     PytestRunnerState.FAIL: QColor("red"),
     PytestRunnerState.TERMINATED: QColor("orange"),
+    PytestRunnerState.STOPPED: QColor("gray"),
 }
 
 # Colors used for the foreground text on the Table tab.
@@ -26,4 +27,5 @@ TABLE_COLORS: dict[PytestRunnerState, QColor] = {
     PytestRunnerState.PASS: QColor("green"),
     PytestRunnerState.FAIL: QColor("red"),
     PytestRunnerState.TERMINATED: QColor("orange"),
+    PytestRunnerState.STOPPED: QColor("gray"),
 }

--- a/src/pytest_fly/gui/graph_tab/progress_bar.py
+++ b/src/pytest_fly/gui/graph_tab/progress_bar.py
@@ -114,7 +114,7 @@ class PytestProgressBar(QWidget):
             for x, _label in grid_ticks:
                 painter.drawLine(int(x), 0, int(x), self.height())
 
-            if pytest_run_state.get_state() == PytestRunnerState.QUEUED or len(self.status_list) < 2:
+            if pytest_run_state.get_state() in (PytestRunnerState.QUEUED, PytestRunnerState.STOPPED) or len(self.status_list) < 2:
                 start_running_time = None
             else:
                 start_running_time = self.status_list[1].time_stamp
@@ -132,7 +132,7 @@ class PytestProgressBar(QWidget):
 
             bar_color = pytest_run_state.get_qt_bar_color()
 
-            if pytest_run_state.get_state() != PytestRunnerState.QUEUED:
+            if pytest_run_state.get_state() not in (PytestRunnerState.QUEUED, PytestRunnerState.STOPPED):
                 seconds_from_start = start_running_time - self.min_time_stamp
                 x1 = (seconds_from_start * horizontal_pixels_per_second) + self.bar_margin
                 y1 = outer_rect.y() + self.bar_margin

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -44,8 +44,14 @@ class ControlWindow(QGroupBox):
         self.run_button.clicked.connect(self.run)
 
         self.stop_button = ControlButton(self, "Stop", False)
+        self.stop_button.setToolTip("Wait for the running tests and then stop")
         layout.addWidget(self.stop_button)
-        self.stop_button.clicked.connect(self.stop)
+        self.stop_button.clicked.connect(self.soft_stop)
+
+        self.force_stop_button = ControlButton(self, "Force Stop", False)
+        self.force_stop_button.setToolTip("Immediately terminate all running tests")
+        layout.addWidget(self.force_stop_button)
+        self.force_stop_button.clicked.connect(self.force_stop)
 
         layout.addStretch()
 
@@ -58,24 +64,32 @@ class ControlWindow(QGroupBox):
         self.pytest_runner: PytestRunner | None = None
         self.prior_durations: dict[str, float] = {}
         self.num_processes: int = 1
+        self._soft_stop_requested: bool = False
 
         self.set_fixed_width()  # calculate and set the widget width
 
     def set_fixed_width(self):
         """Calculate and set a fixed width based on the widest child widget."""
-        max_width = max(self.run_button.sizeHint().width(), self.stop_button.sizeHint().width(), self.parallelism_box.sizeHint().width())
+        max_width = max(self.run_button.sizeHint().width(), self.stop_button.sizeHint().width(), self.force_stop_button.sizeHint().width(), self.parallelism_box.sizeHint().width())
         # Add some padding
         max_width += 30
         self.setFixedWidth(max_width)
 
     def update(self):
-        """Enable/disable run and stop buttons based on the runner state."""
+        """Enable/disable run, stop, and force stop buttons based on the runner state."""
         if self.pytest_runner is None or not self.pytest_runner.is_running():
             self.run_button.setEnabled(True)
             self.stop_button.setEnabled(False)
+            self.force_stop_button.setEnabled(False)
+            self._soft_stop_requested = False
+        elif self._soft_stop_requested:
+            self.run_button.setEnabled(False)
+            self.stop_button.setEnabled(False)
+            self.force_stop_button.setEnabled(True)
         else:
             self.run_button.setEnabled(False)
             self.stop_button.setEnabled(True)
+            self.force_stop_button.setEnabled(True)
 
     def run(self):
         """Discover tests and launch a new :class:`PytestRunner`."""
@@ -122,6 +136,8 @@ class ControlWindow(QGroupBox):
 
         self.run_button.setEnabled(False)
         self.stop_button.setEnabled(True)
+        self.force_stop_button.setEnabled(True)
+        self._soft_stop_requested = False
 
     def _filter_for_resume(self, tests, prior_results, pref):
         """Filter out already-passed tests when running in RESUME mode.
@@ -187,9 +203,16 @@ class ControlWindow(QGroupBox):
                 durations[name] = end - start
         return durations
 
-    def stop(self):
-        """Stop the currently running test suite."""
+    def soft_stop(self):
+        """Stop scheduling new tests but let running tests finish."""
+        self.pytest_runner.soft_stop()
+        self._soft_stop_requested = True
+        self.stop_button.setEnabled(False)
+
+    def force_stop(self):
+        """Immediately terminate all running tests."""
         self.pytest_runner.stop()
         self.run_button.setEnabled(True)
         self.stop_button.setEnabled(False)
+        self.force_stop_button.setEnabled(False)
         self.run_guid = None

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -47,7 +47,7 @@ class StatusWindow(QGroupBox):
                 lines.append(f"{prefix}(calculating...)")
             lines.append("")  # space
 
-            for state in [PytestRunnerState.PASS, PytestRunnerState.FAIL, PytestRunnerState.QUEUED, PytestRunnerState.RUNNING, PytestRunnerState.TERMINATED]:
+            for state in [PytestRunnerState.PASS, PytestRunnerState.FAIL, PytestRunnerState.QUEUED, PytestRunnerState.RUNNING, PytestRunnerState.TERMINATED, PytestRunnerState.STOPPED]:
                 count = counts[state]
                 lines.append(f"{state}: {count} ({count / total_tests:.2%})")
 

--- a/src/pytest_fly/interfaces.py
+++ b/src/pytest_fly/interfaces.py
@@ -81,6 +81,7 @@ class PytestRunnerState(StrEnum):
     PASS = "Pass"
     FAIL = "Fail"
     TERMINATED = "Terminated"
+    STOPPED = "Stopped"
 
 
 class PyTestFlyExitCode(IntEnum):
@@ -98,6 +99,7 @@ class PyTestFlyExitCode(IntEnum):
     # pytest-fly specific exit codes
     NONE = 100  # not yet set
     TERMINATED = 101  # test run was forcefully terminated
+    STOPPED = 102  # test was queued but never ran (soft stop)
 
 
 @dataclass(frozen=True)

--- a/src/pytest_fly/pytest_runner/pytest_runner.py
+++ b/src/pytest_fly/pytest_runner/pytest_runner.py
@@ -36,6 +36,8 @@ class PytestRunState:
                 self._state = PytestRunnerState.FAIL
             elif exit_code == PyTestFlyExitCode.TERMINATED:
                 self._state = PytestRunnerState.TERMINATED
+            elif exit_code == PyTestFlyExitCode.STOPPED:
+                self._state = PytestRunnerState.STOPPED
             elif exit_code == PyTestFlyExitCode.NONE:
                 if last_run_info.pid is None:
                     self._state = PytestRunnerState.QUEUED
@@ -140,6 +142,14 @@ class PytestRunner(Thread):
         except (OSError, RuntimeError, PermissionError) as e:
             log.error(f"error stopping pytest runner,{self.run_guid=},{e}", exc_info=True, stack_info=True)
 
+    def soft_stop(self):
+        """Signal workers to finish their current test and stop picking up new ones."""
+        try:
+            for test_runner in self._test_runners.values():
+                test_runner.soft_stop()
+        except (OSError, RuntimeError, PermissionError) as e:
+            log.error(f"error soft-stopping pytest runner,{self.run_guid=},{e}", exc_info=True, stack_info=True)
+
 
 class _TestRunner(Thread):
     """
@@ -179,6 +189,7 @@ class _TestRunner(Thread):
 
         self.process: Optional[PytestProcess] = None
         self._stop_event = Event()
+        self._soft_stop_event = Event()
 
         # Singleton enforcement (shared across all workers)
         self._singleton_event = singleton_event
@@ -311,7 +322,7 @@ class _TestRunner(Thread):
     def run(self):
         """Consume tests from the queue until it is empty or a stop is requested."""
 
-        while not self._stop_event.is_set():
+        while not self._stop_event.is_set() and not self._soft_stop_event.is_set():
             try:
                 scheduled_test = self.pytest_test_queue.get(False)
             except Empty:
@@ -323,10 +334,14 @@ class _TestRunner(Thread):
                 # Singleton protocol: block others, drain active workers, run exclusively, resume.
                 self._singleton_event.clear()
                 while not self._all_idle_event.wait(timeout=self.update_rate):
-                    if self._stop_event.is_set():
+                    if self._stop_event.is_set() or self._soft_stop_event.is_set():
                         break
                 if self._stop_event.is_set():
                     self._handle_stop_request(test)
+                    break
+                if self._soft_stop_event.is_set():
+                    self._singleton_event.set()
+                    self._drain_queue()
                     break
                 log.info(f'Running singleton test "{test}" ({self.run_guid=})')
                 self._run_single_test(test)
@@ -334,13 +349,34 @@ class _TestRunner(Thread):
             else:
                 # Normal protocol: wait until no singleton is running.
                 while not self._singleton_event.wait(timeout=self.update_rate):
-                    if self._stop_event.is_set():
+                    if self._stop_event.is_set() or self._soft_stop_event.is_set():
                         break
                 if self._stop_event.is_set():
                     self._handle_stop_request(test)
                     break
+                if self._soft_stop_event.is_set():
+                    self._drain_queue()
+                    break
                 self._run_single_test(test)
+
+        if self._soft_stop_event.is_set() and not self._stop_event.is_set():
+            self._drain_queue()
 
     def stop(self):
         """Signal all work to stop as soon as possible."""
         self._stop_event.set()
+
+    def soft_stop(self):
+        """Signal the worker to finish its current test and stop picking up new ones."""
+        self._soft_stop_event.set()
+
+    def _drain_queue(self):
+        """Drain remaining tests from the queue and mark them as STOPPED in the DB."""
+        with PytestProcessInfoDB(self.data_dir) as db:
+            while True:
+                try:
+                    scheduled_test = self.pytest_test_queue.get(False)
+                except Empty:
+                    break
+                info = PytestProcessInfo(self.run_guid, scheduled_test.node_id, None, PyTestFlyExitCode.STOPPED, None, time_stamp=time.time())
+                db.write(info)

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -458,13 +458,14 @@ def test_run_tab(qtbot):
 
 
 def test_control_window_update(qtbot):
-    """ControlWindow.update() should enable Run and disable Stop when idle."""
+    """ControlWindow.update() should enable Run and disable Stop/Force Stop when idle."""
     data_dir = get_temp_dir("test_control_window")
     cw = ControlWindow(None, data_dir)
     qtbot.addWidget(cw)
     cw.update()
     assert cw.run_button.isEnabled()
     assert not cw.stop_button.isEnabled()
+    assert not cw.force_stop_button.isEnabled()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pytest_runner/test_pytest_runner_soft_stop.py
+++ b/tests/test_pytest_runner/test_pytest_runner_soft_stop.py
@@ -1,0 +1,48 @@
+import time
+
+from pytest_fly.pytest_runner import PytestRunner, PytestRunState
+from pytest_fly.interfaces import ScheduledTest, PyTestFlyExitCode, PytestRunnerState
+from pytest_fly.db import PytestProcessInfoDB
+from pytest_fly.guid import generate_uuid
+
+from ..paths import get_temp_dir
+
+
+def test_pytest_runner_soft_stop(app):
+    """Soft stop lets the running test finish and marks queued tests as STOPPED."""
+
+    test_name = "test_pytest_runner_soft_stop"
+
+    data_dir = get_temp_dir(test_name)
+    run_guid = generate_uuid()
+
+    # Schedule a 3-second test first, then an instant test.
+    # With 1 worker process, the second test stays queued while the first runs.
+    scheduled_tests = [
+        ScheduledTest(node_id="tests/test_3_sec_operation.py", singleton=False, duration=None, coverage=None),
+        ScheduledTest(node_id="tests/test_no_operation.py", singleton=False, duration=None, coverage=None),
+    ]
+
+    runner = PytestRunner(run_guid, scheduled_tests, number_of_processes=1, data_dir=data_dir, update_rate=1.0)
+    runner.start()
+    time.sleep(2.0)  # wait for the first test to start running
+    runner.soft_stop()
+    runner.join(30.0)  # the first test should finish naturally (~3 seconds)
+
+    assert not runner.is_running()
+
+    with PytestProcessInfoDB(data_dir) as db:
+        results = db.query(run_guid)
+
+    # The first test (test_3_sec_operation) should have completed normally.
+    first_test_results = [r for r in results if r.name == "tests/test_3_sec_operation.py"]
+    last_first = first_test_results[-1]
+    assert last_first.exit_code == PyTestFlyExitCode.OK
+
+    # The second test (test_no_operation) should be marked as STOPPED.
+    second_test_results = [r for r in results if r.name == "tests/test_no_operation.py"]
+    last_second = second_test_results[-1]
+    assert last_second.exit_code == PyTestFlyExitCode.STOPPED
+
+    pytest_run_state = PytestRunState(second_test_results)
+    assert pytest_run_state.get_state() == PytestRunnerState.STOPPED


### PR DESCRIPTION
## Summary
- Split the single "Stop" button into two distinct actions:
  - **Stop**: Finishes currently running tests, marks queued tests as "Stopped" (new soft stop)
  - **Force Stop**: Immediately terminates all running tests (existing hard stop behavior)
- Added `STOPPED` state and exit code to interfaces for tests that were queued but never ran
- New test verifying soft stop lets running tests complete while stopping queued ones

## Test plan
- [x] All existing runner tests pass (hard stop, simple, multiprocess, singleton)
- [x] New `test_pytest_runner_soft_stop` passes
- [x] GUI display tests pass
- [ ] Manual: run app, click Stop — running tests finish, queued show as Stopped
- [ ] Manual: run app, click Force Stop — all tests terminated immediately
- [ ] Manual: click Stop then Force Stop — escalates to hard stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)