### PR TITLE
Fix coverage graph origin + extract shared time-axis helpers — v0.3.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.15"
+version = "0.3.16"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/coverage_tab/coverage_tab.py
+++ b/src/pytest_fly/gui/coverage_tab/coverage_tab.py
@@ -3,14 +3,14 @@ Coverage tab — displays a step-function line chart of combined code coverage o
 """
 
 from PySide6.QtCore import QPointF, Qt
-from PySide6.QtGui import QBrush, QPainter, QPalette, QPen, QPolygonF
+from PySide6.QtGui import QBrush, QPainter, QPen, QPolygonF
 from PySide6.QtWidgets import QGroupBox, QSizePolicy, QVBoxLayout, QWidget
 
 from ...colors import COVERAGE_FILL_COLOR, COVERAGE_LINE_COLOR, GRID_LINE_COLOR
 from ...interfaces import PytestRunnerState
 from ...tick_data import TickData
-from ..graph_tab.time_axis import compute_grid_ticks
-from ..gui_util import count_test_states, get_text_dimensions
+from ..graph_tab.time_axis import TimeAxisMapping, compute_grid_ticks
+from ..gui_util import count_test_states, get_text_dimensions, window_text_color
 
 # Horizontal grid lines at these percentages
 _Y_GRID_PCTS = [0.25, 0.50, 0.75, 1.00]
@@ -55,8 +55,7 @@ class _CoverageChart(QWidget):
             painter.end()
             return
 
-        palette = self.palette()
-        text_color = palette.color(QPalette.WindowText)
+        text_color = window_text_color(self)
 
         # Draw Y-axis labels and horizontal grid lines
         painter.setPen(QPen(GRID_LINE_COLOR, 1))
@@ -93,11 +92,10 @@ class _CoverageChart(QWidget):
             painter.end()
             return
 
-        time_window = max(self._max_ts - self._min_ts, 1.0)
-        px_per_sec = chart_w / time_window
+        mapping = TimeAxisMapping(min_ts=self._min_ts, max_ts=self._max_ts, width_pixels=chart_w)
 
         def to_pixel(ts: float, pct: float) -> tuple[int, int]:
-            x = margin_left + int((ts - self._min_ts) * px_per_sec)
+            x = margin_left + int(mapping.ts_to_x(ts))
             y = margin_top + int(chart_h * (1.0 - pct))
             return x, y
 
@@ -167,4 +165,4 @@ class CoverageTab(QGroupBox):
         else:
             status_text = ""
 
-        self.chart.update_data(tick.coverage_history, tick.min_time_stamp, tick.max_time_stamp, status_text, tick.covered_lines, tick.total_lines)
+        self.chart.update_data(tick.coverage_history, tick.effective_min_time_stamp, tick.max_time_stamp, status_text, tick.covered_lines, tick.total_lines)

--- a/src/pytest_fly/gui/graph_tab/graph_tab.py
+++ b/src/pytest_fly/gui/graph_tab/graph_tab.py
@@ -37,9 +37,7 @@ class GraphTab(QGroupBox):
     def update_tick(self, tick: TickData) -> None:
         """Refresh the time axis and all progress bars from pre-computed tick data."""
 
-        # Use current_run_start as the effective graph origin so that copied
-        # prior-run records (from RESUME mode) don't stretch the time axis.
-        effective_min = tick.current_run_start if tick.current_run_start is not None else tick.min_time_stamp
+        effective_min = tick.effective_min_time_stamp
 
         self.time_axis.update_time_window(effective_min, tick.max_time_stamp)
 

--- a/src/pytest_fly/gui/graph_tab/progress_bar.py
+++ b/src/pytest_fly/gui/graph_tab/progress_bar.py
@@ -6,7 +6,7 @@ execution timeline with change-detection optimization to skip unnecessary repain
 import time
 
 from PySide6.QtCore import QPointF, QRectF
-from PySide6.QtGui import QBrush, QGuiApplication, QPainter, QPalette, QPen
+from PySide6.QtGui import QBrush, QGuiApplication, QPainter, QPen
 from PySide6.QtWidgets import QMenu, QToolTip, QVBoxLayout, QWidget
 from typeguard import typechecked
 
@@ -14,8 +14,8 @@ from ...colors import GRID_LINE_COLOR
 from ...interfaces import PytestProcessInfo, PytestRunnerState
 from ...logger import get_logger
 from ...pytest_runner.pytest_runner import PytestRunState
-from ..gui_util import get_text_dimensions, tool_tip_limiter
-from .time_axis import compute_grid_ticks
+from ..gui_util import get_text_dimensions, tool_tip_limiter, window_text_color
+from .time_axis import TimeAxisMapping, compute_grid_ticks
 
 log = get_logger()
 
@@ -124,16 +124,14 @@ class PytestProgressBar(QWidget):
             bar_text = f"{pytest_run_state.get_name()} - {pytest_run_state.get_string()}"
 
             outer_rect = self.rect()
-            overall_time_window = max(self.max_time_stamp - self.min_time_stamp, 1)
-            horizontal_pixels_per_second = outer_rect.width() / overall_time_window
+            mapping = TimeAxisMapping(min_ts=self.min_time_stamp, max_ts=self.max_time_stamp, width_pixels=outer_rect.width())
 
             bar_color = pytest_run_state.get_qt_bar_color()
 
             if pytest_run_state.get_state() not in (PytestRunnerState.QUEUED, PytestRunnerState.STOPPED) and start_running_time is not None and end_time >= self.min_time_stamp:
-                seconds_from_start = start_running_time - self.min_time_stamp
-                x1 = (seconds_from_start * horizontal_pixels_per_second) + self.bar_margin
+                x1 = mapping.ts_to_x(start_running_time) + self.bar_margin
                 y1 = outer_rect.y() + self.bar_margin
-                w = ((end_time - start_running_time) * horizontal_pixels_per_second) - (2 * self.bar_margin)
+                w = mapping.elapsed_to_x(end_time - start_running_time) - (2 * self.bar_margin)
                 h = self.one_character_dimensions.height()
                 painter.setPen(QPen(bar_color, 1))
                 bar_rect = QRectF(x1, y1, w, h)
@@ -150,9 +148,7 @@ class PytestProgressBar(QWidget):
             text_left_margin = self.one_character_dimensions.width()
             text_y_margin = int(round((0.5 * self.one_character_dimensions.height() + self.bar_margin + 1)))
 
-            palette = self.palette()
-            text_color = palette.color(QPalette.WindowText)
-            painter.setPen(QPen(text_color, 1))
+            painter.setPen(QPen(window_text_color(self), 1))
             painter.drawText(outer_rect.x() + text_left_margin, outer_rect.y() + text_y_margin, bar_text)
 
             painter.end()

--- a/src/pytest_fly/gui/graph_tab/time_axis.py
+++ b/src/pytest_fly/gui/graph_tab/time_axis.py
@@ -1,20 +1,58 @@
 """
 Time-axis header and grid-line utilities for the Graph tab.
 
-Provides :func:`compute_grid_ticks` (shared between the axis header and
-individual progress bars) and :class:`TimeAxisWidget` (the header painted
-at the top of the progress-bar list).
+Provides:
+- :class:`TimeAxisMapping`: encapsulates the timestamp → pixel-x conversion
+  used by the progress bars, the axis header, and the coverage chart.
+- :func:`compute_grid_ticks`: grid tick positions/labels derived from a
+  :class:`TimeAxisMapping`.
+- :class:`TimeAxisWidget`: the header painted at the top of the progress-bar list.
 """
 
-from PySide6.QtGui import QPainter, QPalette, QPen
+from dataclasses import dataclass
+
+from PySide6.QtGui import QPainter, QPen
 from PySide6.QtWidgets import QWidget
 
 from ...colors import GRID_LINE_COLOR
-from ..gui_util import get_text_dimensions
+from ..gui_util import get_text_dimensions, window_text_color
 
 # Candidate intervals in seconds — chosen so labels stay readable.
 # Extends up to 24h so multi-hour runs don't collapse to minute-granularity grid lines.
 _INTERVALS = [1, 2, 5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 21600, 43200, 86400]
+
+
+@dataclass(frozen=True)
+class TimeAxisMapping:
+    """
+    Maps wall-clock timestamps to pixel x-coordinates along a time axis.
+
+    Shared by :class:`PytestProgressBar`, :class:`TimeAxisWidget`, and the
+    coverage chart so every site agrees on the same math (time-window clamp,
+    pixels-per-second, and ts → x conversion).
+    """
+
+    min_ts: float
+    max_ts: float
+    width_pixels: float
+
+    @property
+    def time_window(self) -> float:
+        """Seconds spanned by the axis, clamped to at least 1.0 so divisions never explode."""
+        return max(self.max_ts - self.min_ts, 1.0)
+
+    @property
+    def pixels_per_second(self) -> float:
+        """Horizontal pixels per elapsed second."""
+        return self.width_pixels / self.time_window
+
+    def ts_to_x(self, ts: float) -> float:
+        """Convert a wall-clock timestamp to a pixel x-offset (0 at ``min_ts``)."""
+        return (ts - self.min_ts) * self.pixels_per_second
+
+    def elapsed_to_x(self, elapsed_seconds: float) -> float:
+        """Convert seconds elapsed from ``min_ts`` to a pixel x-offset."""
+        return elapsed_seconds * self.pixels_per_second
 
 
 def _choose_interval(time_window: float) -> float:
@@ -46,9 +84,6 @@ def compute_grid_ticks(min_ts: float | None, max_ts: float | None, width_pixels:
     """
     Compute X-pixel positions and labels for time-axis grid lines.
 
-    Uses the same time-to-pixel mapping as :class:`PytestProgressBar`:
-    ``x = elapsed * (width / time_window)``.
-
     :param min_ts: Earliest timestamp (epoch seconds), or ``None``.
     :param max_ts: Latest timestamp (epoch seconds), or ``None``.
     :param width_pixels: Widget width in pixels.
@@ -57,15 +92,13 @@ def compute_grid_ticks(min_ts: float | None, max_ts: float | None, width_pixels:
     if min_ts is None or max_ts is None or width_pixels <= 0:
         return []
 
-    time_window = max(max_ts - min_ts, 1.0)
-    pixels_per_second = width_pixels / time_window
-    interval = _choose_interval(time_window)
+    mapping = TimeAxisMapping(min_ts=min_ts, max_ts=max_ts, width_pixels=width_pixels)
+    interval = _choose_interval(mapping.time_window)
 
     ticks: list[tuple[float, str]] = []
     elapsed = 0.0
-    while elapsed <= time_window:
-        x = elapsed * pixels_per_second
-        ticks.append((x, _format_tick_label(elapsed)))
+    while elapsed <= mapping.time_window:
+        ticks.append((mapping.elapsed_to_x(elapsed), _format_tick_label(elapsed)))
         elapsed += interval
 
     return ticks
@@ -109,9 +142,7 @@ class TimeAxisWidget(QWidget):
             painter.drawLine(int(x), h - tick_height, int(x), h)
 
         # Draw labels
-        palette = self.palette()
-        text_color = palette.color(QPalette.WindowText)
-        painter.setPen(QPen(text_color, 1))
+        painter.setPen(QPen(window_text_color(self), 1))
         for x, label in ticks:
             label_width = get_text_dimensions(label).width()
             # Center label on tick; clamp so it doesn't overflow the left edge

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -12,8 +12,8 @@ from functools import cache, lru_cache
 
 import humanize
 from PySide6.QtCore import QSize
-from PySide6.QtGui import QFont, QFontMetrics
-from PySide6.QtWidgets import QPlainTextEdit, QSizePolicy
+from PySide6.QtGui import QColor, QFont, QFontMetrics, QPalette
+from PySide6.QtWidgets import QPlainTextEdit, QSizePolicy, QWidget
 from typeguard import typechecked
 
 from ..const import TOOLTIP_LINE_LIMIT
@@ -189,6 +189,11 @@ def compute_average_parallelism(infos_by_name: dict[str, list[PytestProcessInfo]
         return None
 
     return total_test_time / wall_clock
+
+
+def window_text_color(widget: QWidget) -> QColor:
+    """Return the palette's foreground text color for *widget* (respects light/dark themes)."""
+    return widget.palette().color(QPalette.WindowText)
 
 
 @typechecked

--- a/src/pytest_fly/tick_data.py
+++ b/src/pytest_fly/tick_data.py
@@ -35,3 +35,10 @@ class TickData:
     current_run_start: float | None = None  # wall-clock timestamp captured when Run was pressed; used as the graph time-axis origin
     last_pass_data: dict[str, tuple[float, float]] = field(default_factory=dict)  # test_name -> (start_timestamp, duration_seconds) from most recent passing run
     soft_stop_requested: bool = False
+
+    @property
+    def effective_min_time_stamp(self) -> float | None:
+        """Graph time-axis origin: prefer the explicit run-start timestamp so copied
+        prior-run records (RESUME mode) don't stretch the axis; otherwise fall back
+        to the earliest observed record timestamp."""
+        return self.current_run_start if self.current_run_start is not None else self.min_time_stamp

--- a/tests/test_time_axis.py
+++ b/tests/test_time_axis.py
@@ -1,6 +1,6 @@
 """Tests for time_axis pure utility functions."""
 
-from pytest_fly.gui.graph_tab.time_axis import _choose_interval, _format_tick_label, compute_grid_ticks
+from pytest_fly.gui.graph_tab.time_axis import TimeAxisMapping, _choose_interval, _format_tick_label, compute_grid_ticks
 
 
 def test_choose_interval_short():
@@ -22,10 +22,17 @@ def test_choose_interval_long():
     assert 5 <= num_lines <= 12
 
 
+def test_choose_interval_hours():
+    """Multi-hour windows should use an hour-scale interval yielding 5-12 lines."""
+    interval = _choose_interval(14400.0)  # 4h
+    num_lines = 14400.0 / interval
+    assert 5 <= num_lines <= 12
+
+
 def test_choose_interval_very_long():
-    """Beyond all candidates, should return the largest interval."""
-    interval = _choose_interval(100000.0)
-    assert interval == 600
+    """Beyond all candidates, should return the largest interval (24h)."""
+    interval = _choose_interval(10 * 86400.0)  # 10 days
+    assert interval == 86400
 
 
 def test_format_tick_label_seconds():
@@ -43,6 +50,30 @@ def test_format_tick_label_minutes():
 def test_format_tick_label_mixed():
     assert _format_tick_label(90) == "1m30s"
     assert _format_tick_label(150) == "2m30s"
+
+
+def test_format_tick_label_hours():
+    assert _format_tick_label(3600) == "1h"
+    assert _format_tick_label(7200) == "2h"
+    assert _format_tick_label(3600 + 30 * 60) == "1h30m"
+    assert _format_tick_label(5 * 3600 + 15 * 60) == "5h15m"
+
+
+def test_time_axis_mapping_basic():
+    mapping = TimeAxisMapping(min_ts=1000.0, max_ts=1100.0, width_pixels=200.0)
+    assert mapping.time_window == 100.0
+    assert mapping.pixels_per_second == 2.0
+    assert mapping.ts_to_x(1000.0) == 0.0
+    assert mapping.ts_to_x(1050.0) == 100.0
+    assert mapping.ts_to_x(1100.0) == 200.0
+    assert mapping.elapsed_to_x(50.0) == 100.0
+
+
+def test_time_axis_mapping_clamp():
+    """When min == max, time_window is clamped to 1.0 so px_per_sec is finite."""
+    mapping = TimeAxisMapping(min_ts=1000.0, max_ts=1000.0, width_pixels=200.0)
+    assert mapping.time_window == 1.0
+    assert mapping.pixels_per_second == 200.0
 
 
 def test_compute_grid_ticks_none_timestamps():


### PR DESCRIPTION
## Summary
- **Bug fix:** Coverage tab had the same RESUME-mode origin bug as the progress graph — it was passing `tick.min_time_stamp` (which includes copied prior-run records with old timestamps) instead of the current-run origin.
- **Refactor (DRY):**
  - New `TickData.effective_min_time_stamp` property encapsulates the `current_run_start` origin + `min_time_stamp` fallback. Both tabs now read it — same class of bug can't recur.
  - New `TimeAxisMapping` dataclass (`time_window`, `pixels_per_second`, `ts_to_x`, `elapsed_to_x`) replaces duplicated arithmetic in the progress bar, coverage chart, and grid-tick computation.
  - New `window_text_color(widget)` helper replaces three copies of `palette()/QPalette.WindowText`.
- **Test fixes:** `test_choose_interval_very_long` (broke when v0.3.15 extended intervals to 24h). Added `TimeAxisMapping` unit tests and hour-label tests.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `pytest tests/ --ignore=tests/test_pytest_runner` — 102 / 102 pass
- [ ] Manual: run a multi-hour suite in RESUME — verify both progress AND coverage graph axes start at the new run

🤖 Generated with [Claude Code](https://claude.com/claude-code)