### PR TITLE
Show remaining tests and ETA after Stop — v0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.1"
+version = "0.3.2"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -232,6 +232,7 @@ class FlyAppMainWindow(QMainWindow):
         control = self.run_tab.control_window
         tick = build_tick_data(process_infos, prior_durations=control.prior_durations, num_processes=control.num_processes)
         tick.last_pass_data = last_pass_data
+        tick.soft_stop_requested = control._soft_stop_requested
 
         self._handle_new_run(control.run_guid)
         self._update_coverage(tick)

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -73,10 +73,47 @@ class StatusWindow(QGroupBox):
                 if remaining_seconds > 0 and tick.num_processes > 0:
                     wall_clock = remaining_seconds / tick.num_processes
                     lines.append(f"Estimated remaining: {format_runtime(wall_clock)}")
+
+            if tick.soft_stop_requested:
+                running_count = counts[PytestRunnerState.RUNNING]
+                if running_count > 0:
+                    lines.append("")
+                    lines.append(f"Stopping — {running_count} test{'s' if running_count != 1 else ''} still running")
+                    stopping_eta = self._calculate_stopping_eta(tick)
+                    if stopping_eta is not None:
+                        lines.append(f"Estimated finish: {format_runtime(stopping_eta)}")
+                    else:
+                        lines.append("Estimated finish: unknown")
         else:
             lines = ["Calculating..."]
 
         self.status_widget.set_text("\n".join(lines))
+
+    def _calculate_stopping_eta(self, tick: TickData) -> float | None:
+        """Estimate wall-clock seconds until all running tests finish after a soft stop.
+
+        Since running tests execute in parallel, the wall time is the maximum
+        individual remaining time (not the sum).
+
+        :param tick: Pre-computed data for this refresh cycle.
+        :return: Estimated seconds until the last running test finishes, or ``None`` if no prior data is available.
+        """
+        now = time.time()
+        max_remaining = 0.0
+        any_estimated = False
+        for test_name, run_state in tick.run_states.items():
+            if run_state.get_state() != PytestRunnerState.RUNNING:
+                continue
+            prior = tick.prior_durations.get(test_name)
+            if prior is None or prior <= 0.0:
+                continue
+            any_estimated = True
+            infos = tick.infos_by_name.get(test_name, [])
+            started_at = next((i.time_stamp for i in infos if i.pid is not None), None)
+            if started_at is not None:
+                remaining = max(0.0, prior - (now - started_at))
+                max_remaining = max(max_remaining, remaining)
+        return max_remaining if any_estimated else None
 
     def _calculate_remaining_seconds(self, tick: TickData) -> float:
         """Estimate the total remaining CPU-seconds for queued and running tests.

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -98,9 +98,17 @@ class TableTab(QGroupBox):
         if test_node_id is not None and is_running:
             force_stop_action = menu.addAction("Force Stop")
 
+        # Save row/col before exec_() — the nested event loop lets timer
+        # refreshes destroy the underlying C++ QTableWidgetItem.
+        item_row = item.row() if item is not None else -1
+        item_col = item.column() if item is not None else -1
+
         action = menu.exec_(self.table_widget.viewport().mapToGlobal(position))
 
         if action == copy_tooltip_action:
+            # Re-fetch the item after exec_() to avoid stale C++ pointer
+            if item_row >= 0 and item_col >= 0:
+                item = self.table_widget.item(item_row, item_col)
             if item is not None:
                 tooltip = item.toolTip()
                 # fallback to ItemDataRole if toolTip() is empty

--- a/src/pytest_fly/tick_data.py
+++ b/src/pytest_fly/tick_data.py
@@ -33,3 +33,4 @@ class TickData:
     total_lines: int = 0  # total executable lines in the source
     average_parallelism: float | None = None  # average number of simultaneously running test processes
     last_pass_data: dict[str, tuple[float, float]] = field(default_factory=dict)  # test_name -> (start_timestamp, duration_seconds) from most recent passing run
+    soft_stop_requested: bool = False


### PR DESCRIPTION
## Summary
- When the user presses Stop (soft stop), the Status pane now shows how many tests are still running and an estimated wall-clock finish time based on prior run durations
- The stopping ETA uses the maximum individual remaining time (since running tests execute in parallel after stop, the slowest test determines finish time)
- Fixes a table_tab context menu crash where the nested event loop in `exec_()` could invalidate C++ `QTableWidgetItem` pointers

## Test plan
- [ ] Run `python -m pytest_fly`, start a parallel test run, press Stop, verify "Stopping — N test(s) still running" and "Estimated finish" appear in Status pane
- [ ] Verify the count decreases as tests finish and the message disappears when all tests complete
- [ ] Verify "Estimated finish: unknown" appears when no prior run data exists
- [ ] Right-click a table cell, verify context menu works without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)