### PR TITLE
Fix RESUME graph origin and hour-scale time axis — v0.3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.14"
+version = "0.3.15"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/graph_tab/time_axis.py
+++ b/src/pytest_fly/gui/graph_tab/time_axis.py
@@ -13,7 +13,8 @@ from ...colors import GRID_LINE_COLOR
 from ..gui_util import get_text_dimensions
 
 # Candidate intervals in seconds — chosen so labels stay readable.
-_INTERVALS = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600]
+# Extends up to 24h so multi-hour runs don't collapse to minute-granularity grid lines.
+_INTERVALS = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 21600, 43200, 86400]
 
 
 def _choose_interval(time_window: float) -> float:
@@ -25,14 +26,20 @@ def _choose_interval(time_window: float) -> float:
 
 
 def _format_tick_label(elapsed_seconds: float) -> str:
-    """Format an elapsed-time value into a compact label (e.g. ``'30s'``, ``'2m'``)."""
+    """Format an elapsed-time value into a compact label (e.g. ``'30s'``, ``'2m'``, ``'3h'``, ``'1h30m'``)."""
     if elapsed_seconds < 60:
         return f"{int(elapsed_seconds)}s"
-    minutes = int(elapsed_seconds // 60)
-    seconds = int(elapsed_seconds % 60)
-    if seconds == 0:
-        return f"{minutes}m"
-    return f"{minutes}m{seconds}s"
+    if elapsed_seconds < 3600:
+        minutes = int(elapsed_seconds // 60)
+        seconds = int(elapsed_seconds % 60)
+        if seconds == 0:
+            return f"{minutes}m"
+        return f"{minutes}m{seconds}s"
+    hours = int(elapsed_seconds // 3600)
+    minutes = int((elapsed_seconds % 3600) // 60)
+    if minutes == 0:
+        return f"{hours}h"
+    return f"{hours}h{minutes}m"
 
 
 def compute_grid_ticks(min_ts: float | None, max_ts: float | None, width_pixels: int) -> list[tuple[float, str]]:

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -21,7 +21,6 @@ from typeguard import typechecked
 
 from ..__version__ import application_name
 from ..db import PytestProcessInfoDB
-from ..interfaces import PyTestFlyExitCode
 from ..logger import get_logger
 from ..preferences import get_pref
 from ..pytest_runner.pytest_runner import PytestRunState
@@ -38,7 +37,7 @@ from .table_tab import TableTab
 log = get_logger()
 
 
-def build_tick_data(process_infos: list, prior_durations: dict[str, float] | None = None, num_processes: int = 1) -> TickData:
+def build_tick_data(process_infos: list, prior_durations: dict[str, float] | None = None, num_processes: int = 1, current_run_start: float | None = None) -> TickData:
     """
     Build a :class:`TickData` bundle from a flat list of process info records.
 
@@ -48,18 +47,16 @@ def build_tick_data(process_infos: list, prior_durations: dict[str, float] | Non
     :param process_infos: Flat list of :class:`PytestProcessInfo` objects from the DB.
     :param prior_durations: Optional mapping of test name to prior run duration (seconds), used for ETA.
     :param num_processes: Number of parallel worker processes (used for ETA wall-clock estimation).
+    :param current_run_start: Wall-clock timestamp captured when the Run button was pressed, used
+        as the graph time-axis origin.  Passed in explicitly because RESUME mode copies prior-run
+        records (including their original QUEUED records with ``exit_code == NONE``), so the origin
+        cannot be derived reliably from DB records alone.
     :return: A fully populated :class:`TickData` instance.
     """
     infos_by_name = group_process_infos_by_name(process_infos)
     run_states = {name: PytestRunState(infos) for name, infos in infos_by_name.items()}
     min_ts, max_ts = compute_time_window(process_infos)
     min_ts_s, max_ts_s = compute_time_window(process_infos, require_pid=True)
-
-    # Earliest QUEUED record timestamp — identifies when the current session
-    # started.  Copied prior-run records (from RESUME mode) never have
-    # exit_code == NONE, so this cleanly excludes them.
-    queued_timestamps = [info.time_stamp for info in process_infos if info.exit_code == PyTestFlyExitCode.NONE]
-    current_run_start = min(queued_timestamps) if queued_timestamps else None
 
     return TickData(
         process_infos=process_infos,
@@ -188,7 +185,12 @@ class FlyAppMainWindow(QMainWindow):
             last_pass_data = db.query_last_pass()
 
         control = self.run_tab.control_window
-        tick = build_tick_data(process_infos, prior_durations=control.prior_durations, num_processes=control.num_processes)
+        tick = build_tick_data(
+            process_infos,
+            prior_durations=control.prior_durations,
+            num_processes=control.num_processes,
+            current_run_start=control.current_run_start,
+        )
         tick.last_pass_data = last_pass_data
         tick.soft_stop_requested = control._soft_stop_requested
 

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -5,6 +5,7 @@ Houses the run-preparation logic: test discovery, RESUME filtering,
 failed-first reordering, and coverage-efficiency ordering.
 """
 
+import time
 from dataclasses import replace
 from pathlib import Path
 
@@ -71,6 +72,7 @@ class ControlWindow(QGroupBox):
         self.prior_durations: dict[str, float] = {}
         self.num_processes: int = 1
         self._soft_stop_requested: bool = False
+        self.current_run_start: float | None = None
 
         self.set_fixed_width()  # calculate and set the widget width
 
@@ -105,6 +107,11 @@ class ControlWindow(QGroupBox):
         pref = get_pref()
         refresh_rate = pref.refresh_rate
         self.run_guid = generate_uuid()
+        # Capture start time before any prior records are copied so the graph
+        # time axis can use it as the origin, rather than trying to infer it
+        # from DB records (copied RESUME records also have exit_code == NONE,
+        # which made the DB-derived origin fall back to a prior-run timestamp).
+        self.current_run_start = time.time()
 
         if self.pytest_runner is not None and self.pytest_runner.is_running():
             self.pytest_runner.stop()

--- a/src/pytest_fly/tick_data.py
+++ b/src/pytest_fly/tick_data.py
@@ -32,6 +32,6 @@ class TickData:
     covered_lines: int = 0  # lines executed by all completed tests combined
     total_lines: int = 0  # total executable lines in the source
     average_parallelism: float | None = None  # average number of simultaneously running test processes
-    current_run_start: float | None = None  # earliest QUEUED record timestamp (excludes copied prior-run records in RESUME mode)
+    current_run_start: float | None = None  # wall-clock timestamp captured when Run was pressed; used as the graph time-axis origin
     last_pass_data: dict[str, tuple[float, float]] = field(default_factory=dict)  # test_name -> (start_timestamp, duration_seconds) from most recent passing run
     soft_stop_requested: bool = False


### PR DESCRIPTION
## Summary
- Fix RESUME-mode progress graph still plotting against a prior-run origin. Copied prior-run records include the original QUEUED/RUNNING entries (`exit_code == NONE`), so the DB-derived `current_run_start` was falling back to an old timestamp. Now captured explicitly on `ControlWindow.run()` when the Run button is pressed.
- Extend the time-axis grid intervals up to 24h (15m, 30m, 1h, 2h, 3h, 6h, 12h, 24h) and add hour / hour+minute label formatting (`3h`, `1h30m`) so multi-hour runs no longer collapse to a minute-granularity axis.
- Bump version to 0.3.15.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `pytest tests/test_gui_display.py` — 42 / 42 pass
- [ ] Manual: run a suite in RESTART, then RESUME — verify graph axis starts at the new run
- [ ] Manual: run a multi-hour suite — verify grid lines use hour-scale labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)