### PR TITLE
Add pre-commit hooks for ruff and ty — v0.2.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.10
+    hooks:
+      - id: ruff
+        args: [--fix]
+        exclude: ^demo/
+      - id: ruff-format
+        exclude: ^demo/
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty (informational)
+        entry: bash -c "python -m ty check src || true"
+        language: system
+        pass_filenames: false
+        types: [python]
+        verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.2.5"
+version = "0.2.6"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ hashy
 # linters
 ruff
 ty
+pre-commit
 # testing
 pytest
 pytest-qt


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` with ruff (lint + format) and ty (type check) hooks
- **ruff check** (with `--fix`): blocking — auto-fixes and enforces lint rules on commit
- **ruff format**: blocking — enforces consistent formatting on commit
- **ty check**: informational (non-blocking) — reports type errors but doesn't prevent commits, since ty is early-stage and has pre-existing diagnostics from third-party stubs (PySide6, pref, balsa)
- `demo/` directory excluded from ruff hooks (contains intentional whitespace in string templates)
- Add `pre-commit` to `requirements-dev.txt`

## Setup
After pulling, run `pre-commit install` to activate the hooks locally.

## Test plan
- [x] `pre-commit run --all-files` passes (all hooks green)
- [x] Commit with hooks active succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)