### PR TITLE
Fix test table ordering between RESTART and RESUME — v0.3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.13"
+version = "0.3.14"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -156,7 +156,7 @@ class TableTab(QGroupBox):
         self.table_widget.clearContents()
         self.table_widget.setRowCount(len(tick.infos_by_name))
 
-        for row_number, test_name in enumerate(tick.infos_by_name):
+        for row_number, test_name in enumerate(sorted(tick.infos_by_name)):
             process_infos = tick.infos_by_name[test_name]
             pytest_run_state = tick.run_states[test_name]
 


### PR DESCRIPTION
## Summary
- Sort table rows alphabetically by test name so ordering is consistent across run modes
- Previously, RESUME mode produced a different row order because copied prior-run records were inserted in a different order than RESTART's discovery order

## Test plan
- [ ] Run a test suite in RESTART mode, note the table order
- [ ] Run the same suite in RESUME mode, verify the table order matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)