### PR TITLE
Surface pytest failure output and align Status/Control heights — v0.3.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.18"
+version = "0.3.19"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/const.py
+++ b/src/pytest_fly/const.py
@@ -2,6 +2,3 @@
 
 # Environment variable that overrides the default data directory.
 PYTEST_FLY_DATA_DIR_STRING = "PYTEST_FLY_DATA_DIR"
-
-# Maximum number of output lines shown in a tooltip before truncation.
-TOOLTIP_LINE_LIMIT = 20

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -14,11 +14,12 @@ from pytest_fly.gui.gui_util import get_text_dimensions
 from pytest_fly.interfaces import TestOrder
 from pytest_fly.logger import get_logger
 from pytest_fly.platform.platform_info import get_performance_core_count
-from pytest_fly.preferences import get_pref, refresh_rate_default, utilization_high_threshold_default, utilization_low_threshold_default
+from pytest_fly.preferences import get_pref, refresh_rate_default, tooltip_line_limit_default, utilization_high_threshold_default, utilization_low_threshold_default
 
 log = get_logger()
 
 minimum_refresh_rate = 1.0
+minimum_tooltip_line_limit = 1
 
 
 def _add_labeled_lineedit(
@@ -99,6 +100,11 @@ class Configuration(QWidget):
         low_label = f"Low Utilization Threshold (0.0-1.0, {utilization_low_threshold_default} default)"
         self.utilization_low_threshold_lineedit = _add_labeled_lineedit(layout, low_label, str(pref.utilization_low_threshold), QDoubleValidator(), self.update_utilization_low_threshold)
 
+        layout.addWidget(QLabel(""))  # space
+
+        tooltip_label = f"Tooltip Line Limit (min {minimum_tooltip_line_limit}, {tooltip_line_limit_default} default)"
+        self.tooltip_line_limit_lineedit = _add_labeled_lineedit(layout, tooltip_label, str(pref.tooltip_line_limit), QIntValidator(), self.update_tooltip_line_limit, char_width=6)
+
     def update_verbose(self):
         """Persist the verbose checkbox state to preferences."""
         pref = get_pref()
@@ -146,3 +152,9 @@ class Configuration(QWidget):
         except ValueError:
             pass
         self._validate_utilization_thresholds()
+
+    def update_tooltip_line_limit(self, value: str):
+        """Persist the tooltip line limit (clamped to *minimum_tooltip_line_limit*)."""
+        pref = get_pref()
+        if value.isnumeric():
+            pref.tooltip_line_limit = max(int(value), minimum_tooltip_line_limit)

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -16,8 +16,8 @@ from PySide6.QtGui import QColor, QFont, QFontMetrics, QPalette
 from PySide6.QtWidgets import QPlainTextEdit, QSizePolicy, QWidget
 from typeguard import typechecked
 
-from ..const import TOOLTIP_LINE_LIMIT
 from ..interfaces import PytestProcessInfo
+from ..preferences import get_pref
 
 
 @cache
@@ -196,18 +196,37 @@ def window_text_color(widget: QWidget) -> QColor:
     return widget.palette().color(QPalette.WindowText)
 
 
-@typechecked
-def tool_tip_limiter(text: str | None) -> str:
+def _extract_pytest_failure_section(text: str) -> str | None:
+    """Return the pytest FAILURES section (plus any trailing short-summary) or None if not present.
+
+    Pytest emits a banner like ``==== FAILURES ====`` before per-test tracebacks.
+    The interesting content for a failing run lives from that banner through the
+    end of the output — teardown logs typically appear *before* it, so trimming
+    to this region keeps the actual failure details visible in the tooltip.
     """
-    Limit the number of lines in a tooltip text.
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if line.strip("= ") == "FAILURES":
+            return "\n".join(lines[i:])
+    return None
+
+
+@typechecked
+def tool_tip_limiter(text: str | None, line_limit: int | None = None) -> str:
+    """
+    Prepare tooltip text from pytest output: prefer the FAILURES section when present,
+    then cap at *line_limit* lines (falling back to the user preference).
 
     :param text: The original tooltip text
+    :param line_limit: Max lines to show; if None, reads from user preferences
     :return: The limited tooltip text
     """
     if text is None:
         return ""
-    lines = text.splitlines()
-    if len(lines) > TOOLTIP_LINE_LIMIT:
-        limited_text = "...\n" + "\n".join(lines[len(lines) - TOOLTIP_LINE_LIMIT :])
-        return limited_text
-    return text
+    if line_limit is None:
+        line_limit = get_pref().tooltip_line_limit
+    source = _extract_pytest_failure_section(text) or text
+    lines = source.splitlines()
+    if len(lines) > line_limit:
+        return "...\n" + "\n".join(lines[len(lines) - line_limit :])
+    return source

--- a/src/pytest_fly/gui/run_tab/run_tab.py
+++ b/src/pytest_fly/gui/run_tab/run_tab.py
@@ -33,6 +33,10 @@ class RunTab(QWidget):
         self.status_window = StatusWindow(self)
         self.failed_tests_window = FailedTestsWindow(self)
 
+        # Match StatusWindow's height to ControlWindow's so the two panels line up.
+        # ControlWindow has Fixed size policy (set in its __init__), so its sizeHint is stable.
+        self.status_window.setFixedHeight(self.control_window.sizeHint().height())
+
         top_layout.addWidget(self.control_window, alignment=Qt.AlignmentFlag.AlignTop)
         top_layout.addWidget(self.status_window, alignment=Qt.AlignmentFlag.AlignTop)
         top_layout.addStretch()

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -76,6 +76,7 @@ class TableTab(QGroupBox):
         self.setLayout(layout)
 
         self._current_run_states: dict = {}
+        self._current_infos_by_name: dict = {}  # test node_id -> list[PytestProcessInfo]; source for full (untruncated) copy-to-clipboard
 
     def show_context_menu(self, position: QPoint):
         """Show a right-click context menu allowing the user to copy pytest output or force-stop a running test.
@@ -111,21 +112,28 @@ class TableTab(QGroupBox):
         action = menu.exec_(self.table_widget.viewport().mapToGlobal(position))
 
         if action == copy_tooltip_action:
-            # Re-fetch the item after exec_() to avoid stale C++ pointer
-            if item_row >= 0 and item_col >= 0:
-                item = self.table_widget.item(item_row, item_col)
-            if item is not None:
-                try:
-                    tooltip = item.toolTip()
-                except RuntimeError:
-                    return  # item's C++ object was deleted between retrieval and access
+            # Prefer the untruncated output from the latest PytestProcessInfo so
+            # users get the full pytest output (not the tooltip-limited view).
+            output_text = ""
+            if test_node_id is not None:
+                infos = self._current_infos_by_name.get(test_node_id, [])
+                for info in reversed(infos):
+                    if info.output:
+                        output_text = info.output
+                        break
 
-                # fallback to ItemDataRole if toolTip() is empty
-                if not tooltip:
-                    tooltip = item.data(Qt.ItemDataRole.ToolTipRole) or ""
-                if tooltip:
-                    clipboard = QGuiApplication.clipboard()
-                    clipboard.setText(tooltip)
+            # Fallback to the tooltip text if no output is available yet.
+            if not output_text:
+                if item_row >= 0 and item_col >= 0:
+                    item = self.table_widget.item(item_row, item_col)
+                if item is not None:
+                    try:
+                        output_text = item.toolTip() or item.data(Qt.ItemDataRole.ToolTipRole) or ""
+                    except RuntimeError:
+                        return  # item's C++ object was deleted between retrieval and access
+
+            if output_text:
+                QGuiApplication.clipboard().setText(output_text)
         elif action is not None and action == force_stop_action:
             self.force_stop_test_requested.emit(test_node_id)
 
@@ -152,6 +160,7 @@ class TableTab(QGroupBox):
         """Refresh the table from pre-computed tick data."""
 
         self._current_run_states = tick.run_states
+        self._current_infos_by_name = tick.infos_by_name
 
         self.table_widget.clearContents()
         self.table_widget.setRowCount(len(tick.infos_by_name))

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -22,6 +22,7 @@ refresh_rate_default = 3.0
 utilization_high_threshold_default = 0.8
 utilization_low_threshold_default = 0.5
 run_with_coverage_default = True
+tooltip_line_limit_default = 200  # max lines shown in pytest-output tooltips before truncation
 
 
 class ParallelismControl(IntEnum):
@@ -53,6 +54,8 @@ class FlyPreferences(Pref):
     run_mode: RunMode = attrib(default=RunMode.CHECK)  # 0=restart all tests, 1=resume, 2=resume if possible (i.e., the program version under test has not changed)
 
     test_order: TestOrder = attrib(default=TestOrder.PYTEST)  # 0=pytest default order, 1=coverage efficiency order
+
+    tooltip_line_limit: int = attrib(default=tooltip_line_limit_default)  # max lines of pytest output shown in a tooltip before truncation
 
 
 def get_pref() -> FlyPreferences:

--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -74,7 +74,8 @@ class PytestProcess(Process):
             coverage.start()
 
             try:
-                exit_code = pytest.main([self.name])
+                # -rA: show full short test summary (all outcomes, untruncated assertion messages)
+                exit_code = pytest.main([self.name, "-rA"])
             except Exception:
                 exit_code = PyTestFlyExitCode.INTERNAL_ERROR
                 try:


### PR DESCRIPTION
## Summary
- Extract the pytest ``FAILURES`` section in tooltips so failure details aren't hidden behind teardown logs.
- Make the tooltip line limit a user preference (default 200, up from a hardcoded 20) and expose it in the Configuration tab.
- Copy Pytest Output in the Table tab now copies the full, untruncated output from ``PytestProcessInfo`` instead of the already-limited tooltip text.
- Run ``pytest.main`` with ``-rA`` for a fuller short-summary section.
- Run tab: match ``StatusWindow`` height to ``ControlWindow`` so the two top-row panels line up.
- Version bump to 0.3.19.

## Test plan
- [ ] Run a failing test; hover the Table tab state cell and confirm the tooltip shows the FAILURES section (traceback), not just the teardown logs.
- [ ] Right-click a failing row and choose Copy Pytest Output; paste into a text editor and confirm the full, untruncated pytest output is on the clipboard.
- [ ] Open the Configuration tab, change Tooltip Line Limit, re-open the app, and confirm the preference persists.
- [ ] Visual check on the Run tab: Status and Control panels have the same height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)