### PR TITLE
Fix About tab crash on pre-formatted cache sizes — v0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.0"
+version = "0.3.1"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/about_tab/about.py
+++ b/src/pytest_fly/gui/about_tab/about.py
@@ -25,7 +25,7 @@ class AboutDataWorker(QObject):
         for key, value in get_platform_info().items():
             key_string = " ".join([s.capitalize() for s in key.split("_")]).replace("Cpu", "CPU")
             if any([descriptor in key.lower() for descriptor in ["cache", "memory"]]):
-                text_lines.append(f"{key_string}: {humanize.naturalsize(value)}")
+                text_lines.append(f"{key_string}: {humanize.naturalsize(value) if isinstance(value, (int, float)) else value}")
             elif "freq" in key:
                 text_lines.append(f"{key_string}: {value / 1000.0} GHz")
             else:


### PR DESCRIPTION
## Summary
- Fix `ValueError` in About tab when `cpuinfo` returns cache/memory values as pre-formatted strings (e.g. `'2.5 MiB'`) instead of numeric bytes
- Only pass numeric values through `humanize.naturalsize()`; display strings as-is
- Bump version to 0.3.1

## Test plan
- [x] CI `test_about` should now pass on Linux runners where `cpuinfo` returns string cache sizes
- [ ] Manual: verify About tab still displays correctly on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)