### PR TITLE
Add Last Pass columns to test table — v0.2.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.2.8"
+version = "0.2.9"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/db/db.py
+++ b/src/pytest_fly/db/db.py
@@ -111,6 +111,48 @@ class PytestProcessInfoDB(MSQLite):
 
         return rows
 
+    def query_last_pass(self) -> dict[str, tuple[float, float]]:
+        """
+        For each test name, find the most recent run where the test passed.
+
+        Searches across all ``run_guid`` values to locate the latest passing
+        result (``exit_code == OK``) for every test.
+
+        :return: Dictionary mapping test name to ``(start_timestamp, duration_seconds)``.
+        """
+
+        ok_val = int(PyTestFlyExitCode.OK)
+        statement = f"""
+            SELECT p.name, s.start_ts, p.time_stamp AS end_ts
+            FROM (
+                SELECT name, MAX(run_guid) AS run_guid
+                FROM {self.table_name}
+                WHERE exit_code = ?
+                GROUP BY name
+            ) latest
+            JOIN {self.table_name} p
+                ON p.name = latest.name
+                AND p.run_guid = latest.run_guid
+                AND p.exit_code = ?
+            JOIN (
+                SELECT name, run_guid, MIN(time_stamp) AS start_ts
+                FROM {self.table_name}
+                WHERE pid IS NOT NULL
+                GROUP BY name, run_guid
+            ) s
+                ON s.name = latest.name
+                AND s.run_guid = latest.run_guid
+        """
+        result = {}
+        try:
+            for row in self.execute(statement, [ok_val, ok_val]):
+                name, start_ts, end_ts = row[0], row[1], row[2]
+                if start_ts is not None and end_ts is not None:
+                    result[name] = (start_ts, end_ts - start_ts)
+        except sqlite3.OperationalError as e:
+            log.debug(f"query_last_pass failed (table may not exist yet): {e}")
+        return result
+
     def delete(self, run_guid: str | None = None):
         """
         Delete records.  If *run_guid* is ``None`` the entire table is dropped;

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -226,9 +226,11 @@ class FlyAppMainWindow(QMainWindow):
         """
         with PytestProcessInfoDB(self.data_dir) as db:
             process_infos = db.query(self.run_tab.control_window.run_guid)
+            last_pass_data = db.query_last_pass()
 
         control = self.run_tab.control_window
         tick = build_tick_data(process_infos, prior_durations=control.prior_durations, num_processes=control.num_processes)
+        tick.last_pass_data = last_pass_data
 
         self._handle_new_run(control.run_guid)
         self._update_coverage(tick)

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -12,7 +12,6 @@ from ...preferences import ParallelismControl, get_pref
 from ...pytest_runner.coverage import compute_per_test_coverage
 from ...pytest_runner.pytest_runner import PytestRunner
 from ...pytest_runner.test_list import GetTests
-from ..gui_util import extract_test_duration
 from .control_pushbutton import ControlButton
 from .parallelism_control_box import ParallelismControlBox
 from .run_mode_control_box import RunModeControlBox
@@ -115,14 +114,15 @@ class ControlWindow(QGroupBox):
         # Query prior results once (used by both RESUME filtering and failed-first ordering)
         with PytestProcessInfoDB(self.data_dir) as db:
             prior_results = db.query()  # most recent run
+            last_pass_data = db.query_last_pass()  # most recent passing run per test
 
         tests = self._filter_for_resume(tests, prior_results, pref)
 
         # Reorder so previously-failed tests run first (within their singleton group)
         tests = self._reorder_failed_first(tests, prior_results)
 
-        # Compute prior durations for ETA estimation
-        self.prior_durations = self._compute_prior_durations(prior_results)
+        # Use last-pass durations for ETA estimation (from the most recent passing run)
+        self.prior_durations = {name: duration for name, (_, duration) in last_pass_data.items()}
         self.num_processes = processes
 
         # Populate coverage/duration for coverage-efficiency ordering
@@ -185,22 +185,6 @@ class ControlWindow(QGroupBox):
             )
             for t in tests
         ]
-
-    def _compute_prior_durations(self, prior_results):
-        """Compute durations from prior results for ETA estimation.
-
-        :param prior_results: List of prior PytestProcessInfo records.
-        :return: Dictionary mapping test name to duration in seconds.
-        """
-        durations = {}
-        prior_by_name: dict[str, list] = {}
-        for r in prior_results:
-            prior_by_name.setdefault(r.name, []).append(r)
-        for name, infos in prior_by_name.items():
-            start, end = extract_test_duration(infos)
-            if start is not None and end is not None:
-                durations[name] = end - start
-        return durations
 
     def soft_stop(self):
         """Stop scheduling new tests but let running tests finish."""

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 from enum import Enum
 
 from PySide6.QtCore import QPoint, Qt, Signal
@@ -19,6 +20,8 @@ class Columns(Enum):
     MEMORY = 3
     RUNTIME = 4
     COVERAGE = 5
+    LAST_PASS_START = 6
+    LAST_PASS_DURATION = 7
 
 
 def set_utilization_color(item: QTableWidgetItem, value: float):
@@ -58,7 +61,7 @@ class TableTab(QGroupBox):
         # Create a table widget to hold the content
         self.table_widget = QTableWidget(parent=scroll_area)
         self.table_widget.setColumnCount(len(Columns))
-        self.table_widget.setHorizontalHeaderLabels(["Name", "State", "CPU", "Memory", "Runtime", "Coverage"])
+        self.table_widget.setHorizontalHeaderLabels(["Name", "State", "CPU", "Memory", "Runtime", "Coverage", "Last Pass Start", "Last Pass Duration"])
         self.table_widget.horizontalHeader().setStretchLastSection(True)
         self.table_widget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.table_widget.customContextMenuRequested.connect(self.show_context_menu)
@@ -194,5 +197,17 @@ class TableTab(QGroupBox):
             coverage_pct = tick.per_test_coverage.get(test_name)
             coverage_text = f"{coverage_pct:.1%}" if coverage_pct is not None else ""
             self.table_widget.setItem(row_number, Columns.COVERAGE.value, QTableWidgetItem(coverage_text))
+
+            # Last pass data (persists across runs)
+            last_pass = tick.last_pass_data.get(test_name)
+            if last_pass is not None:
+                last_pass_start_ts, last_pass_duration = last_pass
+                last_pass_start_text = datetime.fromtimestamp(last_pass_start_ts).strftime("%Y-%m-%d %H:%M:%S")
+                last_pass_duration_text = format_runtime(last_pass_duration)
+            else:
+                last_pass_start_text = ""
+                last_pass_duration_text = ""
+            self.table_widget.setItem(row_number, Columns.LAST_PASS_START.value, QTableWidgetItem(last_pass_start_text))
+            self.table_widget.setItem(row_number, Columns.LAST_PASS_DURATION.value, QTableWidgetItem(last_pass_duration_text))
 
         self.table_widget.resizeColumnsToContents()

--- a/src/pytest_fly/tick_data.py
+++ b/src/pytest_fly/tick_data.py
@@ -31,3 +31,4 @@ class TickData:
     per_test_coverage: dict[str, float] = field(default_factory=dict)  # test_name -> coverage_pct 0.0-1.0
     covered_lines: int = 0  # lines executed by all completed tests combined
     total_lines: int = 0  # total executable lines in the source
+    last_pass_data: dict[str, tuple[float, float]] = field(default_factory=dict)  # test_name -> (start_timestamp, duration_seconds) from most recent passing run

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -207,6 +207,40 @@ def test_table_tab_updates_on_second_tick(app):
     assert state_2 == PytestRunnerState.PASS.value
 
 
+def test_table_tab_last_pass_columns(app):
+    """TableTab should display last pass start time and duration from last_pass_data."""
+    from pytest_fly.gui.table_tab.table_tab import Columns
+
+    table = TableTab()
+    tick = _make_tick_data_with_tests()
+    now = time.time()
+    tick.last_pass_data = {
+        "tests/test_a.py": (now - 3600, 4.5),  # passed 1 hour ago, took 4.5s
+    }
+    table.update_tick(tick)
+
+    assert table.table_widget.columnCount() == len(Columns)
+
+    # Collect last-pass data by test name
+    last_pass_by_name = {}
+    for row in range(table.table_widget.rowCount()):
+        name_item = table.table_widget.item(row, Columns.NAME.value)
+        start_item = table.table_widget.item(row, Columns.LAST_PASS_START.value)
+        dur_item = table.table_widget.item(row, Columns.LAST_PASS_DURATION.value)
+        assert start_item is not None
+        assert dur_item is not None
+        last_pass_by_name[name_item.text()] = (start_item.text(), dur_item.text())
+
+    # test_a has last-pass data
+    start_text, dur_text = last_pass_by_name["tests/test_a.py"]
+    assert start_text != ""  # should have a formatted datetime
+    assert "4" in dur_text  # should contain "4" from "4.5 seconds"
+
+    # test_b and test_c have no last-pass data
+    assert last_pass_by_name["tests/test_b.py"] == ("", "")
+    assert last_pass_by_name["tests/test_c.py"] == ("", "")
+
+
 # ---------------------------------------------------------------------------
 # GraphTab tests
 # ---------------------------------------------------------------------------

--- a/tests/test_pytest_process_info_db.py
+++ b/tests/test_pytest_process_info_db.py
@@ -83,3 +83,69 @@ def test_pytest_process_info_db_query_most_recent():
         rows = db.query()  # None = most recent
         assert len(rows) == 1
         assert rows[0].run_guid == guid_new
+
+
+def test_query_last_pass():
+    """query_last_pass returns data from the most recent passing run, even if a later run failed."""
+
+    db_dir = get_temp_dir("test_query_last_pass")
+    now = time.time()
+    guid_a = "aaa-run-a"
+    guid_b = "bbb-run-b"
+
+    with PytestProcessInfoDB(db_dir) as db:
+        # Run A: test_x passes (queued, started, completed OK)
+        db.write(PytestProcessInfo(run_guid=guid_a, name="test_x", pid=None, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now))
+        db.write(PytestProcessInfo(run_guid=guid_a, name="test_x", pid=100, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now + 1))
+        db.write(PytestProcessInfo(run_guid=guid_a, name="test_x", pid=100, exit_code=PyTestFlyExitCode.OK, output="passed", time_stamp=now + 6))
+
+        # Run B: test_x fails
+        db.write(PytestProcessInfo(run_guid=guid_b, name="test_x", pid=None, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now + 100))
+        db.write(PytestProcessInfo(run_guid=guid_b, name="test_x", pid=200, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now + 101))
+        db.write(PytestProcessInfo(run_guid=guid_b, name="test_x", pid=200, exit_code=PyTestFlyExitCode.TESTS_FAILED, output="failed", time_stamp=now + 108))
+
+        result = db.query_last_pass()
+        assert "test_x" in result
+        start_ts, duration = result["test_x"]
+        assert start_ts == now + 1  # first record with pid set in run A
+        assert abs(duration - 5.0) < 0.01  # 6 - 1 = 5 seconds
+
+
+def test_query_last_pass_never_passed():
+    """query_last_pass returns empty dict for a test that has never passed."""
+
+    db_dir = get_temp_dir("test_query_last_pass_never_passed")
+    now = time.time()
+    guid = "aaa-run"
+
+    with PytestProcessInfoDB(db_dir) as db:
+        db.write(PytestProcessInfo(run_guid=guid, name="test_y", pid=None, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now))
+        db.write(PytestProcessInfo(run_guid=guid, name="test_y", pid=100, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now + 1))
+        db.write(PytestProcessInfo(run_guid=guid, name="test_y", pid=100, exit_code=PyTestFlyExitCode.TESTS_FAILED, output="fail", time_stamp=now + 3))
+
+        result = db.query_last_pass()
+        assert "test_y" not in result
+
+
+def test_query_last_pass_multiple_passes():
+    """query_last_pass returns the most recent passing run when a test passed in multiple runs."""
+
+    db_dir = get_temp_dir("test_query_last_pass_multiple_passes")
+    now = time.time()
+    guid_a = "aaa-run-a"
+    guid_b = "bbb-run-b"
+
+    with PytestProcessInfoDB(db_dir) as db:
+        # Run A: test_x passes with duration 5s
+        db.write(PytestProcessInfo(run_guid=guid_a, name="test_x", pid=100, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now))
+        db.write(PytestProcessInfo(run_guid=guid_a, name="test_x", pid=100, exit_code=PyTestFlyExitCode.OK, output="passed", time_stamp=now + 5))
+
+        # Run B: test_x passes with duration 3s
+        db.write(PytestProcessInfo(run_guid=guid_b, name="test_x", pid=200, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now + 100))
+        db.write(PytestProcessInfo(run_guid=guid_b, name="test_x", pid=200, exit_code=PyTestFlyExitCode.OK, output="passed", time_stamp=now + 103))
+
+        result = db.query_last_pass()
+        assert "test_x" in result
+        start_ts, duration = result["test_x"]
+        assert start_ts == now + 100  # from run B (most recent)
+        assert abs(duration - 3.0) < 0.01


### PR DESCRIPTION
## Summary
- Add "Last Pass Start" and "Last Pass Duration" columns to the test table showing data from each test's most recent successful run
- New `query_last_pass()` DB method queries across all historical runs to find the latest passing result per test
- ETA estimation now uses last-pass durations instead of most-recent-run durations, unifying the data source

## Test plan
- [x] `pytest tests/test_pytest_process_info_db.py` — 3 new DB tests (pass-then-fail, never-passed, multiple-passes)
- [x] `pytest tests/test_gui_display.py` — new table column rendering test
- [x] `ruff check` and `ruff format` pass
- [ ] Manual: launch app, run tests, verify columns populate after a pass; re-run with a failure and confirm last-pass data persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)