### PR TITLE
Fix RESUME graph whitespace from prior-run timestamps — v0.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.5"
+version = "0.3.6"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/graph_tab/graph_tab.py
+++ b/src/pytest_fly/gui/graph_tab/graph_tab.py
@@ -35,7 +35,11 @@ class GraphTab(QGroupBox):
     def update_tick(self, tick: TickData) -> None:
         """Refresh the time axis and all progress bars from pre-computed tick data."""
 
-        self.time_axis.update_time_window(tick.min_time_stamp, tick.max_time_stamp)
+        # Use current_run_start as the effective graph origin so that copied
+        # prior-run records (from RESUME mode) don't stretch the time axis.
+        effective_min = tick.current_run_start if tick.current_run_start is not None else tick.min_time_stamp
+
+        self.time_axis.update_time_window(effective_min, tick.max_time_stamp)
 
         # Remove bars for tests no longer in the current tick
         removed_names = set(self.progress_bars) - set(tick.infos_by_name)
@@ -49,9 +53,9 @@ class GraphTab(QGroupBox):
             run_state = tick.run_states[test_name]
             if test_name in self.progress_bars:
                 progress_bar = self.progress_bars[test_name]
-                progress_bar.update_pytest_process_info(infos, tick.min_time_stamp, tick.max_time_stamp, run_state)
+                progress_bar.update_pytest_process_info(infos, effective_min, tick.max_time_stamp, run_state)
             else:
-                progress_bar = PytestProgressBar(infos, tick.min_time_stamp, tick.max_time_stamp, run_state)
+                progress_bar = PytestProgressBar(infos, effective_min, tick.max_time_stamp, run_state)
                 self.progress_bars[test_name] = progress_bar
 
         # Ensure layout order matches tick.infos_by_name order (same as table tab)

--- a/src/pytest_fly/gui/graph_tab/progress_bar.py
+++ b/src/pytest_fly/gui/graph_tab/progress_bar.py
@@ -124,7 +124,7 @@ class PytestProgressBar(QWidget):
 
             bar_color = pytest_run_state.get_qt_bar_color()
 
-            if pytest_run_state.get_state() not in (PytestRunnerState.QUEUED, PytestRunnerState.STOPPED) and start_running_time is not None:
+            if pytest_run_state.get_state() not in (PytestRunnerState.QUEUED, PytestRunnerState.STOPPED) and start_running_time is not None and end_time >= self.min_time_stamp:
                 seconds_from_start = start_running_time - self.min_time_stamp
                 x1 = (seconds_from_start * horizontal_pixels_per_second) + self.bar_margin
                 y1 = outer_rect.y() + self.bar_margin

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -17,7 +17,7 @@ from ..db import PytestProcessInfoDB
 from ..file_util import sanitize_test_name
 from ..gui.about_tab.about import About
 from ..gui.configuration_tab.configuration import Configuration
-from ..interfaces import PytestRunnerState, RunMode
+from ..interfaces import PyTestFlyExitCode, PytestRunnerState, RunMode
 from ..logger import get_logger
 from ..preferences import get_pref
 from ..pytest_runner.coverage import calculate_coverage
@@ -49,6 +49,12 @@ def build_tick_data(process_infos: list, prior_durations: dict[str, float] | Non
     min_ts, max_ts = compute_time_window(process_infos)
     min_ts_s, max_ts_s = compute_time_window(process_infos, require_pid=True)
 
+    # Earliest QUEUED record timestamp — identifies when the current session
+    # started.  Copied prior-run records (from RESUME mode) never have
+    # exit_code == NONE, so this cleanly excludes them.
+    queued_timestamps = [info.time_stamp for info in process_infos if info.exit_code == PyTestFlyExitCode.NONE]
+    current_run_start = min(queued_timestamps) if queued_timestamps else None
+
     return TickData(
         process_infos=process_infos,
         infos_by_name=infos_by_name,
@@ -60,6 +66,7 @@ def build_tick_data(process_infos: list, prior_durations: dict[str, float] | Non
         prior_durations=prior_durations if prior_durations is not None else {},
         num_processes=num_processes,
         average_parallelism=compute_average_parallelism(infos_by_name),
+        current_run_start=current_run_start,
     )
 
 

--- a/src/pytest_fly/tick_data.py
+++ b/src/pytest_fly/tick_data.py
@@ -32,5 +32,6 @@ class TickData:
     covered_lines: int = 0  # lines executed by all completed tests combined
     total_lines: int = 0  # total executable lines in the source
     average_parallelism: float | None = None  # average number of simultaneously running test processes
+    current_run_start: float | None = None  # earliest QUEUED record timestamp (excludes copied prior-run records in RESUME mode)
     last_pass_data: dict[str, tuple[float, float]] = field(default_factory=dict)  # test_name -> (start_timestamp, duration_seconds) from most recent passing run
     soft_stop_requested: bool = False


### PR DESCRIPTION
## Summary
- In RESUME mode, copied prior-run records have old timestamps that stretched the Progress graph time axis far to the left, creating a large whitespace gap before the current run's bars
- Compute `current_run_start` from the earliest QUEUED record (`exit_code == NONE`), which is always fresh — copied prior records never have that exit code
- Graph tab uses `current_run_start` as the effective time axis origin
- Progress bar skips drawing colored bars for tests that completed before the current run started; prior-passed tests still appear as labeled rows showing their Pass state

## Test plan
- [ ] Run full suite in RESTART mode, verify graph looks normal
- [ ] Switch to RESUME mode, re-run — verify graph time axis starts at the current run, not the prior run
- [ ] Verify prior-passed tests show as labeled "Pass" rows without colored bars in the graph
- [ ] Verify currently-running/re-run tests display bars normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)