### PR TITLE
Align table/graph ordering with execution queue and mark singletons — v0.3.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.17"
+version = "0.3.18"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/graph_tab/graph_tab.py
+++ b/src/pytest_fly/gui/graph_tab/graph_tab.py
@@ -51,11 +51,12 @@ class GraphTab(QGroupBox):
         # Create or update bars
         for test_name, infos in tick.infos_by_name.items():
             run_state = tick.run_states[test_name]
+            is_singleton = test_name in tick.singleton_names
             if test_name in self.progress_bars:
                 progress_bar = self.progress_bars[test_name]
-                progress_bar.update_pytest_process_info(infos, effective_min, tick.max_time_stamp, run_state)
+                progress_bar.update_pytest_process_info(infos, effective_min, tick.max_time_stamp, run_state, is_singleton)
             else:
-                progress_bar = PytestProgressBar(infos, effective_min, tick.max_time_stamp, run_state)
+                progress_bar = PytestProgressBar(infos, effective_min, tick.max_time_stamp, run_state, is_singleton)
                 self.progress_bars[test_name] = progress_bar
 
         # Ensure layout order matches tick.infos_by_name order (same as table tab)

--- a/src/pytest_fly/gui/graph_tab/progress_bar.py
+++ b/src/pytest_fly/gui/graph_tab/progress_bar.py
@@ -32,6 +32,7 @@ class PytestProgressBar(QWidget):
         min_time_stamp: float,
         max_time_stamp: float,
         run_state: PytestRunState,
+        is_singleton: bool = False,
     ) -> None:
 
         super().__init__()
@@ -43,6 +44,7 @@ class PytestProgressBar(QWidget):
         self.min_time_stamp = min_time_stamp
         self.max_time_stamp = max_time_stamp
         self._run_state = run_state
+        self._is_singleton = is_singleton
 
         if len(status_list) > 0:
             name = status_list[0].name
@@ -65,9 +67,9 @@ class PytestProgressBar(QWidget):
         self._prev_min_ts: float | None = None
         self._prev_max_ts: float | None = None
 
-        self.update_pytest_process_info(status_list, min_time_stamp, max_time_stamp, run_state)
+        self.update_pytest_process_info(status_list, min_time_stamp, max_time_stamp, run_state, is_singleton)
 
-    def update_pytest_process_info(self, status_list: list[PytestProcessInfo], min_time_stamp: float, max_time_stamp: float, run_state: PytestRunState):
+    def update_pytest_process_info(self, status_list: list[PytestProcessInfo], min_time_stamp: float, max_time_stamp: float, run_state: PytestRunState, is_singleton: bool = False):
         """
         Update the bar's data and schedule a repaint — but only if the data
         actually changed or the test is still running (its bar grows over time).
@@ -76,7 +78,16 @@ class PytestProgressBar(QWidget):
         new_count = len(status_list)
         new_last_ts = status_list[-1].time_stamp if status_list else None
         is_running = len(status_list) > 0 and status_list[-1].pid is not None and run_state.get_state() == PytestRunnerState.RUNNING
-        if not is_running and new_count == self._prev_count and new_last_ts == self._prev_last_ts and min_time_stamp == self._prev_min_ts and max_time_stamp == self._prev_max_ts:
+        singleton_changed = is_singleton != self._is_singleton
+        unchanged = (
+            not is_running
+            and not singleton_changed
+            and new_count == self._prev_count
+            and new_last_ts == self._prev_last_ts
+            and min_time_stamp == self._prev_min_ts
+            and max_time_stamp == self._prev_max_ts
+        )
+        if unchanged:
             return  # no change — skip repaint
         self._prev_count = new_count
         self._prev_last_ts = new_last_ts
@@ -87,6 +98,7 @@ class PytestProgressBar(QWidget):
         self.min_time_stamp = min_time_stamp
         self.max_time_stamp = max_time_stamp
         self._run_state = run_state
+        self._is_singleton = is_singleton
 
         if len(self.status_list) > 0:
             name = self.status_list[0].name
@@ -121,7 +133,10 @@ class PytestProgressBar(QWidget):
             else:
                 end_time = self.status_list[-1].time_stamp
 
-            bar_text = f"{pytest_run_state.get_name()} - {pytest_run_state.get_string()}"
+            name_label = pytest_run_state.get_name()
+            if self._is_singleton:
+                name_label = f"{name_label} (singleton)"
+            bar_text = f"{name_label} - {pytest_run_state.get_string()}"
 
             outer_rect = self.rect()
             mapping = TimeAxisMapping(min_ts=self.min_time_stamp, max_ts=self.max_time_stamp, width_pixels=outer_rect.width())

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -37,12 +37,22 @@ from .table_tab import TableTab
 log = get_logger()
 
 
-def build_tick_data(process_infos: list, prior_durations: dict[str, float] | None = None, num_processes: int = 1, current_run_start: float | None = None) -> TickData:
+def build_tick_data(
+    process_infos: list,
+    prior_durations: dict[str, float] | None = None,
+    num_processes: int = 1,
+    current_run_start: float | None = None,
+    singleton_names: set[str] | None = None,
+) -> TickData:
     """
     Build a :class:`TickData` bundle from a flat list of process info records.
 
     Performs grouping, time-window computation, and run-state construction
     once so that all tabs can share the pre-computed results.
+
+    ``infos_by_name`` and ``run_states`` are ordered alphabetically by test name
+    with singleton tests last, so all tabs that iterate these dicts render in
+    the same order (matching the runner's execution order).
 
     :param process_infos: Flat list of :class:`PytestProcessInfo` objects from the DB.
     :param prior_durations: Optional mapping of test name to prior run duration (seconds), used for ETA.
@@ -51,10 +61,15 @@ def build_tick_data(process_infos: list, prior_durations: dict[str, float] | Non
         as the graph time-axis origin.  Passed in explicitly because RESUME mode copies prior-run
         records (including their original QUEUED records with ``exit_code == NONE``), so the origin
         cannot be derived reliably from DB records alone.
+    :param singleton_names: Node ids of tests marked ``@pytest.mark.singleton``; these are sorted
+        last in the output dicts to match the runner's end-of-queue placement.
     :return: A fully populated :class:`TickData` instance.
     """
-    infos_by_name = group_process_infos_by_name(process_infos)
-    run_states = {name: PytestRunState(infos) for name, infos in infos_by_name.items()}
+    singletons = singleton_names if singleton_names is not None else set()
+    grouped = group_process_infos_by_name(process_infos)
+    ordered_names = sorted(grouped, key=lambda n: (n in singletons, n))
+    infos_by_name = {name: grouped[name] for name in ordered_names}
+    run_states = {name: PytestRunState(infos_by_name[name]) for name in ordered_names}
     min_ts, max_ts = compute_time_window(process_infos)
     min_ts_s, max_ts_s = compute_time_window(process_infos, require_pid=True)
 
@@ -70,6 +85,7 @@ def build_tick_data(process_infos: list, prior_durations: dict[str, float] | Non
         num_processes=num_processes,
         average_parallelism=compute_average_parallelism(infos_by_name),
         current_run_start=current_run_start,
+        singleton_names=singletons,
     )
 
 
@@ -190,6 +206,7 @@ class FlyAppMainWindow(QMainWindow):
             prior_durations=control.prior_durations,
             num_processes=control.num_processes,
             current_run_start=control.current_run_start,
+            singleton_names=control.singleton_names,
         )
         tick.last_pass_data = last_pass_data
         tick.soft_stop_requested = control._soft_stop_requested

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -73,6 +73,7 @@ class ControlWindow(QGroupBox):
         self.num_processes: int = 1
         self._soft_stop_requested: bool = False
         self.current_run_start: float | None = None
+        self.singleton_names: set[str] = set()
 
         self.set_fixed_width()  # calculate and set the widget width
 
@@ -148,8 +149,11 @@ class ControlWindow(QGroupBox):
                         for record in prior_by_name.get(node_id, []):
                             db.write(replace(record, run_guid=self.run_guid))
 
-        # Reorder so previously-failed tests run first (within their singleton group)
-        tests = self._reorder_failed_first(tests, prior_results)
+        # Reorder so previously-failed tests run first (within their singleton group).
+        # RESTART means "start over" — ignore prior results entirely so execution order
+        # matches the alphabetical table display.
+        if pref.run_mode != RunMode.RESTART:
+            tests = self._reorder_failed_first(tests, prior_results)
 
         # Use last-pass durations for ETA estimation (from the most recent passing run)
         self.prior_durations = {name: duration for name, (_, duration) in last_pass_data.items()}
@@ -159,6 +163,8 @@ class ControlWindow(QGroupBox):
         if pref.test_order == TestOrder.COVERAGE:
             tests = self._apply_coverage_order(tests)
             tests.sort()
+
+        self.singleton_names = {t.node_id for t in tests if t.singleton}
 
         self.pytest_runner = PytestRunner(self.run_guid, tests, processes, self.data_dir, refresh_rate)
         self.pytest_runner.start()

--- a/src/pytest_fly/gui/run_tab/failed_tests_window.py
+++ b/src/pytest_fly/gui/run_tab/failed_tests_window.py
@@ -32,7 +32,7 @@ class FailedTestsWindow(QGroupBox):
 
     def update_tick(self, tick: TickData):
         """Rebuild the failed test list from pre-computed tick data."""
-        failed_names = sorted(test_name for test_name, run_state in tick.run_states.items() if run_state.get_state() == PytestRunnerState.FAIL)
+        failed_names = [test_name for test_name, run_state in tick.run_states.items() if run_state.get_state() == PytestRunnerState.FAIL]
 
         if failed_names != self._failed_names:
             self._failed_names = failed_names

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -156,11 +156,14 @@ class TableTab(QGroupBox):
         self.table_widget.clearContents()
         self.table_widget.setRowCount(len(tick.infos_by_name))
 
-        for row_number, test_name in enumerate(sorted(tick.infos_by_name)):
+        for row_number, test_name in enumerate(tick.infos_by_name):
             process_infos = tick.infos_by_name[test_name]
             pytest_run_state = tick.run_states[test_name]
 
-            name_item = QTableWidgetItem(pytest_run_state.get_name())
+            display_name = pytest_run_state.get_name()
+            if test_name in tick.singleton_names:
+                display_name = f"{display_name} (singleton)"
+            name_item = QTableWidgetItem(display_name)
             name_item.setData(Qt.ItemDataRole.UserRole, test_name)  # store node_id for context menu
             self.table_widget.setItem(row_number, Columns.NAME.value, name_item)
 

--- a/src/pytest_fly/tick_data.py
+++ b/src/pytest_fly/tick_data.py
@@ -35,6 +35,7 @@ class TickData:
     current_run_start: float | None = None  # wall-clock timestamp captured when Run was pressed; used as the graph time-axis origin
     last_pass_data: dict[str, tuple[float, float]] = field(default_factory=dict)  # test_name -> (start_timestamp, duration_seconds) from most recent passing run
     soft_stop_requested: bool = False
+    singleton_names: set[str] = field(default_factory=set)  # node_ids of tests marked with @pytest.mark.singleton — displayed last in test-listing tabs
 
     @property
     def effective_min_time_stamp(self) -> float | None:


### PR DESCRIPTION
## Summary
- RESTART mode no longer applies failed-first reordering (that was semantically a RESUME concept) — execution order now matches the alphabetical table display.
- Singletons are sorted last in Table, Failed Tests, and Graph tabs, matching the runner's end-of-queue placement.
- Singletons are labeled " (singleton)" in the Table name column and Graph bar text.
- Centralized ordering in `build_tick_data` (pre-sorts `infos_by_name` and `run_states`) so every consumer iterates in the same order.

## Test plan
- [x] Lint passes (`ruff check`)
- [x] Unit smoke test of sort order in `build_tick_data`
- [x] Visual render of Table and Graph tabs with two non-singleton passes, one non-singleton fail, and two singleton tests (one pass, one fail); singletons appear last in both tabs with the "(singleton)" suffix
- [ ] Manual run: open app, trigger a pytest-fly run with `@pytest.mark.singleton` tests and verify the queue and displayed order agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)