### PR TITLE
Show all tests in RESUME mode — v0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.3"
+version = "0.3.4"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/graph_tab/progress_bar.py
+++ b/src/pytest_fly/gui/graph_tab/progress_bar.py
@@ -124,7 +124,7 @@ class PytestProgressBar(QWidget):
 
             bar_color = pytest_run_state.get_qt_bar_color()
 
-            if pytest_run_state.get_state() not in (PytestRunnerState.QUEUED, PytestRunnerState.STOPPED):
+            if pytest_run_state.get_state() not in (PytestRunnerState.QUEUED, PytestRunnerState.STOPPED) and start_running_time is not None:
                 seconds_from_start = start_running_time - self.min_time_stamp
                 x1 = (seconds_from_start * horizontal_pixels_per_second) + self.bar_margin
                 y1 = outer_rect.y() + self.bar_margin

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 
 from PySide6.QtCore import Qt
@@ -6,7 +7,7 @@ from typeguard import typechecked
 
 from ...db import PytestProcessInfoDB
 from ...guid import generate_uuid
-from ...interfaces import PyTestFlyExitCode, RunMode, ScheduledTest, TestOrder
+from ...interfaces import PyTestFlyExitCode, PytestProcessInfo, RunMode, ScheduledTest, TestOrder
 from ...logger import get_logger
 from ...preferences import ParallelismControl, get_pref
 from ...pytest_runner.coverage import compute_per_test_coverage
@@ -116,7 +117,19 @@ class ControlWindow(QGroupBox):
             prior_results = db.query()  # most recent run
             last_pass_data = db.query_last_pass()  # most recent passing run per test
 
+        all_node_ids = {t.node_id for t in tests}
         tests = self._filter_for_resume(tests, prior_results, pref)
+
+        # In RESUME mode, write DB records for previously-passed tests so they
+        # appear in all GUI tabs (table, graph, status) alongside the re-run tests.
+        if pref.run_mode == RunMode.RESUME:
+            skipped_node_ids = all_node_ids - {t.node_id for t in tests}
+            if skipped_node_ids:
+                now = time.time()
+                with PytestProcessInfoDB(self.data_dir) as db:
+                    for node_id in sorted(skipped_node_ids):
+                        info = PytestProcessInfo(run_guid=self.run_guid, name=node_id, pid=None, exit_code=PyTestFlyExitCode.OK, output=None, time_stamp=now)
+                        db.write(info)
 
         # Reorder so previously-failed tests run first (within their singleton group)
         tests = self._reorder_failed_first(tests, prior_results)


### PR DESCRIPTION
## Summary
- In RESUME mode, display all discovered tests in every GUI tab (Table, Graph, Status), not just the tests being re-run
- Previously-passed tests appear with Pass status alongside re-running tests
- Fix progress bar crash when a PASS test has only one DB record (no bar to draw)

## Test plan
- [ ] Run a full test suite in RESTART mode, verify all tests appear
- [ ] Switch to RESUME mode and run again — verify all tests (including previously-passed) appear in Table, Graph, and Status tabs
- [ ] Verify previously-passed tests show as "Pass" with no runtime/CPU/memory metrics
- [ ] Verify re-running (failed/new) tests execute and update normally
- [ ] Confirm Status tab shows correct total test count and pass rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)