### PR TITLE
Add failed tests pane to Run tab — v0.3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.12"
+version = "0.3.13"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/graph_tab/progress_bar.py
+++ b/src/pytest_fly/gui/graph_tab/progress_bar.py
@@ -52,7 +52,7 @@ class PytestProgressBar(QWidget):
         self.bar_margin = 1
         self.bar_height = name_text_dimensions.height() + 2 * self.bar_margin
         self.setFixedHeight(self.bar_height)
-        log.info(f"{self.bar_height=},{name_text_dimensions=}")
+        log.debug(f"{self.bar_height=},{name_text_dimensions=}")
 
         # --- Tooltip-related state ---
         self.setMouseTracking(True)  # receive mouseMoveEvent even with no button pressed

--- a/src/pytest_fly/gui/run_tab/failed_tests_window.py
+++ b/src/pytest_fly/gui/run_tab/failed_tests_window.py
@@ -1,0 +1,52 @@
+"""Failed tests pane — lists test names that have failed in the current run, with clipboard copy support."""
+
+from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QPushButton, QSizePolicy, QVBoxLayout
+
+from ...gui.gui_util import PlainTextWidget
+from ...interfaces import PytestRunnerState
+from ...tick_data import TickData
+
+
+class FailedTestsWindow(QGroupBox):
+    """Displays a list of failed test names with a button to copy them to the clipboard."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setTitle("Failed Tests")
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+
+        self._failed_names: list[str] = []
+
+        self._text_widget = PlainTextWidget(self, "(none)")
+        layout.addWidget(self._text_widget)
+
+        button_layout = QHBoxLayout()
+        self._copy_button = QPushButton("Copy to Clipboard")
+        self._copy_button.setEnabled(False)
+        self._copy_button.clicked.connect(self._copy_to_clipboard)
+        button_layout.addWidget(self._copy_button)
+        button_layout.addStretch()
+        layout.addLayout(button_layout)
+
+    def update_tick(self, tick: TickData):
+        """Rebuild the failed test list from pre-computed tick data."""
+        failed_names = sorted(test_name for test_name, run_state in tick.run_states.items() if run_state.get_state() == PytestRunnerState.FAIL)
+
+        if failed_names != self._failed_names:
+            self._failed_names = failed_names
+            if failed_names:
+                self._text_widget.set_text("\n".join(failed_names))
+                self._copy_button.setEnabled(True)
+            else:
+                self._text_widget.set_text("(none)")
+                self._copy_button.setEnabled(False)
+
+    def _copy_to_clipboard(self):
+        """Copy the failed test names to the system clipboard."""
+        from PySide6.QtWidgets import QApplication
+
+        if self._failed_names:
+            clipboard = QApplication.clipboard()
+            clipboard.setText("\n".join(self._failed_names))

--- a/src/pytest_fly/gui/run_tab/run_tab.py
+++ b/src/pytest_fly/gui/run_tab/run_tab.py
@@ -3,12 +3,13 @@
 from pathlib import Path
 
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QHBoxLayout, QWidget
+from PySide6.QtWidgets import QHBoxLayout, QVBoxLayout, QWidget
 from typeguard import typechecked
 
 from ...logger import get_logger
 from ...tick_data import TickData
 from .control_window import ControlWindow
+from .failed_tests_window import FailedTestsWindow
 from .status_window import StatusWindow
 
 log = get_logger()
@@ -21,18 +22,27 @@ class RunTab(QWidget):
     def __init__(self, parent, data_dir: Path):
         super().__init__(parent)
 
-        layout = QHBoxLayout()
-        layout.setAlignment(Qt.AlignmentFlag.AlignTop)
-        self.setLayout(layout)
+        outer_layout = QVBoxLayout()
+        outer_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+        self.setLayout(outer_layout)
+
+        top_layout = QHBoxLayout()
+        top_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
         self.control_window = ControlWindow(self, data_dir)
         self.status_window = StatusWindow(self)
+        self.failed_tests_window = FailedTestsWindow(self)
 
-        layout.addWidget(self.control_window, alignment=Qt.AlignmentFlag.AlignTop)
-        layout.addWidget(self.status_window, alignment=Qt.AlignmentFlag.AlignTop)
-        layout.addStretch()
+        top_layout.addWidget(self.control_window, alignment=Qt.AlignmentFlag.AlignTop)
+        top_layout.addWidget(self.status_window, alignment=Qt.AlignmentFlag.AlignTop)
+        top_layout.addStretch()
+
+        outer_layout.addLayout(top_layout)
+        outer_layout.addWidget(self.failed_tests_window, alignment=Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
+        outer_layout.addStretch()
 
     def update_tick(self, tick: TickData):
-        """Forward pre-computed tick data to the status window and control panel."""
+        """Forward pre-computed tick data to the status window, failed tests pane, and control panel."""
         self.status_window.update_tick(tick)
+        self.failed_tests_window.update_tick(tick)
         self.control_window.update()


### PR DESCRIPTION
## Summary
- Add a "Failed Tests" pane below the control/status widgets in the Run tab that lists failed test names
- Includes a "Copy to Clipboard" button for easy copying of failed test names
- The text widget is also selectable for manual partial copy
- Bump version to 0.3.13

## Test plan
- [ ] Run the app and execute a test suite with known failures
- [ ] Verify failed test names appear in the pane as tests complete
- [ ] Verify the "Copy to Clipboard" button copies all failed test names
- [ ] Verify the pane shows "(none)" when there are no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)