### PR TITLE
Add per-test Force Stop in table context menu — v0.2.7

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -1,8 +1,8 @@
+import textwrap
 from multiprocessing import Process
 from pathlib import Path
-import textwrap
-import pytest
 
+import pytest
 from ismain import is_main
 
 from pytest_fly import main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.2.6"
+version = "0.2.7"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -122,6 +122,8 @@ class FlyAppMainWindow(QMainWindow):
         self._total_lines: int = 0
         self._last_run_guid: str | None = None
 
+        self.table_tab.force_stop_test_requested.connect(self._force_stop_single_test)
+
         self.setCentralWidget(self.tab_widget)
 
         # timer for periodic updates
@@ -152,6 +154,12 @@ class FlyAppMainWindow(QMainWindow):
             pytest_runner.join(30.0)
 
         event.accept()
+
+    def _force_stop_single_test(self, test_name: str):
+        """Handle request to terminate a single running test from the table tab."""
+        control = self.run_tab.control_window
+        if control.pytest_runner is not None and control.pytest_runner.is_running():
+            control.pytest_runner.force_stop_test(test_name)
 
     def _handle_new_run(self, current_guid: str | None):
         """Reset coverage state when a new run starts and clear old coverage files.

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -1,12 +1,12 @@
 import time
 from enum import Enum
 
-from PySide6.QtCore import QPoint, Qt
+from PySide6.QtCore import QPoint, Qt, Signal
 from PySide6.QtGui import QColor, QGuiApplication
 from PySide6.QtWidgets import QGroupBox, QMenu, QScrollArea, QTableWidget, QTableWidgetItem, QVBoxLayout
 
 from ...gui.gui_util import format_runtime, tool_tip_limiter
-from ...interfaces import PyTestFlyExitCode
+from ...interfaces import PyTestFlyExitCode, PytestRunnerState
 from ...platform.platform_info import get_performance_core_count
 from ...preferences import get_pref
 from ...tick_data import TickData
@@ -43,6 +43,8 @@ def set_utilization_color(item: QTableWidgetItem, value: float):
 class TableTab(QGroupBox):
     """Tab showing a per-test table with state, CPU, memory, and runtime columns."""
 
+    force_stop_test_requested = Signal(str)  # emits the test node_id
+
     def __init__(self):
         super().__init__()
 
@@ -65,20 +67,37 @@ class TableTab(QGroupBox):
         layout.addWidget(scroll_area)
         self.setLayout(layout)
 
+        self._current_run_states: dict = {}
+
     def show_context_menu(self, position: QPoint):
-        """Show a right-click context menu allowing the user to copy pytest output.
+        """Show a right-click context menu allowing the user to copy pytest output or force-stop a running test.
 
         :param position: Click position relative to the table viewport.
         """
+        item = self.table_widget.itemAt(position)
+        if item is None:
+            item = self.table_widget.currentItem()
+
+        # Determine the test node_id and state for the right-clicked row
+        row = item.row() if item is not None else -1
+        test_node_id = None
+        is_running = False
+        if row >= 0:
+            name_item = self.table_widget.item(row, Columns.NAME.value)
+            if name_item is not None:
+                test_node_id = name_item.data(Qt.ItemDataRole.UserRole)
+            if test_node_id is not None and test_node_id in self._current_run_states:
+                is_running = self._current_run_states[test_node_id].get_state() == PytestRunnerState.RUNNING
+
         menu = QMenu()
         copy_tooltip_action = menu.addAction("Copy Pytest Output")
+        force_stop_action = None
+        if test_node_id is not None and is_running:
+            force_stop_action = menu.addAction("Force Stop")
+
         action = menu.exec_(self.table_widget.viewport().mapToGlobal(position))
 
         if action == copy_tooltip_action:
-            # try the item under the mouse; fallback to current item
-            item = self.table_widget.itemAt(position)
-            if item is None:
-                item = self.table_widget.currentItem()
             if item is not None:
                 tooltip = item.toolTip()
                 # fallback to ItemDataRole if toolTip() is empty
@@ -87,6 +106,8 @@ class TableTab(QGroupBox):
                 if tooltip:
                     clipboard = QGuiApplication.clipboard()
                     clipboard.setText(tooltip)
+        elif action is not None and action == force_stop_action:
+            self.force_stop_test_requested.emit(test_node_id)
 
     def copy_selected_text(self):
         selected_ranges = self.table_widget.selectedRanges()
@@ -110,6 +131,8 @@ class TableTab(QGroupBox):
     def update_tick(self, tick: TickData):
         """Refresh the table from pre-computed tick data."""
 
+        self._current_run_states = tick.run_states
+
         self.table_widget.clearContents()
         self.table_widget.setRowCount(len(tick.infos_by_name))
 
@@ -117,7 +140,9 @@ class TableTab(QGroupBox):
             process_infos = tick.infos_by_name[test_name]
             pytest_run_state = tick.run_states[test_name]
 
-            self.table_widget.setItem(row_number, Columns.NAME.value, QTableWidgetItem(pytest_run_state.get_name()))
+            name_item = QTableWidgetItem(pytest_run_state.get_name())
+            name_item.setData(Qt.ItemDataRole.UserRole, test_name)  # store node_id for context menu
+            self.table_widget.setItem(row_number, Columns.NAME.value, name_item)
 
             state_item = QTableWidgetItem()
             state_text = pytest_run_state.get_string()

--- a/src/pytest_fly/pytest_runner/pytest_runner.py
+++ b/src/pytest_fly/pytest_runner/pytest_runner.py
@@ -150,6 +150,22 @@ class PytestRunner(Thread):
         except (OSError, RuntimeError, PermissionError) as e:
             log.error(f"error soft-stopping pytest runner,{self.run_guid=},{e}", exc_info=True, stack_info=True)
 
+    def force_stop_test(self, test_name: str) -> None:
+        """Terminate a single running test identified by its node_id.
+
+        Iterates worker threads and signals the one currently running the
+        given test to terminate its process.  Other workers are unaffected.
+
+        :param test_name: The test node_id to terminate.
+        """
+        for test_runner in self._test_runners.values():
+            proc = test_runner.process
+            if proc is not None and proc.name == test_name:
+                test_runner.force_stop_current()
+                log.info(f'force stop requested for test "{test_name}" ({self.run_guid=})')
+                return
+        log.warning(f'force stop: no running process found for test "{test_name}" ({self.run_guid=})')
+
 
 class _TestRunner(Thread):
     """
@@ -190,6 +206,7 @@ class _TestRunner(Thread):
         self.process: Optional[PytestProcess] = None
         self._stop_event = Event()
         self._soft_stop_event = Event()
+        self._force_stop_current_event = Event()
 
         # Singleton enforcement (shared across all workers)
         self._singleton_event = singleton_event
@@ -298,7 +315,7 @@ class _TestRunner(Thread):
             self.process.start()
 
             while self.process.is_alive():
-                if self._stop_event.is_set():
+                if self._stop_event.is_set() or self._force_stop_current_event.is_set():
                     self._handle_stop_request(test)
 
                 # Poll / yield to avoid busy-looping
@@ -313,6 +330,7 @@ class _TestRunner(Thread):
             else:
                 log.info(f'process for test "{self.process.name}" completed ({self.run_guid=})')
         finally:
+            self._force_stop_current_event.clear()
             self._decrement_active()
 
     # ------------------------------------------------------------------
@@ -369,6 +387,10 @@ class _TestRunner(Thread):
     def soft_stop(self):
         """Signal the worker to finish its current test and stop picking up new ones."""
         self._soft_stop_event.set()
+
+    def force_stop_current(self):
+        """Signal this worker to terminate its currently running test."""
+        self._force_stop_current_event.set()
 
     def _drain_queue(self):
         """Drain remaining tests from the queue and mark them as STOPPED in the DB."""


### PR DESCRIPTION
## Summary
- Right-clicking a running test in the Table tab now shows a **Force Stop** context menu action that terminates only that specific test process
- The rest of the run continues — other running and queued tests are unaffected
- Particularly useful for hung tests that would otherwise require stopping the entire run

## Changes
- `pytest_runner.py`: Added `PytestRunner.force_stop_test(test_name)` and per-worker `_force_stop_current_event` that terminates one test without breaking the worker loop
- `table_tab.py`: Extended context menu with conditional "Force Stop" action (only shown for running tests), emits `force_stop_test_requested` signal
- `gui_main.py`: Wires the table signal to the runner
- `pyproject.toml`: Version bump to 0.2.7

## Test plan
- [ ] Run the app and start a parallel test run
- [ ] Right-click a running test in the Table tab — "Force Stop" should appear
- [ ] Right-click a non-running test — "Force Stop" should NOT appear
- [ ] Click "Force Stop" on a running test — it should show "Terminated" while other tests continue
- [ ] Verify the overall run completes normally
- [ ] `pytest tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)