### PR TITLE
Fix robustness issues — v0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.2"
+version = "0.3.3"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -110,7 +110,11 @@ class TableTab(QGroupBox):
             if item_row >= 0 and item_col >= 0:
                 item = self.table_widget.item(item_row, item_col)
             if item is not None:
-                tooltip = item.toolTip()
+                try:
+                    tooltip = item.toolTip()
+                except RuntimeError:
+                    return  # item's C++ object was deleted between retrieval and access
+
                 # fallback to ItemDataRole if toolTip() is empty
                 if not tooltip:
                     tooltip = item.data(Qt.ItemDataRole.ToolTipRole) or ""

--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -2,6 +2,7 @@ import contextlib
 import io
 import shutil
 import time
+import traceback
 from multiprocessing import Process
 from pathlib import Path
 from queue import Empty
@@ -67,7 +68,11 @@ class PytestProcess(Process):
             coverage = Coverage(coverage_temp_file_path)
             coverage.start()
 
-            exit_code = pytest.main([self.name])
+            try:
+                exit_code = pytest.main([self.name])
+            except Exception:
+                exit_code = PyTestFlyExitCode.INTERNAL_ERROR
+                buf.write(f"\n\npytest.main raised an exception:\n{traceback.format_exc()}")
 
             coverage.stop()
             coverage.save()


### PR DESCRIPTION
## Summary
- Guard against unhandled exceptions from `pytest.main()` during plugin teardown that left tests appearing stuck with no recorded exit code or output
- Guard against tooltip widget being deleted mid-update in the test table

## Test plan
- [ ] Run a test suite and verify tests complete and record results correctly
- [ ] Verify tooltip behavior in the test table doesn't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)