### PR TITLE
Switch to uv for venv and dependency management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,23 @@ Home = "https://github.com/jamesabel/pytest-fly"
 Repository = "https://github.com/jamesabel/pytest-fly"
 Documentation = "https://github.com/jamesabel/pytest-fly#readme"
 
+[dependency-groups]
+dev = [
+    "ruff",
+    "ty",
+    "pre-commit",
+    "pytest-qt",
+    "pytest-pycharm",
+    "pytest-cov",
+    "pytest-xdist",
+    "pytest-benchmark",
+    "pytest-rerunfailures",
+    "pytest-randomly",
+    "flit",
+    "hatch",
+    "pip-tools",
+]
+
 [tool.ruff]
 line-length = 192
 

--- a/scripts/make_venv_dev.bat
+++ b/scripts/make_venv_dev.bat
@@ -1,8 +1,5 @@
 pushd .
 cd ..
 rmdir /S /Q .venv
-c:"\Program Files\Python314\python.exe" -m venv --clear .venv
-.venv\Scripts\python.exe -m pip install --upgrade pip
-.venv\Scripts\pip3 install -U setuptools
-.venv\Scripts\pip3 install -U -r requirements-dev.txt
+uv sync
 popd


### PR DESCRIPTION
## Summary
- Add `[dependency-groups] dev` section to `pyproject.toml` with all dev-only packages (linters, test plugins, build tools)
- Simplify `scripts/make_venv_dev.bat` to use `uv sync` instead of manual venv creation and pip installs
- Fixes `pytest-qt` (and `qtbot` fixture) not being available when tests were run outside the venv

## Test plan
- [ ] Run `scripts\make_venv_dev.bat` — verify it creates `.venv` via `uv sync`
- [ ] Run `uv run pytest tests/` — verify all 103 tests pass (including qtbot tests)
- [ ] Run `uv run python -m pytest_fly` — verify the app launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)