### PR TITLE
Migrate from black/flake8/mypy to ruff and ty — v0.2.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,15 +23,15 @@ python -m pytest_fly
 pytest tests/                          # full suite
 pytest tests/test_foo.py               # single file
 pytest tests/test_foo.py::test_bar     # single test
-tox                                    # full matrix: py312, pypy3, flake8
+tox                                    # full matrix: py312, pypy3, ruff
 tox -e py312                           # single tox environment
 ```
 
 ### Code quality
 ```bash
-black src tests                        # format (line length 192)
-flake8 src tests                       # lint
-mypy src                               # type check
+ruff check src tests                   # lint
+ruff format src tests                  # format (line length 192)
+ty check src                           # type check
 ```
 
 ### Install for development
@@ -81,6 +81,7 @@ Tests are parallelised **at the module level**. All functions inside a module ru
 | File watching | watchdog |
 | Resource monitoring | psutil |
 | Data classes | attrs |
-| Formatting | black (len=192), flake8, mypy |
+| Linting/Formatting | ruff (len=192) |
+| Type checking | ty |
 | Build | hatchling |
 | CI | GitHub Actions + tox |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,11 @@ Home = "https://github.com/jamesabel/pytest-fly"
 Repository = "https://github.com/jamesabel/pytest-fly"
 Documentation = "https://github.com/jamesabel/pytest-fly#readme"
 
-[tool.black]
+[tool.ruff]
 line-length = 192
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.2.4"
+version = "0.2.5"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,9 +16,8 @@ tobool
 uuid6
 hashy
 # linters
-black
-flake8
-mypy
+ruff
+ty
 # testing
 pytest
 pytest-qt

--- a/src/pytest_fly/db/__init__.py
+++ b/src/pytest_fly/db/__init__.py
@@ -1,1 +1,1 @@
-from .db import PytestProcessInfoDB
+from .db import PytestProcessInfoDB as PytestProcessInfoDB

--- a/src/pytest_fly/db/db.py
+++ b/src/pytest_fly/db/db.py
@@ -1,15 +1,14 @@
-from pathlib import Path
-from enum import IntEnum, StrEnum
 import sqlite3
 from dataclasses import asdict
+from enum import IntEnum, StrEnum
+from pathlib import Path
 
 from msqlite import MSQLite
 from typeguard import typechecked
 
-from ..logger import get_logger
 from ..__version__ import application_name
-from ..interfaces import PytestProcessInfo, PyTestFlyExitCode
-
+from ..interfaces import PyTestFlyExitCode, PytestProcessInfo
+from ..logger import get_logger
 
 log = get_logger()
 

--- a/src/pytest_fly/gui/__init__.py
+++ b/src/pytest_fly/gui/__init__.py
@@ -1,1 +1,1 @@
-from .gui_main import fly_main
+from .gui_main import fly_main as fly_main

--- a/src/pytest_fly/gui/about_tab/about.py
+++ b/src/pytest_fly/gui/about_tab/about.py
@@ -1,10 +1,12 @@
 from dataclasses import asdict
+
 import humanize
 from PySide6.QtCore import QObject, QThread, Signal
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QSizePolicy
-from pytest_fly.gui.gui_util import PlainTextWidget
+from PySide6.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
+
 from pytest_fly.gui.about_tab.project_info import get_project_info
-from pytest_fly.platform.platform_info import get_platform_info, get_performance_core_count
+from pytest_fly.gui.gui_util import PlainTextWidget
+from pytest_fly.platform.platform_info import get_performance_core_count, get_platform_info
 
 
 class AboutDataWorker(QObject):

--- a/src/pytest_fly/gui/about_tab/project_info.py
+++ b/src/pytest_fly/gui/about_tab/project_info.py
@@ -1,7 +1,7 @@
-from pathlib import Path
 import tomllib
 from dataclasses import dataclass
 from functools import cache
+from pathlib import Path
 
 
 @dataclass(frozen=True)

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -1,14 +1,13 @@
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QCheckBox, QLabel, QLineEdit
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QIntValidator, QDoubleValidator
-
+from PySide6.QtGui import QDoubleValidator, QIntValidator
+from PySide6.QtWidgets import QCheckBox, QLabel, QLineEdit, QVBoxLayout, QWidget
 from tobool import to_bool_strict
 
-from pytest_fly.preferences import get_pref, refresh_rate_default, utilization_high_threshold_default, utilization_low_threshold_default
-from pytest_fly.interfaces import TestOrder
-from pytest_fly.platform.platform_info import get_performance_core_count
-from pytest_fly.logger import get_logger
 from pytest_fly.gui.gui_util import get_text_dimensions
+from pytest_fly.interfaces import TestOrder
+from pytest_fly.logger import get_logger
+from pytest_fly.platform.platform_info import get_performance_core_count
+from pytest_fly.preferences import get_pref, refresh_rate_default, utilization_high_threshold_default, utilization_low_threshold_default
 
 log = get_logger()
 

--- a/src/pytest_fly/gui/coverage_tab/__init__.py
+++ b/src/pytest_fly/gui/coverage_tab/__init__.py
@@ -1,1 +1,1 @@
-from .coverage_tab import CoverageTab
+from .coverage_tab import CoverageTab as CoverageTab

--- a/src/pytest_fly/gui/coverage_tab/coverage_tab.py
+++ b/src/pytest_fly/gui/coverage_tab/coverage_tab.py
@@ -2,14 +2,14 @@
 Coverage tab — displays a step-function line chart of combined code coverage over time.
 """
 
-from PySide6.QtWidgets import QGroupBox, QVBoxLayout, QWidget, QSizePolicy
-from PySide6.QtGui import QPainter, QPen, QColor, QPalette, QBrush, QPolygonF
-from PySide6.QtCore import Qt, QPointF
+from PySide6.QtCore import QPointF, Qt
+from PySide6.QtGui import QBrush, QColor, QPainter, QPalette, QPen, QPolygonF
+from PySide6.QtWidgets import QGroupBox, QSizePolicy, QVBoxLayout, QWidget
 
-from ...tick_data import TickData
 from ...interfaces import PytestRunnerState
+from ...tick_data import TickData
 from ..graph_tab.time_axis import compute_grid_ticks
-from ..gui_util import get_text_dimensions, count_test_states
+from ..gui_util import count_test_states, get_text_dimensions
 
 GRID_LINE_COLOR = QColor(180, 180, 180, 100)
 COVERAGE_LINE_COLOR = QColor(34, 139, 34)  # forest green

--- a/src/pytest_fly/gui/graph_tab/__init__.py
+++ b/src/pytest_fly/gui/graph_tab/__init__.py
@@ -1,1 +1,1 @@
-from .graph_tab import GraphTab
+from .graph_tab import GraphTab as GraphTab

--- a/src/pytest_fly/gui/graph_tab/graph_tab.py
+++ b/src/pytest_fly/gui/graph_tab/graph_tab.py
@@ -1,5 +1,5 @@
-from PySide6.QtWidgets import QGroupBox, QVBoxLayout, QWidget, QScrollArea
 from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QGroupBox, QScrollArea, QVBoxLayout, QWidget
 
 from ...tick_data import TickData
 from .progress_bar import PytestProgressBar

--- a/src/pytest_fly/gui/graph_tab/progress_bar.py
+++ b/src/pytest_fly/gui/graph_tab/progress_bar.py
@@ -1,15 +1,16 @@
 # python
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QToolTip, QMenu
-from PySide6.QtCore import QRectF, QPointF
-from PySide6.QtGui import QPainter, QPen, QBrush, QPalette, QGuiApplication
 import time
+
+from PySide6.QtCore import QPointF, QRectF
+from PySide6.QtGui import QBrush, QGuiApplication, QPainter, QPalette, QPen
+from PySide6.QtWidgets import QMenu, QToolTip, QVBoxLayout, QWidget
 from typeguard import typechecked
 
 from ...interfaces import PytestProcessInfo, PytestRunnerState
+from ...logger import get_logger
 from ...pytest_runner.pytest_runner import PytestRunState
 from ..gui_util import get_text_dimensions, tool_tip_limiter
-from .time_axis import compute_grid_ticks, GRID_LINE_COLOR
-from ...logger import get_logger
+from .time_axis import GRID_LINE_COLOR, compute_grid_ticks
 
 log = get_logger()
 
@@ -69,16 +70,8 @@ class PytestProgressBar(QWidget):
         # O(1) change detection: skip repaint if nothing changed
         new_count = len(status_list)
         new_last_ts = status_list[-1].time_stamp if status_list else None
-        is_running = (
-            len(status_list) > 0 and status_list[-1].pid is not None and run_state.get_state() == PytestRunnerState.RUNNING
-        )
-        if (
-            not is_running
-            and new_count == self._prev_count
-            and new_last_ts == self._prev_last_ts
-            and min_time_stamp == self._prev_min_ts
-            and max_time_stamp == self._prev_max_ts
-        ):
+        is_running = len(status_list) > 0 and status_list[-1].pid is not None and run_state.get_state() == PytestRunnerState.RUNNING
+        if not is_running and new_count == self._prev_count and new_last_ts == self._prev_last_ts and min_time_stamp == self._prev_min_ts and max_time_stamp == self._prev_max_ts:
             return  # no change — skip repaint
         self._prev_count = new_count
         self._prev_last_ts = new_last_ts
@@ -102,7 +95,6 @@ class PytestProgressBar(QWidget):
 
     def paintEvent(self, event):
         if len(self.status_list) > 0:
-
             pytest_run_state = self._run_state
 
             painter = QPainter(self)

--- a/src/pytest_fly/gui/graph_tab/time_axis.py
+++ b/src/pytest_fly/gui/graph_tab/time_axis.py
@@ -6,11 +6,10 @@ individual progress bars) and :class:`TimeAxisWidget` (the header painted
 at the top of the progress-bar list).
 """
 
+from PySide6.QtGui import QColor, QPainter, QPalette, QPen
 from PySide6.QtWidgets import QWidget
-from PySide6.QtGui import QPainter, QPen, QColor, QPalette
 
 from ..gui_util import get_text_dimensions
-
 
 # Candidate intervals in seconds — chosen so labels stay readable.
 _INTERVALS = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600]

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -3,32 +3,31 @@ import shutil
 import time
 from pathlib import Path
 
-from PySide6.QtWidgets import (
-    QMainWindow,
-    QApplication,
-    QTabWidget,
-    QSizePolicy,
-)
 from PySide6.QtCore import QCoreApplication, QRect, QTimer
+from PySide6.QtWidgets import (
+    QApplication,
+    QMainWindow,
+    QSizePolicy,
+    QTabWidget,
+)
 from typeguard import typechecked
 
-from ..db import PytestProcessInfoDB
-from ..logger import get_logger
-from ..gui.configuration_tab.configuration import Configuration
-from ..gui.about_tab.about import About
-from ..preferences import get_pref
 from ..__version__ import application_name
-from ..tick_data import TickData
-from ..interfaces import PytestRunnerState, RunMode
-from ..pytest_runner.pytest_runner import PytestRunState
-from ..pytest_runner.coverage import calculate_coverage
+from ..db import PytestProcessInfoDB
 from ..file_util import sanitize_test_name
-from .gui_util import get_font, get_text_dimensions, group_process_infos_by_name, compute_time_window
+from ..gui.about_tab.about import About
+from ..gui.configuration_tab.configuration import Configuration
+from ..interfaces import PytestRunnerState, RunMode
+from ..logger import get_logger
+from ..preferences import get_pref
+from ..pytest_runner.coverage import calculate_coverage
+from ..pytest_runner.pytest_runner import PytestRunState
+from ..tick_data import TickData
+from .coverage_tab import CoverageTab
+from .graph_tab import GraphTab
+from .gui_util import compute_time_window, get_font, get_text_dimensions, group_process_infos_by_name
 from .run_tab import RunTab
 from .table_tab import TableTab
-from .graph_tab import GraphTab
-from .coverage_tab import CoverageTab
-
 
 log = get_logger()
 
@@ -181,7 +180,6 @@ class FlyAppMainWindow(QMainWindow):
         """
         current_completed = {name for name, rs in tick.run_states.items() if rs.get_state() in (PytestRunnerState.PASS, PytestRunnerState.FAIL)}
         if current_completed and current_completed != self._completed_tests:
-            new_tests = current_completed - self._completed_tests
             self._completed_tests = current_completed
             try:
                 coverage_pct, self._covered_lines, self._total_lines = calculate_coverage("current", self.data_dir, write_report=False)
@@ -194,6 +192,7 @@ class FlyAppMainWindow(QMainWindow):
             # (total_lines) may have changed as new tests discover new source files.
             if self._total_lines > 0:
                 from coverage import Coverage
+
                 coverage_dir = Path(self.data_dir, "coverage")
                 for test_name in self._completed_tests:
                     safe_name = sanitize_test_name(test_name)

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -1,12 +1,11 @@
 from collections import defaultdict
 from datetime import timedelta
-from functools import lru_cache, cache
-
-from PySide6.QtWidgets import QPlainTextEdit, QSizePolicy
-from PySide6.QtGui import QFont, QFontMetrics
-from PySide6.QtCore import QSize
+from functools import cache, lru_cache
 
 import humanize
+from PySide6.QtCore import QSize
+from PySide6.QtGui import QFont, QFontMetrics
+from PySide6.QtWidgets import QPlainTextEdit, QSizePolicy
 from typeguard import typechecked
 
 from ..const import TOOLTIP_LINE_LIMIT

--- a/src/pytest_fly/gui/run_tab/__init__.py
+++ b/src/pytest_fly/gui/run_tab/__init__.py
@@ -1,1 +1,1 @@
-from .run_tab import RunTab
+from .run_tab import RunTab as RunTab

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -1,19 +1,18 @@
 from pathlib import Path
 
-from PySide6.QtWidgets import QGroupBox, QVBoxLayout, QSizePolicy, QApplication
 from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QGroupBox, QSizePolicy, QVBoxLayout
 from typeguard import typechecked
 
+from ...db import PytestProcessInfoDB
+from ...guid import generate_uuid
+from ...interfaces import PyTestFlyExitCode, RunMode, ScheduledTest, TestOrder
+from ...logger import get_logger
+from ...preferences import ParallelismControl, get_pref
+from ...pytest_runner.coverage import compute_per_test_coverage
 from ...pytest_runner.pytest_runner import PytestRunner
 from ...pytest_runner.test_list import GetTests
-from ...pytest_runner.coverage import compute_per_test_coverage
-from ...preferences import get_pref, ParallelismControl
-from ...interfaces import RunMode, TestOrder, PyTestFlyExitCode, ScheduledTest
-from ...db import PytestProcessInfoDB
-from ...logger import get_logger
-from ...guid import generate_uuid
 from ..gui_util import extract_test_duration
-
 from .control_pushbutton import ControlButton
 from .parallelism_control_box import ParallelismControlBox
 from .run_mode_control_box import RunModeControlBox

--- a/src/pytest_fly/gui/run_tab/parallelism_control_box.py
+++ b/src/pytest_fly/gui/run_tab/parallelism_control_box.py
@@ -1,6 +1,6 @@
-from PySide6.QtWidgets import QGroupBox, QVBoxLayout, QRadioButton, QButtonGroup
+from PySide6.QtWidgets import QButtonGroup, QGroupBox, QRadioButton, QVBoxLayout
 
-from pytest_fly.preferences import get_pref, ParallelismControl
+from pytest_fly.preferences import ParallelismControl, get_pref
 
 
 class ParallelismControlBox(QGroupBox):

--- a/src/pytest_fly/gui/run_tab/run_mode_control_box.py
+++ b/src/pytest_fly/gui/run_tab/run_mode_control_box.py
@@ -1,5 +1,6 @@
-from PySide6.QtWidgets import QGroupBox, QVBoxLayout, QRadioButton, QButtonGroup
-from pytest_fly.preferences import get_pref, RunMode
+from PySide6.QtWidgets import QButtonGroup, QGroupBox, QRadioButton, QVBoxLayout
+
+from pytest_fly.preferences import RunMode, get_pref
 
 
 class RunModeControlBox(QGroupBox):

--- a/src/pytest_fly/gui/run_tab/run_tab.py
+++ b/src/pytest_fly/gui/run_tab/run_tab.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
-from PySide6.QtWidgets import QWidget, QHBoxLayout
 from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QHBoxLayout, QWidget
 from typeguard import typechecked
 
+from ...logger import get_logger
+from ...tick_data import TickData
 from .control_window import ControlWindow
 from .status_window import StatusWindow
-from ...tick_data import TickData
-from ...logger import get_logger
 
 log = get_logger()
 

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -1,6 +1,6 @@
 import time
 
-from PySide6.QtWidgets import QGroupBox, QVBoxLayout, QSizePolicy
+from PySide6.QtWidgets import QGroupBox, QSizePolicy, QVBoxLayout
 
 from ...gui.gui_util import PlainTextWidget, count_test_states, format_runtime
 from ...interfaces import PytestRunnerState

--- a/src/pytest_fly/gui/run_tab/view_coverage.py
+++ b/src/pytest_fly/gui/run_tab/view_coverage.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 from typeguard import typechecked
 
-from pytest_fly.logger import get_logger
-from pytest_fly.file_util import find_most_recent_file
 from pytest_fly.__version__ import application_name
+from pytest_fly.file_util import find_most_recent_file
+from pytest_fly.logger import get_logger
 
 log = get_logger(application_name)
 

--- a/src/pytest_fly/gui/table_tab/__init__.py
+++ b/src/pytest_fly/gui/table_tab/__init__.py
@@ -1,1 +1,1 @@
-from .table_tab import TableTab
+from .table_tab import TableTab as TableTab

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -1,15 +1,15 @@
 import time
 from enum import Enum
 
-from PySide6.QtWidgets import QGroupBox, QVBoxLayout, QScrollArea, QTableWidget, QTableWidgetItem, QMenu
-from PySide6.QtCore import Qt, QPoint
+from PySide6.QtCore import QPoint, Qt
 from PySide6.QtGui import QColor, QGuiApplication
+from PySide6.QtWidgets import QGroupBox, QMenu, QScrollArea, QTableWidget, QTableWidgetItem, QVBoxLayout
 
-from ...preferences import get_pref
+from ...gui.gui_util import format_runtime, tool_tip_limiter
 from ...interfaces import PyTestFlyExitCode
-from ...tick_data import TickData
-from ...gui.gui_util import tool_tip_limiter, format_runtime
 from ...platform.platform_info import get_performance_core_count
+from ...preferences import get_pref
+from ...tick_data import TickData
 
 
 class Columns(Enum):

--- a/src/pytest_fly/interfaces.py
+++ b/src/pytest_fly/interfaces.py
@@ -6,7 +6,6 @@ from pytest import ExitCode
 
 from .logger import get_logger
 
-
 log = get_logger()
 
 
@@ -85,7 +84,6 @@ class PytestRunnerState(StrEnum):
 
 
 class PyTestFlyExitCode(IntEnum):
-
     # pytest exit codes
     OK = ExitCode.OK
     TESTS_FAILED = ExitCode.TESTS_FAILED

--- a/src/pytest_fly/main.py
+++ b/src/pytest_fly/main.py
@@ -1,10 +1,10 @@
 from balsa import Balsa
 
 from .__version__ import application_name, author
+from .gui import fly_main
 from .logger import get_logger
 from .paths import get_default_data_dir
 from .preferences import get_pref
-from .gui import fly_main
 
 log = get_logger(application_name)
 

--- a/src/pytest_fly/paths.py
+++ b/src/pytest_fly/paths.py
@@ -1,10 +1,11 @@
 import os
-from pathlib import Path
-from platformdirs import user_data_dir
 from functools import cache
+from pathlib import Path
 
-from .const import PYTEST_FLY_DATA_DIR_STRING
+from platformdirs import user_data_dir
+
 from .__version__ import application_name, author
+from .const import PYTEST_FLY_DATA_DIR_STRING
 
 
 @cache

--- a/src/pytest_fly/platform/__init__.py
+++ b/src/pytest_fly/platform/__init__.py
@@ -1,2 +1,26 @@
-from .platform_info import get_platform_info, get_performance_core_count
-from .os import is_windows, is_linux, rm_file, is_file_locked, remove_readonly, remove_readonly_onerror, rm_dir, mk_dirs
+from .os import (
+    is_file_locked as is_file_locked,
+)
+from .os import (
+    is_linux as is_linux,
+)
+from .os import (
+    is_windows as is_windows,
+)
+from .os import (
+    mk_dirs as mk_dirs,
+)
+from .os import (
+    remove_readonly as remove_readonly,
+)
+from .os import (
+    remove_readonly_onerror as remove_readonly_onerror,
+)
+from .os import (
+    rm_dir as rm_dir,
+)
+from .os import (
+    rm_file as rm_file,
+)
+from .platform_info import get_performance_core_count as get_performance_core_count
+from .platform_info import get_platform_info as get_platform_info

--- a/src/pytest_fly/platform/os.py
+++ b/src/pytest_fly/platform/os.py
@@ -1,11 +1,11 @@
 import os
+import shutil
 import stat
+import sys
 import time
+from functools import cache
 from pathlib import Path
 from typing import Union
-import sys
-from functools import cache
-import shutil
 
 from typeguard import typechecked
 

--- a/src/pytest_fly/platform/platform_info.py
+++ b/src/pytest_fly/platform/platform_info.py
@@ -1,8 +1,8 @@
-from functools import cache
-import platform
 import getpass
+import platform
 import struct
 import sys
+from functools import cache
 
 import psutil
 from cpuinfo import get_cpu_info

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -4,8 +4,8 @@ from attr import attrib, attrs
 from pref import Pref
 
 from .__version__ import application_name, author
-from .platform import get_performance_core_count
 from .interfaces import RunMode, TestOrder
+from .platform import get_performance_core_count
 
 preferences_file_name = f"{application_name}_preferences.db"
 

--- a/src/pytest_fly/pytest_runner/__init__.py
+++ b/src/pytest_fly/pytest_runner/__init__.py
@@ -1,3 +1,4 @@
-from .const import TIMEOUT
-from .pytest_runner import PytestRunner, PytestRunState
-from .test_list import GetTests
+from .const import TIMEOUT as TIMEOUT
+from .pytest_runner import PytestRunner as PytestRunner
+from .pytest_runner import PytestRunState as PytestRunState
+from .test_list import GetTests as GetTests

--- a/src/pytest_fly/pytest_runner/coverage.py
+++ b/src/pytest_fly/pytest_runner/coverage.py
@@ -1,14 +1,14 @@
-from pathlib import Path
 import io
-
-from hashy import get_string_sha256
+from pathlib import Path
 
 from coverage import Coverage
-from coverage.exceptions import NoDataError, DataError
+from coverage.exceptions import DataError, NoDataError
+from hashy import get_string_sha256
 
-from ..logger import get_logger
-from ..file_util import find_most_recent_file, sanitize_test_name
 from pytest_fly.__version__ import application_name
+
+from ..file_util import find_most_recent_file, sanitize_test_name
+from ..logger import get_logger
 
 log = get_logger(application_name)
 
@@ -61,7 +61,6 @@ def read_most_recent_coverage_summary_file(coverage_parent_directory: Path) -> f
 
 
 class PytestFlyCoverage(Coverage):
-
     def __init__(self, data_file: Path, **kwargs) -> None:
         super().__init__(data_file, timid=True, concurrency=["thread", "multiprocessing"], check_preimported=True, **kwargs)
         # avoid: "CoverageWarning: Couldn't parse '...': No source for code: '...'. (couldnt-parse)"

--- a/src/pytest_fly/pytest_runner/process_monitor.py
+++ b/src/pytest_fly/pytest_runner/process_monitor.py
@@ -1,8 +1,9 @@
 import time
-from multiprocessing import Process, Queue, Event
 from dataclasses import dataclass
+from multiprocessing import Event, Process, Queue
 
-from psutil import NoSuchProcess, Process as PsutilProcess
+from psutil import NoSuchProcess
+from psutil import Process as PsutilProcess
 from typeguard import typechecked
 
 

--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -11,10 +11,10 @@ from coverage import Coverage
 from typeguard import typechecked
 
 from ..__version__ import application_name
-from ..file_util import sanitize_test_name
-from ..interfaces import PytestProcessInfo, PyTestFlyExitCode
-from ..logger import get_logger
 from ..db import PytestProcessInfoDB
+from ..file_util import sanitize_test_name
+from ..interfaces import PyTestFlyExitCode, PytestProcessInfo
+from ..logger import get_logger
 from .process_monitor import ProcessMonitor
 
 log = get_logger(application_name)
@@ -57,7 +57,6 @@ class PytestProcess(Process):
         # Redirect stdout and stderr so nothing goes to the console.
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
-
             # create a temp coverage file and then move it so if the file exists, the content is complete (the save is not necessarily instantaneous and atomic)
             coverage_dir = Path(self.data_dir, "coverage")
             coverage_dir.mkdir(parents=True, exist_ok=True)

--- a/src/pytest_fly/pytest_runner/pytest_runner.py
+++ b/src/pytest_fly/pytest_runner/pytest_runner.py
@@ -1,18 +1,18 @@
-from pathlib import Path
-from queue import Queue, Empty
-from typing import Optional
-from threading import Event, Lock, Thread
 import time
+from pathlib import Path
+from queue import Empty, Queue
+from threading import Event, Lock, Thread
+from typing import Optional
 
-from typeguard import typechecked
 from PySide6.QtGui import QColor
+from typeguard import typechecked
 
-from ..logger import get_logger
-from ..interfaces import PytestRunnerState, PyTestFlyExitCode, ScheduledTest
 from ..colors import BAR_COLORS, TABLE_COLORS
-from .pytest_process import PytestProcess, PytestProcessInfo
 from ..db import PytestProcessInfoDB
+from ..interfaces import PyTestFlyExitCode, PytestRunnerState, ScheduledTest
+from ..logger import get_logger
 from .const import TIMEOUT
+from .pytest_process import PytestProcess, PytestProcessInfo
 
 log = get_logger()
 

--- a/src/pytest_fly/pytest_runner/test_list.py
+++ b/src/pytest_fly/pytest_runner/test_list.py
@@ -1,20 +1,19 @@
 import sys
 from io import StringIO
-from pathlib import Path
 from multiprocessing import Process, Queue
+from pathlib import Path
 from queue import Empty
 
 import pytest
 from typeguard import typechecked
 
-from ..logger import get_logger
 from ..interfaces import ScheduledTest
+from ..logger import get_logger
 
 log = get_logger()
 
 
 class GetTests(Process):
-
     def __init__(self, test_dir: Path = Path("").resolve()):
         """
         Collects all pytest tests within the given directory (recursively) in a separate process and returns their node IDs as a list of strings.
@@ -35,7 +34,6 @@ class GetTests(Process):
 
         # singleton last
         for collect_singleton in (False, True):
-
             # Temporarily redirect stdout so we can parse pytest’s collection output.
             original_stdout = sys.stdout
             buffer = StringIO()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,6 @@ from pathlib import Path
 import pytest
 from PySide6.QtWidgets import QApplication
 
-from pytest_fly.db import PytestProcessInfoDB
-
 pytest_plugins = "pytester"
 
 

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 from typeguard import typechecked
 
-from pytest_fly.platform import mk_dirs
 from pytest_fly.const import PYTEST_FLY_DATA_DIR_STRING
+from pytest_fly.platform import mk_dirs
 
 
 @typechecked()

--- a/tests/test_coverage_calculation.py
+++ b/tests/test_coverage_calculation.py
@@ -4,10 +4,10 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from pytest_fly.pytest_runner.coverage import (
-    write_coverage_summary_file,
-    read_most_recent_coverage_summary_file,
-    calculate_coverage,
     _parse_report_totals,
+    calculate_coverage,
+    read_most_recent_coverage_summary_file,
+    write_coverage_summary_file,
 )
 
 

--- a/tests/test_do_something.py
+++ b/tests/test_do_something.py
@@ -1,5 +1,5 @@
-import time
 import random
+import time
 
 
 def test_do_something():

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -6,25 +6,25 @@ import time
 from pathlib import Path
 
 from pytest_fly.db import PytestProcessInfoDB
-from pytest_fly.gui.gui_main import build_tick_data
-from pytest_fly.gui.run_tab.status_window import StatusWindow
-from pytest_fly.gui.run_tab.control_window import ControlWindow
-from pytest_fly.gui.run_tab.control_pushbutton import ControlButton
-from pytest_fly.gui.run_tab.run_mode_control_box import RunModeControlBox
-from pytest_fly.gui.run_tab.parallelism_control_box import ParallelismControlBox
-from pytest_fly.gui.run_tab.run_tab import RunTab
-from pytest_fly.gui.run_tab.view_coverage import ViewCoverage
-from pytest_fly.gui.table_tab.table_tab import TableTab
+from pytest_fly.gui.about_tab.about import About
+from pytest_fly.gui.about_tab.project_info import get_project_info
+from pytest_fly.gui.configuration_tab.configuration import Configuration
+from pytest_fly.gui.coverage_tab import CoverageTab
 from pytest_fly.gui.graph_tab.graph_tab import GraphTab
 from pytest_fly.gui.graph_tab.progress_bar import PytestProgressBar
 from pytest_fly.gui.graph_tab.time_axis import TimeAxisWidget
-from pytest_fly.gui.coverage_tab import CoverageTab
-from pytest_fly.gui.configuration_tab.configuration import Configuration
-from pytest_fly.gui.about_tab.about import About
-from pytest_fly.gui.about_tab.project_info import get_project_info
-from pytest_fly.interfaces import PytestProcessInfo, PyTestFlyExitCode, PytestRunnerState, ScheduledTest
-from pytest_fly.pytest_runner.pytest_runner import PytestRunner, PytestRunState
+from pytest_fly.gui.gui_main import build_tick_data
+from pytest_fly.gui.run_tab.control_pushbutton import ControlButton
+from pytest_fly.gui.run_tab.control_window import ControlWindow
+from pytest_fly.gui.run_tab.parallelism_control_box import ParallelismControlBox
+from pytest_fly.gui.run_tab.run_mode_control_box import RunModeControlBox
+from pytest_fly.gui.run_tab.run_tab import RunTab
+from pytest_fly.gui.run_tab.status_window import StatusWindow
+from pytest_fly.gui.run_tab.view_coverage import ViewCoverage
+from pytest_fly.gui.table_tab.table_tab import TableTab
 from pytest_fly.guid import generate_uuid
+from pytest_fly.interfaces import PyTestFlyExitCode, PytestProcessInfo, PytestRunnerState, ScheduledTest
+from pytest_fly.pytest_runner.pytest_runner import PytestRunner, PytestRunState
 
 from .paths import get_temp_dir
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -4,8 +4,8 @@ import psutil
 
 from pytest_fly.platform.platform_info import (
     _get_p_core_count_windows,
-    get_performance_core_count,
     get_efficiency_core_count,
+    get_performance_core_count,
 )
 
 

--- a/tests/test_pytest_process.py
+++ b/tests/test_pytest_process.py
@@ -1,10 +1,10 @@
-from tempfile import TemporaryDirectory
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
+from pytest_fly.db import PytestProcessInfoDB
+from pytest_fly.guid import generate_uuid
 from pytest_fly.interfaces import PyTestFlyExitCode
 from pytest_fly.pytest_runner.pytest_process import PytestProcess
-from pytest_fly.guid import generate_uuid
-from pytest_fly.db import PytestProcessInfoDB
 
 
 def test_pytest_process():

--- a/tests/test_pytest_process_info_db.py
+++ b/tests/test_pytest_process_info_db.py
@@ -1,9 +1,8 @@
 import time
 
 from pytest_fly.db import PytestProcessInfoDB
-from pytest_fly.interfaces import PytestProcessInfo, PyTestFlyExitCode
 from pytest_fly.guid import generate_uuid
-
+from pytest_fly.interfaces import PyTestFlyExitCode, PytestProcessInfo
 
 from .paths import get_temp_dir
 

--- a/tests/test_pytest_runner/test_pytest_runner_multiprocess.py
+++ b/tests/test_pytest_runner/test_pytest_runner_multiprocess.py
@@ -1,7 +1,7 @@
-from pytest_fly.pytest_runner import PytestRunner
+from pytest_fly.db import PytestProcessInfoDB
 from pytest_fly.guid import generate_uuid
 from pytest_fly.interfaces import ScheduledTest
-from pytest_fly.db import PytestProcessInfoDB
+from pytest_fly.pytest_runner import PytestRunner
 
 from ..paths import get_temp_dir
 

--- a/tests/test_pytest_runner/test_pytest_runner_simple.py
+++ b/tests/test_pytest_runner/test_pytest_runner_simple.py
@@ -1,7 +1,7 @@
-from pytest_fly.pytest_runner import PytestRunner
-from pytest_fly.interfaces import ScheduledTest, PyTestFlyExitCode
 from pytest_fly.db import PytestProcessInfoDB
 from pytest_fly.guid import generate_uuid
+from pytest_fly.interfaces import PyTestFlyExitCode, ScheduledTest
+from pytest_fly.pytest_runner import PytestRunner
 
 from ..paths import get_temp_dir
 

--- a/tests/test_pytest_runner/test_pytest_runner_singleton.py
+++ b/tests/test_pytest_runner/test_pytest_runner_singleton.py
@@ -1,7 +1,7 @@
-from pytest_fly.pytest_runner import PytestRunner
-from pytest_fly.guid import generate_uuid
-from pytest_fly.interfaces import ScheduledTest, PyTestFlyExitCode
 from pytest_fly.db import PytestProcessInfoDB
+from pytest_fly.guid import generate_uuid
+from pytest_fly.interfaces import PyTestFlyExitCode, ScheduledTest
+from pytest_fly.pytest_runner import PytestRunner
 
 from ..paths import get_temp_dir
 
@@ -57,6 +57,5 @@ def test_pytest_runner_singleton(app):
         final_record = records[-1]
         assert final_record.exit_code == PyTestFlyExitCode.OK, f"{test_name_key} did not pass: {final_record.exit_code}"
         assert final_record.time_stamp <= singleton_start_time, (
-            f"Singleton test started at {singleton_start_time} but "
-            f"{test_name_key} finished at {final_record.time_stamp} — singleton was not exclusive"
+            f"Singleton test started at {singleton_start_time} but {test_name_key} finished at {final_record.time_stamp} — singleton was not exclusive"
         )

--- a/tests/test_pytest_runner/test_pytest_runner_soft_stop.py
+++ b/tests/test_pytest_runner/test_pytest_runner_soft_stop.py
@@ -1,9 +1,9 @@
 import time
 
-from pytest_fly.pytest_runner import PytestRunner, PytestRunState
-from pytest_fly.interfaces import ScheduledTest, PyTestFlyExitCode, PytestRunnerState
 from pytest_fly.db import PytestProcessInfoDB
 from pytest_fly.guid import generate_uuid
+from pytest_fly.interfaces import PyTestFlyExitCode, PytestRunnerState, ScheduledTest
+from pytest_fly.pytest_runner import PytestRunner, PytestRunState
 
 from ..paths import get_temp_dir
 

--- a/tests/test_pytest_runner/test_pytest_runner_stop.py
+++ b/tests/test_pytest_runner/test_pytest_runner_stop.py
@@ -1,9 +1,9 @@
 import time
 
-from pytest_fly.pytest_runner import PytestRunner, PytestRunState
-from pytest_fly.interfaces import ScheduledTest, PyTestFlyExitCode, PytestRunnerState
 from pytest_fly.db import PytestProcessInfoDB
 from pytest_fly.guid import generate_uuid
+from pytest_fly.interfaces import PyTestFlyExitCode, PytestRunnerState, ScheduledTest
+from pytest_fly.pytest_runner import PytestRunner, PytestRunState
 
 from ..paths import get_temp_dir
 

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from pytest_fly.guid import generate_uuid, decode_uuid_timestamp
+from pytest_fly.guid import decode_uuid_timestamp, generate_uuid
 
 
 def test_generate_uuid():

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py312,pypy3,flake8
+envlist = py312,pypy3,ruff
 
 [testenv]
 deps = pytest>=6.2.0
 commands = pytest {posargs:tests}
 
-[testenv:flake8]
+[testenv:ruff]
 skip_install = true
-deps = flake8
-commands = flake8 src tests
+deps = ruff
+commands =
+    ruff check src tests
+    ruff format --check src tests


### PR DESCRIPTION
## Summary
- Replace **black** (formatter), **flake8** (linter), and **mypy** (type checker) with **ruff** (lint + format) and **ty** (type checking), both from Astral
- Configure ruff in `pyproject.toml` with line-length 192 and `E`, `F`, `W`, `I` rule sets
- Fix all 22 lint errors: explicit re-exports in `__init__.py` files, import sorting, unused variable, unused import
- Reformat all files with `ruff format`
- Update `tox.ini` (flake8 env → ruff env), `requirements-dev.txt`, `CLAUDE.md`

## Test plan
- [x] `ruff check src tests` — all checks passed
- [x] `ruff format --check src tests` — all files formatted
- [x] All existing tests pass after reformatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)