### PR TITLE
Fix blank test data in RESUME mode — v0.3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.4"
+version = "0.3.5"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -1,4 +1,4 @@
-import time
+from dataclasses import replace
 from pathlib import Path
 
 from PySide6.QtCore import Qt
@@ -7,7 +7,7 @@ from typeguard import typechecked
 
 from ...db import PytestProcessInfoDB
 from ...guid import generate_uuid
-from ...interfaces import PyTestFlyExitCode, PytestProcessInfo, RunMode, ScheduledTest, TestOrder
+from ...interfaces import PyTestFlyExitCode, RunMode, ScheduledTest, TestOrder
 from ...logger import get_logger
 from ...preferences import ParallelismControl, get_pref
 from ...pytest_runner.coverage import compute_per_test_coverage
@@ -120,16 +120,19 @@ class ControlWindow(QGroupBox):
         all_node_ids = {t.node_id for t in tests}
         tests = self._filter_for_resume(tests, prior_results, pref)
 
-        # In RESUME mode, write DB records for previously-passed tests so they
-        # appear in all GUI tabs (table, graph, status) alongside the re-run tests.
+        # In RESUME mode, copy the complete prior-run records for previously-passed
+        # tests into the current run so they appear in all GUI tabs (table, graph,
+        # status) with their original data (runtime, CPU, memory, output, etc.).
         if pref.run_mode == RunMode.RESUME:
             skipped_node_ids = all_node_ids - {t.node_id for t in tests}
             if skipped_node_ids:
-                now = time.time()
+                prior_by_name = {}
+                for r in prior_results:
+                    prior_by_name.setdefault(r.name, []).append(r)
                 with PytestProcessInfoDB(self.data_dir) as db:
                     for node_id in sorted(skipped_node_ids):
-                        info = PytestProcessInfo(run_guid=self.run_guid, name=node_id, pid=None, exit_code=PyTestFlyExitCode.OK, output=None, time_stamp=now)
-                        db.write(info)
+                        for record in prior_by_name.get(node_id, []):
+                            db.write(replace(record, run_guid=self.run_guid))
 
         # Reorder so previously-failed tests run first (within their singleton group)
         tests = self._reorder_failed_first(tests, prior_results)


### PR DESCRIPTION
## Summary
- Fix previously-passed tests showing blank Last Pass Start, Last Pass Duration, runtime, CPU, memory, and output in RESUME mode
- Root cause: the single synthetic DB record (pid=None, exit_code=OK) became the "latest pass" but had no pid, breaking the `query_last_pass()` JOIN and leaving all data columns empty
- Now copies the **complete set of prior-run DB records** for each skipped test, re-stamped with the current run_guid, preserving all original data

## Test plan
- [ ] Run full suite in RESTART mode, then switch to RESUME and re-run
- [ ] Verify previously-passed tests show Last Pass Start, Last Pass Duration, runtime, CPU, memory in the Table tab
- [ ] Verify Graph tab shows progress bars for previously-passed tests
- [ ] Verify Status tab shows correct total count and pass rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)