### PR TITLE
Add average parallelism metric to Status window — v0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.2.9"
+version = "0.3.0"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -25,7 +25,7 @@ from ..pytest_runner.pytest_runner import PytestRunState
 from ..tick_data import TickData
 from .coverage_tab import CoverageTab
 from .graph_tab import GraphTab
-from .gui_util import compute_time_window, get_font, get_text_dimensions, group_process_infos_by_name
+from .gui_util import compute_average_parallelism, compute_time_window, get_font, get_text_dimensions, group_process_infos_by_name
 from .run_tab import RunTab
 from .table_tab import TableTab
 
@@ -59,6 +59,7 @@ def build_tick_data(process_infos: list, prior_durations: dict[str, float] | Non
         max_time_stamp_started=max_ts_s,
         prior_durations=prior_durations if prior_durations is not None else {},
         num_processes=num_processes,
+        average_parallelism=compute_average_parallelism(infos_by_name),
     )
 
 

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -1,3 +1,4 @@
+import time
 from collections import defaultdict
 from datetime import timedelta
 from functools import cache, lru_cache
@@ -145,6 +146,42 @@ def extract_test_duration(infos: list) -> tuple[float | None, float | None]:
         if info.exit_code != PyTestFlyExitCode.NONE:
             end = info.time_stamp
     return start, end
+
+
+def compute_average_parallelism(infos_by_name: dict[str, list[PytestProcessInfo]]) -> float | None:
+    """
+    Compute the average number of simultaneously running test processes.
+
+    Average parallelism = total_test_time / wall_clock_time.
+
+    For in-progress tests (started but not finished), the current time is used
+    as the end time so the metric updates live during a run.
+
+    :param infos_by_name: Process info records grouped by test name.
+    :return: Average parallelism, or ``None`` if insufficient data.
+    """
+    total_test_time = 0.0
+    all_starts: list[float] = []
+    all_ends: list[float] = []
+    now = time.time()
+
+    for infos in infos_by_name.values():
+        start, end = extract_test_duration(infos)
+        if start is not None:
+            if end is None:
+                end = now  # test still running
+            total_test_time += end - start
+            all_starts.append(start)
+            all_ends.append(end)
+
+    if not all_starts:
+        return None
+
+    wall_clock = max(all_ends) - min(all_starts)
+    if wall_clock <= 0:
+        return None
+
+    return total_test_time / wall_clock
 
 
 @typechecked

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -56,6 +56,9 @@ class StatusWindow(QGroupBox):
                 overall_time = max_time_stamp - min_time_stamp
                 lines.append(f"Total time: {format_runtime(overall_time)}")
 
+            if tick.average_parallelism is not None:
+                lines.append(f"Avg parallelism: {tick.average_parallelism:.1f}x")
+
             # add current code coverage
             if tick.coverage_history:
                 latest_coverage = tick.coverage_history[-1][1]

--- a/src/pytest_fly/tick_data.py
+++ b/src/pytest_fly/tick_data.py
@@ -31,4 +31,5 @@ class TickData:
     per_test_coverage: dict[str, float] = field(default_factory=dict)  # test_name -> coverage_pct 0.0-1.0
     covered_lines: int = 0  # lines executed by all completed tests combined
     total_lines: int = 0  # total executable lines in the source
+    average_parallelism: float | None = None  # average number of simultaneously running test processes
     last_pass_data: dict[str, tuple[float, float]] = field(default_factory=dict)  # test_name -> (start_timestamp, duration_seconds) from most recent passing run

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -14,6 +14,7 @@ from pytest_fly.gui.graph_tab.graph_tab import GraphTab
 from pytest_fly.gui.graph_tab.progress_bar import PytestProgressBar
 from pytest_fly.gui.graph_tab.time_axis import TimeAxisWidget
 from pytest_fly.gui.gui_main import build_tick_data
+from pytest_fly.gui.gui_util import compute_average_parallelism
 from pytest_fly.gui.run_tab.control_pushbutton import ControlButton
 from pytest_fly.gui.run_tab.control_window import ControlWindow
 from pytest_fly.gui.run_tab.parallelism_control_box import ParallelismControlBox
@@ -542,6 +543,33 @@ def test_status_window_with_coverage(app):
     assert "Coverage: 52.0%" in text
     assert "260/500 lines" in text
     assert "30.0%" not in text
+
+
+def test_average_parallelism_calculation(app):
+    """compute_average_parallelism should return correct value for overlapping tests."""
+    tick = _make_tick_data_with_tests()
+    # test_a: started at now-9, ended at now-5 → 4s
+    # test_b: started at now-8, ended at now-3 → 5s
+    # test_c: queued only → 0s
+    # wall clock: (now-9) to (now-3) = 6s
+    # avg parallelism = (4+5)/6 = 1.5
+    assert tick.average_parallelism is not None
+    assert abs(tick.average_parallelism - 1.5) < 0.01
+
+
+def test_average_parallelism_empty():
+    """compute_average_parallelism should return None for empty data."""
+    assert compute_average_parallelism({}) is None
+
+
+def test_status_window_shows_parallelism(app):
+    """StatusWindow should display average parallelism when available."""
+    window = StatusWindow(None)
+    tick = _make_tick_data_with_tests()
+    window.update_tick(tick)
+    text = window.status_widget.toPlainText()
+    assert "Avg parallelism:" in text
+    assert "1.5x" in text
 
 
 def test_coverage_consistent_across_all_views(app):


### PR DESCRIPTION
## Summary
- Add "Avg parallelism" field to the Status pane showing the average number of simultaneously running test processes during a run
- Computed as total test time / wall-clock time, with live updates for in-progress runs
- Bump version to 0.3.0

## Test plan
- [x] New unit tests for `compute_average_parallelism` (empty data, overlapping tests)
- [x] New test verifying Status window displays the metric
- [x] All existing tests continue to pass
- [ ] Manual: run app with `python -m pytest_fly`, start a parallel test run, confirm "Avg parallelism" appears in Status pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)