### PR TITLE
Detect program-under-test version and wire RunMode.CHECK — v0.3.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.19"
+version = "0.3.20"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/db/db.py
+++ b/src/pytest_fly/db/db.py
@@ -38,7 +38,18 @@ class PytestProcessInfoDB(MSQLite):
         self._columns = []
         # fake to fill out all the fields since the underlying data structure is a dataclass
         # use concrete non-None values for optional fields so the schema maps to the correct SQLite types
-        dummy_pytest_process_info = PytestProcessInfo(run_guid="", name="", pid=0, exit_code=PyTestFlyExitCode.NONE, output="", time_stamp=0.0, cpu_percent=0.0, memory_percent=0.0)
+        dummy_pytest_process_info = PytestProcessInfo(
+            run_guid="",
+            name="",
+            pid=0,
+            exit_code=PyTestFlyExitCode.NONE,
+            output="",
+            time_stamp=0.0,
+            cpu_percent=0.0,
+            memory_percent=0.0,
+            put_version="",
+            put_fingerprint="",
+        )
         for column, value in asdict(dummy_pytest_process_info).items():
             # "equivalent" SQLite types
             if isinstance(value, IntEnum):

--- a/src/pytest_fly/gui/about_tab/about.py
+++ b/src/pytest_fly/gui/about_tab/about.py
@@ -1,6 +1,7 @@
 """About tab — shows project metadata and system/hardware information."""
 
 from dataclasses import asdict
+from pathlib import Path
 
 import humanize
 from PySide6.QtCore import QObject, QThread, Signal
@@ -10,6 +11,8 @@ from pytest_fly.gui.about_tab.project_info import get_project_info
 from pytest_fly.gui.gui_util import PlainTextWidget
 from pytest_fly.logger import get_log_directory
 from pytest_fly.platform.platform_info import get_performance_core_count, get_platform_info
+from pytest_fly.preferences import get_pref
+from pytest_fly.put_version import detect_put_version
 
 
 class AboutDataWorker(QObject):
@@ -23,6 +26,14 @@ class AboutDataWorker(QObject):
         text_lines = []
         for key, value in asdict(get_project_info()).items():
             text_lines.append(f"{key}: {value}")
+        text_lines.append("")
+
+        pref = get_pref()
+        project_root = Path(pref.target_project_path).resolve() if pref.target_project_path else Path.cwd()
+        put_info = detect_put_version(project_root)
+        text_lines.append("Program Under Test:")
+        for key, value in asdict(put_info).items():
+            text_lines.append(f"    {key}: {value}")
         text_lines.append("")
 
         for key, value in get_platform_info().items():

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QDoubleValidator, QIntValidator, QValidator
-from PySide6.QtWidgets import QCheckBox, QLabel, QLineEdit, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QCheckBox, QFileDialog, QHBoxLayout, QLabel, QLineEdit, QPushButton, QVBoxLayout, QWidget
 from tobool import to_bool_strict
 
 from pytest_fly.gui.gui_util import get_text_dimensions
@@ -105,6 +105,21 @@ class Configuration(QWidget):
         tooltip_label = f"Tooltip Line Limit (min {minimum_tooltip_line_limit}, {tooltip_line_limit_default} default)"
         self.tooltip_line_limit_lineedit = _add_labeled_lineedit(layout, tooltip_label, str(pref.tooltip_line_limit), QIntValidator(), self.update_tooltip_line_limit, char_width=6)
 
+        layout.addWidget(QLabel(""))  # space
+
+        # Target project path — empty means auto-detect from the current working directory at run time.
+        layout.addWidget(QLabel("Target Project Path (empty = auto-detect from current directory)"))
+        target_path_row = QHBoxLayout()
+        self.target_project_path_lineedit = QLineEdit()
+        self.target_project_path_lineedit.setText(pref.target_project_path)
+        self.target_project_path_lineedit.setPlaceholderText("(auto-detect)")
+        self.target_project_path_lineedit.textChanged.connect(self.update_target_project_path)
+        target_path_row.addWidget(self.target_project_path_lineedit)
+        self.target_project_path_browse = QPushButton("Browse…")
+        self.target_project_path_browse.clicked.connect(self._browse_target_project_path)
+        target_path_row.addWidget(self.target_project_path_browse)
+        layout.addLayout(target_path_row)
+
     def update_verbose(self):
         """Persist the verbose checkbox state to preferences."""
         pref = get_pref()
@@ -158,3 +173,16 @@ class Configuration(QWidget):
         pref = get_pref()
         if value.isnumeric():
             pref.tooltip_line_limit = max(int(value), minimum_tooltip_line_limit)
+
+    def update_target_project_path(self, value: str):
+        """Persist the target-project path override (empty = auto-detect)."""
+        pref = get_pref()
+        pref.target_project_path = value.strip()
+
+    def _browse_target_project_path(self):
+        """Open a directory picker to choose the target project path."""
+        pref = get_pref()
+        start = pref.target_project_path or ""
+        selected = QFileDialog.getExistingDirectory(self, "Select target project directory", start)
+        if selected:
+            self.target_project_path_lineedit.setText(selected)

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -21,6 +21,7 @@ from typeguard import typechecked
 
 from ..__version__ import application_name
 from ..db import PytestProcessInfoDB
+from ..interfaces import PutVersionInfo
 from ..logger import get_logger
 from ..preferences import get_pref
 from ..pytest_runner.pytest_runner import PytestRunState
@@ -43,6 +44,7 @@ def build_tick_data(
     num_processes: int = 1,
     current_run_start: float | None = None,
     singleton_names: set[str] | None = None,
+    put_version_info: PutVersionInfo | None = None,
 ) -> TickData:
     """
     Build a :class:`TickData` bundle from a flat list of process info records.
@@ -86,6 +88,7 @@ def build_tick_data(
         average_parallelism=compute_average_parallelism(infos_by_name),
         current_run_start=current_run_start,
         singleton_names=singletons,
+        put_version_info=put_version_info,
     )
 
 
@@ -207,6 +210,7 @@ class FlyAppMainWindow(QMainWindow):
             num_processes=control.num_processes,
             current_run_start=control.current_run_start,
             singleton_names=control.singleton_names,
+            put_version_info=control.put_version_info,
         )
         tick.last_pass_data = last_pass_data
         tick.soft_stop_requested = control._soft_stop_requested

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -15,9 +15,10 @@ from typeguard import typechecked
 
 from ...db import PytestProcessInfoDB
 from ...guid import generate_uuid
-from ...interfaces import PyTestFlyExitCode, RunMode, ScheduledTest, TestOrder
+from ...interfaces import PutVersionInfo, PyTestFlyExitCode, RunMode, ScheduledTest, TestOrder
 from ...logger import get_logger
 from ...preferences import ParallelismControl, get_pref
+from ...put_version import detect_put_version
 from ...pytest_runner.coverage import compute_per_test_coverage
 from ...pytest_runner.pytest_runner import PytestRunner
 from ...pytest_runner.test_list import GetTests
@@ -74,6 +75,7 @@ class ControlWindow(QGroupBox):
         self._soft_stop_requested: bool = False
         self.current_run_start: float | None = None
         self.singleton_names: set[str] = set()
+        self.put_version_info: PutVersionInfo | None = None
 
         self.set_fixed_width()  # calculate and set the widget width
 
@@ -102,10 +104,18 @@ class ControlWindow(QGroupBox):
 
     def run(self):
         """Discover tests and launch a new :class:`PytestRunner`."""
-        get_tests = GetTests()
+        pref = get_pref()
+
+        # Resolve the project root from the preference override (if any) and detect the
+        # program-under-test version before starting collection so we can pass the path
+        # into GetTests for consistent discovery.
+        project_root = Path(pref.target_project_path).resolve() if pref.target_project_path else Path.cwd()
+        self.put_version_info = detect_put_version(project_root)
+        log.info(f"PUT detected: {self.put_version_info}")
+
+        get_tests = GetTests(test_dir=project_root)
         get_tests.start()
 
-        pref = get_pref()
         refresh_rate = pref.refresh_rate
         self.run_guid = generate_uuid()
         # Capture start time before any prior records are copied so the graph
@@ -132,13 +142,18 @@ class ControlWindow(QGroupBox):
             prior_results = db.query()  # most recent run
             last_pass_data = db.query_last_pass()  # most recent passing run per test
 
-        all_node_ids = {t.node_id for t in tests}
-        tests = self._filter_for_resume(tests, prior_results, pref)
+        # CHECK mode: behave like RESUME if the PUT fingerprint matches the prior run, else RESTART.
+        effective_mode = pref.run_mode
+        if pref.run_mode == RunMode.CHECK:
+            effective_mode = self._resolve_check_mode(prior_results)
 
-        # In RESUME mode, copy the complete prior-run records for previously-passed
-        # tests into the current run so they appear in all GUI tabs (table, graph,
-        # status) with their original data (runtime, CPU, memory, output, etc.).
-        if pref.run_mode == RunMode.RESUME:
+        all_node_ids = {t.node_id for t in tests}
+        tests = self._filter_for_resume(tests, prior_results, effective_mode)
+
+        # In RESUME mode (or CHECK-as-RESUME), copy the complete prior-run records for
+        # previously-passed tests into the current run so they appear in all GUI tabs
+        # (table, graph, status) with their original data (runtime, CPU, memory, output, etc.).
+        if effective_mode == RunMode.RESUME:
             skipped_node_ids = all_node_ids - {t.node_id for t in tests}
             if skipped_node_ids:
                 prior_by_name = {}
@@ -152,7 +167,7 @@ class ControlWindow(QGroupBox):
         # Reorder so previously-failed tests run first (within their singleton group).
         # RESTART means "start over" — ignore prior results entirely so execution order
         # matches the alphabetical table display.
-        if pref.run_mode != RunMode.RESTART:
+        if effective_mode != RunMode.RESTART:
             tests = self._reorder_failed_first(tests, prior_results)
 
         # Use last-pass durations for ETA estimation (from the most recent passing run)
@@ -166,7 +181,9 @@ class ControlWindow(QGroupBox):
 
         self.singleton_names = {t.node_id for t in tests if t.singleton}
 
-        self.pytest_runner = PytestRunner(self.run_guid, tests, processes, self.data_dir, refresh_rate)
+        put_label = self.put_version_info.short_label() if self.put_version_info else ""
+        put_fp = self.put_version_info.fingerprint() if self.put_version_info else ""
+        self.pytest_runner = PytestRunner(self.run_guid, tests, processes, self.data_dir, refresh_rate, put_version=put_label, put_fingerprint=put_fp)
         self.pytest_runner.start()
 
         self.run_button.setEnabled(False)
@@ -174,22 +191,49 @@ class ControlWindow(QGroupBox):
         self.force_stop_button.setEnabled(True)
         self._soft_stop_requested = False
 
-    def _filter_for_resume(self, tests, prior_results, pref):
+    def _filter_for_resume(self, tests, prior_results, effective_mode):
         """Filter out already-passed tests when running in RESUME mode.
 
         :param tests: List of scheduled tests.
         :param prior_results: List of prior PytestProcessInfo records.
-        :param pref: User preferences object.
+        :param effective_mode: The resolved RunMode (CHECK has already been collapsed
+            to RESUME or RESTART by :meth:`_resolve_check_mode`).
         :return: Filtered list of tests.
         """
         original_count = len(tests)
-        if pref.run_mode == RunMode.RESUME:
+        if effective_mode == RunMode.RESUME:
             passed = {r.name for r in prior_results if r.exit_code == PyTestFlyExitCode.OK}
             tests = [t for t in tests if t.node_id not in passed]
             log.info(f"RESUME filter: {original_count} discovered, {len(passed)} passed in prior run, {len(tests)} to re-run")
         else:
-            log.info(f"run_mode={pref.run_mode!r} (not RESUME), skipping filter — all {original_count} tests will run")
+            log.info(f"run_mode={effective_mode!r} (not RESUME), skipping filter — all {original_count} tests will run")
         return tests
+
+    def _resolve_check_mode(self, prior_results) -> RunMode:
+        """Collapse :attr:`RunMode.CHECK` into either RESUME or RESTART based on the PUT fingerprint.
+
+        If the prior run's PUT fingerprint matches the current one, behave like RESUME;
+        otherwise restart.  A dirty working tree always changes the fingerprint (because
+        :meth:`PutVersionInfo.fingerprint` incorporates ``git_dirty``) so developers
+        iterating on code get fresh runs.
+
+        :param prior_results: Records from the most recent prior run, or an empty list.
+        :return: Either :attr:`RunMode.RESUME` or :attr:`RunMode.RESTART`.
+        """
+        current_fp = self.put_version_info.fingerprint() if self.put_version_info else ""
+        prior_fp = None
+        for record in prior_results:
+            if record.put_fingerprint:
+                prior_fp = record.put_fingerprint
+                break
+        if prior_fp is None:
+            log.info("CHECK: no prior PUT fingerprint recorded, restarting")
+            return RunMode.RESTART
+        if prior_fp != current_fp:
+            log.info(f"CHECK: PUT fingerprint changed ({prior_fp!r} -> {current_fp!r}), restarting")
+            return RunMode.RESTART
+        log.info(f"CHECK: PUT fingerprint unchanged ({current_fp!r}), resuming")
+        return RunMode.RESUME
 
     def _reorder_failed_first(self, tests, prior_results):
         """Reorder tests so previously-failed ones run first (within their singleton group).

--- a/src/pytest_fly/gui/run_tab/run_mode_control_box.py
+++ b/src/pytest_fly/gui/run_tab/run_mode_control_box.py
@@ -1,4 +1,4 @@
-"""Radio-button group for selecting the run mode (Restart / Resume)."""
+"""Radio-button group for selecting the run mode (Restart / Resume / Check)."""
 
 from PySide6.QtWidgets import QButtonGroup, QGroupBox, QRadioButton, QVBoxLayout
 
@@ -6,7 +6,7 @@ from pytest_fly.preferences import RunMode, get_pref
 
 
 class RunModeControlBox(QGroupBox):
-    """Radio-button group for selecting the run mode (Restart / Resume)."""
+    """Radio-button group for selecting the run mode (Restart / Resume / Check)."""
 
     def __init__(self, parent):
         super().__init__("Run Mode", parent)
@@ -18,19 +18,25 @@ class RunModeControlBox(QGroupBox):
         self.run_mode_restart.setToolTip("Always rerun all tests from scratch.")
         self.run_mode_resume = QRadioButton("Resume")
         self.run_mode_resume.setToolTip("Resume test run. Only run tests\nthat either failed or were not run.")
+        self.run_mode_check = QRadioButton("Check")
+        self.run_mode_check.setToolTip("Resume if the program under test has not\nchanged since the prior run; otherwise restart.")
 
         self.run_mode_group.addButton(self.run_mode_restart)
         self.run_mode_group.addButton(self.run_mode_resume)
+        self.run_mode_group.addButton(self.run_mode_check)
 
         layout.addWidget(self.run_mode_restart)
         layout.addWidget(self.run_mode_resume)
+        layout.addWidget(self.run_mode_check)
 
         pref = get_pref()
         self.run_mode_restart.setChecked(pref.run_mode == RunMode.RESTART)
         self.run_mode_resume.setChecked(pref.run_mode == RunMode.RESUME)
+        self.run_mode_check.setChecked(pref.run_mode == RunMode.CHECK)
 
         self.run_mode_restart.toggled.connect(self.update_preferences)
         self.run_mode_resume.toggled.connect(self.update_preferences)
+        self.run_mode_check.toggled.connect(self.update_preferences)
 
     def update_preferences(self):
         """Sync the selected radio button back to user preferences."""
@@ -39,3 +45,5 @@ class RunModeControlBox(QGroupBox):
             pref.run_mode = RunMode.RESTART
         elif self.run_mode_resume.isChecked():
             pref.run_mode = RunMode.RESUME
+        elif self.run_mode_check.isChecked():
+            pref.run_mode = RunMode.CHECK

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -35,7 +35,13 @@ class StatusWindow(QGroupBox):
 
         if len(tick.infos_by_name) > 0:
             total_tests = len(tick.infos_by_name)
-            lines = [f"{total_tests} tests", ""]
+            lines = []
+            if tick.put_version_info is not None:
+                put_line = f"PUT: {tick.put_version_info.short_label()}"
+                if tick.put_version_info.git_dirty:
+                    put_line += "  [uncommitted changes]"
+                lines.extend([put_line, ""])
+            lines.extend([f"{total_tests} tests", ""])
 
             # get current pass rate
             current_pass_count = counts[PytestRunnerState.PASS]
@@ -87,7 +93,13 @@ class StatusWindow(QGroupBox):
                     else:
                         lines.append("Estimated finish: unknown")
         else:
-            lines = ["Calculating..."]
+            lines = []
+            if tick.put_version_info is not None:
+                put_line = f"PUT: {tick.put_version_info.short_label()}"
+                if tick.put_version_info.git_dirty:
+                    put_line += "  [uncommitted changes]"
+                lines.extend([put_line, ""])
+            lines.append("Calculating...")
 
         self.status_widget.set_text("\n".join(lines))
 

--- a/src/pytest_fly/interfaces.py
+++ b/src/pytest_fly/interfaces.py
@@ -109,6 +109,55 @@ class PyTestFlyExitCode(IntEnum):
 
 
 @dataclass(frozen=True)
+class PutVersionInfo:
+    """
+    Detected metadata about the program under test (PUT) — the package/project whose tests are being run.
+
+    Captured once at the start of each pytest-fly run and stamped onto every
+    :class:`PytestProcessInfo` record via its ``put_version`` / ``put_fingerprint``
+    scalar fields.  Used to label runs in the GUI and to gate :attr:`RunMode.CHECK`.
+    """
+
+    name: str | None  # PEP 621 project name, or None if undetectable
+    version: str | None  # declared or installed version, or None
+    source: str  # "pyproject" | "setup.cfg" | "importlib.metadata" | "override" | "unknown"
+    git_describe: str | None  # e.g. "v0.3.19-4-gabc1234-dirty"
+    git_sha: str | None  # short SHA (7 chars)
+    git_branch: str | None
+    git_dirty: bool | None  # True if working tree has uncommitted changes
+    project_root: str  # absolute path used for detection
+
+    def fingerprint(self) -> str:
+        """Stable string for equality comparison in :attr:`RunMode.CHECK`.
+
+        Includes ``git_dirty`` so any uncommitted change invalidates CHECK and
+        falls back to a full restart.
+        """
+        parts = [
+            self.name or "",
+            self.version or "",
+            self.source,
+            self.git_sha or "",
+            "dirty" if self.git_dirty else "clean" if self.git_dirty is False else "",
+        ]
+        return "|".join(parts)
+
+    def short_label(self) -> str:
+        """Concise display label for the status window header (e.g. ``"pytest-fly 0.3.19 (abc1234-dirty)"``)."""
+        name = self.name or "unknown"
+        version = self.version or "?"
+        label = f"{name} {version}"
+        if self.git_sha:
+            suffix = self.git_sha
+            if self.git_dirty:
+                suffix += "-dirty"
+            label += f" ({suffix})"
+        elif self.git_dirty:
+            label += " (dirty)"
+        return label
+
+
+@dataclass(frozen=True)
 class PytestProcessInfo:
     """
     Information about a pytest process.
@@ -122,3 +171,5 @@ class PytestProcessInfo:
     time_stamp: float  # time stamp of the info update
     cpu_percent: float | None = None  # peak CPU usage during the run, as reported by psutil (100.0 = one full logical CPU; can exceed 100 on multi-core)
     memory_percent: float | None = None  # peak memory usage during the run (percent of total physical RAM)
+    put_version: str | None = None  # program-under-test short label (e.g. "pytest-fly 0.3.19 (abc1234)")
+    put_fingerprint: str | None = None  # program-under-test fingerprint for RunMode.CHECK comparison

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -57,6 +57,8 @@ class FlyPreferences(Pref):
 
     tooltip_line_limit: int = attrib(default=tooltip_line_limit_default)  # max lines of pytest output shown in a tooltip before truncation
 
+    target_project_path: str = attrib(default="")  # absolute path to the program under test; empty means auto-detect from cwd at run time
+
 
 def get_pref() -> FlyPreferences:
     """Return a :class:`FlyPreferences` instance (reads from / auto-saves to disk)."""

--- a/src/pytest_fly/put_version.py
+++ b/src/pytest_fly/put_version.py
@@ -1,0 +1,218 @@
+"""
+Program-under-test (PUT) version detection.
+
+Resolves the name, version, and git state of the project whose tests are being
+run by pytest-fly.  Called once per run from :class:`ControlWindow.run` and the
+result is stamped onto every :class:`PytestProcessInfo` record.
+
+Detection cascade (first hit wins), rooted at a ``project_root`` that defaults
+to the current working directory:
+
+1. Explicit override (from preferences).
+2. ``pyproject.toml`` walk-up: ``[project].name`` + ``[project].version``.
+3. ``setup.cfg`` ``[metadata]`` ``name`` + ``version``.
+4. ``importlib.metadata`` fallback — only when a package name was detected but
+   the version was dynamic or missing (e.g., hatch-dynamic or setuptools_scm
+   installed via ``pip install -e .``).
+
+Git metadata (describe, SHA, branch, dirty flag) is captured independently when
+a ``.git`` directory is present.  All helpers fail silently — detection never
+blocks a run.
+"""
+
+from __future__ import annotations
+
+import configparser
+import subprocess
+import tomllib
+from importlib import metadata
+from pathlib import Path
+
+from .interfaces import PutVersionInfo
+from .logger import get_logger
+
+log = get_logger()
+
+_GIT_TIMEOUT_SECONDS = 2.0
+
+
+def detect_put_version(project_root: Path | None = None, override: PutVersionInfo | None = None) -> PutVersionInfo:
+    """Detect the program-under-test metadata.
+
+    :param project_root: Directory to walk up from when searching for project
+        metadata.  Defaults to :func:`Path.cwd`.
+    :param override: If supplied, returned verbatim with ``source="override"``.
+    :return: A populated :class:`PutVersionInfo`.  Fields that could not be
+        determined are ``None``; callers must tolerate that.
+    """
+    if override is not None:
+        return override
+
+    root = (project_root or Path.cwd()).resolve()
+
+    name, version, source = None, None, "unknown"
+
+    pyproject_name, pyproject_version, pyproject_root = _read_pyproject(root)
+    if pyproject_name is not None or pyproject_version is not None:
+        name, version, source = pyproject_name, pyproject_version, "pyproject"
+        if pyproject_root is not None:
+            root = pyproject_root
+
+    if version is None:
+        cfg_name, cfg_version, cfg_root = _read_setup_cfg(root)
+        if cfg_name is not None or cfg_version is not None:
+            name = name or cfg_name
+            version = cfg_version
+            source = "setup.cfg"
+            if cfg_root is not None:
+                root = cfg_root
+
+    if version is None and name:
+        metadata_version = _importlib_metadata_version(name)
+        if metadata_version is not None:
+            version = metadata_version
+            source = "importlib.metadata"
+
+    git_describe, git_sha, git_branch, git_dirty = _collect_git_info(root)
+
+    return PutVersionInfo(
+        name=name,
+        version=version,
+        source=source,
+        git_describe=git_describe,
+        git_sha=git_sha,
+        git_branch=git_branch,
+        git_dirty=git_dirty,
+        project_root=str(root),
+    )
+
+
+def _walk_up_for_file(start: Path, filename: str) -> Path | None:
+    """Walk upward from *start* looking for *filename*.  Returns the containing directory or ``None``."""
+    current = start
+    seen: set[Path] = set()
+    while current not in seen:
+        seen.add(current)
+        candidate = current / filename
+        if candidate.is_file():
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+    return None
+
+
+def _read_pyproject(start: Path) -> tuple[str | None, str | None, Path | None]:
+    """Return ``(name, version_or_None_if_dynamic, project_root)`` from the nearest ``pyproject.toml``."""
+    project_dir = _walk_up_for_file(start, "pyproject.toml")
+    if project_dir is None:
+        return None, None, None
+    try:
+        with open(project_dir / "pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as e:
+        log.debug(f"could not parse pyproject.toml at {project_dir}: {e}")
+        return None, None, project_dir
+
+    project = data.get("project", {}) or {}
+    name = project.get("name")
+    version = project.get("version")
+    # Treat a pyproject that marks "version" as dynamic as version=None (fall through to importlib.metadata).
+    dynamic = project.get("dynamic") or []
+    if "version" in dynamic:
+        version = None
+    if not isinstance(name, str):
+        name = None
+    if not isinstance(version, str):
+        version = None
+    return name, version, project_dir
+
+
+def _read_setup_cfg(start: Path) -> tuple[str | None, str | None, Path | None]:
+    """Return ``(name, version, project_root)`` from the nearest ``setup.cfg``."""
+    project_dir = _walk_up_for_file(start, "setup.cfg")
+    if project_dir is None:
+        return None, None, None
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(project_dir / "setup.cfg", encoding="utf-8")
+    except (OSError, configparser.Error) as e:
+        log.debug(f"could not parse setup.cfg at {project_dir}: {e}")
+        return None, None, project_dir
+    if not parser.has_section("metadata"):
+        return None, None, project_dir
+    name = parser.get("metadata", "name", fallback=None)
+    version = parser.get("metadata", "version", fallback=None)
+    # setup.cfg can reference a file or attr for version; if it starts with "file:" / "attr:"
+    # we can't resolve it without executing setup.py, so treat as missing.
+    if version and version.strip().startswith(("file:", "attr:")):
+        version = None
+    return name, version, project_dir
+
+
+def _importlib_metadata_version(name: str) -> str | None:
+    """Return the installed version of *name* via :mod:`importlib.metadata`, or ``None``."""
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return None
+    except Exception as e:
+        log.debug(f"importlib.metadata lookup failed for {name!r}: {e}")
+        return None
+
+
+def _run_git(args: list[str], cwd: Path) -> str | None:
+    """Run ``git <args>`` in *cwd*.  Returns stripped stdout or ``None`` on any failure."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+        log.debug(f"git {args} failed in {cwd}: {e}")
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    return out if out else None
+
+
+def _is_git_repo(project_root: Path) -> bool:
+    """Return True if *project_root* is inside a git working tree."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _collect_git_info(project_root: Path) -> tuple[str | None, str | None, str | None, bool | None]:
+    """Return ``(describe, short_sha, branch, dirty)`` for the git repo at *project_root*.
+
+    All four values are ``None`` when git is unavailable or the directory is not a git repo.
+    """
+    if not _is_git_repo(project_root):
+        return None, None, None, None
+
+    describe = _run_git(["describe", "--tags", "--always", "--dirty"], project_root)
+    sha = _run_git(["rev-parse", "--short", "HEAD"], project_root)
+    branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], project_root)
+    # `git status --porcelain` returns empty string on clean, non-empty on dirty.
+    # _run_git returns None for empty stdout, so None here means clean (given we got this far).
+    status = _run_git(["status", "--porcelain"], project_root)
+    dirty = bool(status)
+    return describe, sha, branch, dirty

--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -32,7 +32,7 @@ class PytestProcess(Process):
     """
 
     @typechecked()
-    def __init__(self, run_guid: str, test: Path | str, data_dir: Path, update_rate: float) -> None:
+    def __init__(self, run_guid: str, test: Path | str, data_dir: Path, update_rate: float, put_version: str = "", put_fingerprint: str = "") -> None:
         """
         Pytest process for a single pytest test.
 
@@ -40,11 +40,15 @@ class PytestProcess(Process):
         :param test: the test to run
         :param data_dir: the directory to store coverage data in
         :param update_rate: the update rate for the process monitor
+        :param put_version: display label for the program under test (stamped on each DB record)
+        :param put_fingerprint: program-under-test fingerprint for RunMode.CHECK comparison
         """
         super().__init__(name=str(test))
         self.data_dir = data_dir
         self.run_guid = run_guid
         self.update_rate = update_rate
+        self.put_version = put_version
+        self.put_fingerprint = put_fingerprint
 
         self._process_monitor_process = None
 
@@ -56,7 +60,16 @@ class PytestProcess(Process):
 
         # update the pytest process info to show that the test is running
         with PytestProcessInfoDB(self.data_dir) as db:
-            pytest_process_info = PytestProcessInfo(self.run_guid, self.name, self.pid, PyTestFlyExitCode.NONE, None, time_stamp=time.time())
+            pytest_process_info = PytestProcessInfo(
+                self.run_guid,
+                self.name,
+                self.pid,
+                PyTestFlyExitCode.NONE,
+                None,
+                time_stamp=time.time(),
+                put_version=self.put_version,
+                put_fingerprint=self.put_fingerprint,
+            )
             db.write(pytest_process_info)
 
         # Finally, actually run pytest!
@@ -113,7 +126,18 @@ class PytestProcess(Process):
 
         # update the pytest process info to show that the test has finished
         with PytestProcessInfoDB(self.data_dir) as db:
-            pytest_process_info = PytestProcessInfo(self.run_guid, self.name, self.pid, exit_code, output, time.time(), peak_cpu, peak_memory)
+            pytest_process_info = PytestProcessInfo(
+                self.run_guid,
+                self.name,
+                self.pid,
+                exit_code,
+                output,
+                time.time(),
+                peak_cpu,
+                peak_memory,
+                put_version=self.put_version,
+                put_fingerprint=self.put_fingerprint,
+            )
             db.write(pytest_process_info)
 
         log.debug(f"{self.name=},{self.name},{exit_code=},{output=}")

--- a/src/pytest_fly/pytest_runner/pytest_runner.py
+++ b/src/pytest_fly/pytest_runner/pytest_runner.py
@@ -88,12 +88,23 @@ class PytestRunner(Thread):
     """
 
     @typechecked()
-    def __init__(self, run_guid: str, tests: list[ScheduledTest], number_of_processes: int, data_dir: Path, update_rate: float):
+    def __init__(
+        self,
+        run_guid: str,
+        tests: list[ScheduledTest],
+        number_of_processes: int,
+        data_dir: Path,
+        update_rate: float,
+        put_version: str = "",
+        put_fingerprint: str = "",
+    ):
         self.run_guid = run_guid
         self.tests = tests
         self.number_of_processes = number_of_processes
         self.data_dir = data_dir
         self.update_rate = update_rate
+        self.put_version = put_version
+        self.put_fingerprint = put_fingerprint
 
         self._test_runners = {}
         self._started_event = Event()
@@ -108,7 +119,16 @@ class PytestRunner(Thread):
         with PytestProcessInfoDB(self.data_dir) as db:
             for test in self.tests:
                 test_queue.put(test)
-                pytest_process_info = PytestProcessInfo(self.run_guid, test.node_id, None, PyTestFlyExitCode.NONE, None, time_stamp=time.time())  # queued
+                pytest_process_info = PytestProcessInfo(
+                    self.run_guid,
+                    test.node_id,
+                    None,
+                    PyTestFlyExitCode.NONE,
+                    None,
+                    time_stamp=time.time(),
+                    put_version=self.put_version,
+                    put_fingerprint=self.put_fingerprint,
+                )  # queued
                 db.write(pytest_process_info)
 
         # Singleton enforcement primitives (shared across all workers)
@@ -120,7 +140,18 @@ class PytestRunner(Thread):
         all_idle_event.set()  # no workers active initially
 
         for thread_number in range(self.number_of_processes):
-            test_runner = _TestRunner(self.run_guid, test_queue, self.data_dir, self.update_rate, singleton_event, active_count_lock, active_workers, all_idle_event)
+            test_runner = _TestRunner(
+                self.run_guid,
+                test_queue,
+                self.data_dir,
+                self.update_rate,
+                singleton_event,
+                active_count_lock,
+                active_workers,
+                all_idle_event,
+                put_version=self.put_version,
+                put_fingerprint=self.put_fingerprint,
+            )
             test_runner.start()
             self._test_runners[thread_number] = test_runner
         self._started_event.set()
@@ -194,6 +225,8 @@ class _TestRunner(Thread):
         active_count_lock: Lock,
         active_workers: list,
         all_idle_event: Event,
+        put_version: str = "",
+        put_fingerprint: str = "",
     ) -> None:
         """
         :param run_guid: GUID identifying the overall test run.
@@ -211,6 +244,8 @@ class _TestRunner(Thread):
         self.pytest_test_queue = pytest_test_queue
         self.data_dir = data_dir
         self.update_rate = update_rate
+        self.put_version = put_version
+        self.put_fingerprint = put_fingerprint
 
         self.process: Optional[PytestProcess] = None
         self._stop_event = Event()
@@ -265,7 +300,16 @@ class _TestRunner(Thread):
         if not proc.is_alive():
             log.info(f'process for test "{proc_name}" terminated ({self.run_guid=})')
             with PytestProcessInfoDB(self.data_dir) as db:
-                info = PytestProcessInfo(self.run_guid, test, None, PyTestFlyExitCode.TERMINATED, None, time_stamp=time.time())
+                info = PytestProcessInfo(
+                    self.run_guid,
+                    test,
+                    None,
+                    PyTestFlyExitCode.TERMINATED,
+                    None,
+                    time_stamp=time.time(),
+                    put_version=self.put_version,
+                    put_fingerprint=self.put_fingerprint,
+                )
                 db.write(info)
         else:
             self._force_kill_process(proc, proc_name)
@@ -319,7 +363,7 @@ class _TestRunner(Thread):
 
         self._increment_active()
         try:
-            self.process = PytestProcess(self.run_guid, test, self.data_dir, self.update_rate)
+            self.process = PytestProcess(self.run_guid, test, self.data_dir, self.update_rate, self.put_version, self.put_fingerprint)
             log.info(f'Starting process for test "{test}" ({self.run_guid=})')
             self.process.start()
 
@@ -409,5 +453,14 @@ class _TestRunner(Thread):
                     scheduled_test = self.pytest_test_queue.get(False)
                 except Empty:
                     break
-                info = PytestProcessInfo(self.run_guid, scheduled_test.node_id, None, PyTestFlyExitCode.STOPPED, None, time_stamp=time.time())
+                info = PytestProcessInfo(
+                    self.run_guid,
+                    scheduled_test.node_id,
+                    None,
+                    PyTestFlyExitCode.STOPPED,
+                    None,
+                    time_stamp=time.time(),
+                    put_version=self.put_version,
+                    put_fingerprint=self.put_fingerprint,
+                )
                 db.write(info)

--- a/src/pytest_fly/tick_data.py
+++ b/src/pytest_fly/tick_data.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from .interfaces import PytestProcessInfo
+from .interfaces import PutVersionInfo, PytestProcessInfo
 
 
 @dataclass
@@ -36,6 +36,7 @@ class TickData:
     last_pass_data: dict[str, tuple[float, float]] = field(default_factory=dict)  # test_name -> (start_timestamp, duration_seconds) from most recent passing run
     soft_stop_requested: bool = False
     singleton_names: set[str] = field(default_factory=set)  # node_ids of tests marked with @pytest.mark.singleton — displayed last in test-listing tabs
+    put_version_info: PutVersionInfo | None = None  # program-under-test metadata detected at the start of the current run
 
     @property
     def effective_min_time_stamp(self) -> float | None:

--- a/tests/test_put_version.py
+++ b/tests/test_put_version.py
@@ -1,0 +1,181 @@
+"""Tests for :mod:`pytest_fly.put_version` — program-under-test version detection."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from pytest_fly.interfaces import PutVersionInfo
+from pytest_fly.put_version import detect_put_version
+
+
+def _write_pyproject(tmp_path: Path, body: str) -> None:
+    (tmp_path / "pyproject.toml").write_text(body, encoding="utf-8")
+
+
+def _git_available() -> bool:
+    try:
+        subprocess.run(["git", "--version"], capture_output=True, timeout=2, check=False)
+        return True
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _init_git_repo(path: Path, *, commit: bool = True) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=str(path), check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(path), check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=str(path), check=True)
+    # Force master so the branch name is deterministic across git versions.
+    subprocess.run(["git", "checkout", "-q", "-b", "master"], cwd=str(path), check=True)
+    if commit:
+        subprocess.run(["git", "add", "-A"], cwd=str(path), check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "initial"], cwd=str(path), check=True)
+
+
+def test_pyproject_static_version(tmp_path):
+    _write_pyproject(tmp_path, '[project]\nname = "widget"\nversion = "1.2.3"\n')
+    info = detect_put_version(tmp_path)
+    assert info.name == "widget"
+    assert info.version == "1.2.3"
+    assert info.source == "pyproject"
+
+
+def test_pyproject_dynamic_version_without_install(tmp_path):
+    """Dynamic version and the package isn't installed — version should be None but name preserved."""
+    _write_pyproject(
+        tmp_path,
+        '[project]\nname = "definitely-not-installed-pkg-xyz-pytest-fly-test"\ndynamic = ["version"]\n',
+    )
+    info = detect_put_version(tmp_path)
+    assert info.name == "definitely-not-installed-pkg-xyz-pytest-fly-test"
+    assert info.version is None
+    # Source remains "pyproject" because the name came from there, even though the version fell through.
+    assert info.source == "pyproject"
+
+
+def test_pyproject_dynamic_version_with_installed_package(tmp_path):
+    """Dynamic version falls back to importlib.metadata when the package is installed (pytest is always installed)."""
+    _write_pyproject(tmp_path, '[project]\nname = "pytest"\ndynamic = ["version"]\n')
+    info = detect_put_version(tmp_path)
+    assert info.name == "pytest"
+    assert info.version is not None  # importlib.metadata resolved pytest
+    assert info.source == "importlib.metadata"
+
+
+def test_setup_cfg_only(tmp_path):
+    (tmp_path / "setup.cfg").write_text("[metadata]\nname = sample\nversion = 0.9.0\n", encoding="utf-8")
+    info = detect_put_version(tmp_path)
+    assert info.name == "sample"
+    assert info.version == "0.9.0"
+    assert info.source == "setup.cfg"
+
+
+def test_setup_cfg_file_reference_is_ignored(tmp_path):
+    """setup.cfg version of `file:` or `attr:` can't be resolved without executing setup.py — treated as missing."""
+    (tmp_path / "setup.cfg").write_text("[metadata]\nname = sample\nversion = file: VERSION\n", encoding="utf-8")
+    info = detect_put_version(tmp_path)
+    assert info.name == "sample"
+    assert info.version is None
+
+
+def test_no_metadata_no_git_unknown(tmp_path):
+    info = detect_put_version(tmp_path)
+    assert info.name is None
+    assert info.version is None
+    assert info.source == "unknown"
+    assert info.git_sha is None
+    assert info.git_dirty is None
+
+
+def test_override_returned_verbatim(tmp_path):
+    override = PutVersionInfo(
+        name="from-override",
+        version="9.9.9",
+        source="override",
+        git_describe=None,
+        git_sha=None,
+        git_branch=None,
+        git_dirty=None,
+        project_root=str(tmp_path),
+    )
+    info = detect_put_version(tmp_path, override=override)
+    assert info is override
+
+
+@pytest.mark.skipif(not _git_available(), reason="git is not available")
+def test_git_clean_tree(tmp_path):
+    _write_pyproject(tmp_path, '[project]\nname = "gitpkg"\nversion = "0.1.0"\n')
+    _init_git_repo(tmp_path, commit=True)
+    info = detect_put_version(tmp_path)
+    assert info.name == "gitpkg"
+    assert info.version == "0.1.0"
+    assert info.git_sha is not None
+    assert info.git_dirty is False
+    # fingerprint should encode the clean state
+    assert "clean" in info.fingerprint()
+
+
+@pytest.mark.skipif(not _git_available(), reason="git is not available")
+def test_git_dirty_changes_fingerprint(tmp_path):
+    _write_pyproject(tmp_path, '[project]\nname = "gitpkg"\nversion = "0.1.0"\n')
+    _init_git_repo(tmp_path, commit=True)
+    clean = detect_put_version(tmp_path)
+
+    # Make the tree dirty.
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "gitpkg"\nversion = "0.1.0"\n# dirty edit\n', encoding="utf-8")
+    dirty = detect_put_version(tmp_path)
+
+    assert clean.git_dirty is False
+    assert dirty.git_dirty is True
+    assert clean.fingerprint() != dirty.fingerprint()
+
+
+def test_short_label_includes_name_and_version():
+    info = PutVersionInfo(
+        name="widget",
+        version="1.2.3",
+        source="pyproject",
+        git_describe=None,
+        git_sha="abc1234",
+        git_branch="main",
+        git_dirty=False,
+        project_root="/some/path",
+    )
+    assert info.short_label() == "widget 1.2.3 (abc1234)"
+
+
+def test_short_label_with_dirty_suffix():
+    info = PutVersionInfo(
+        name="widget",
+        version="1.2.3",
+        source="pyproject",
+        git_describe=None,
+        git_sha="abc1234",
+        git_branch="main",
+        git_dirty=True,
+        project_root="/some/path",
+    )
+    assert info.short_label() == "widget 1.2.3 (abc1234-dirty)"
+
+
+def test_short_label_unknown_fallback():
+    info = PutVersionInfo(
+        name=None,
+        version=None,
+        source="unknown",
+        git_describe=None,
+        git_sha=None,
+        git_branch=None,
+        git_dirty=None,
+        project_root="/some/path",
+    )
+    assert info.short_label() == "unknown ?"
+
+
+def test_fingerprint_is_deterministic():
+    a = PutVersionInfo("p", "1", "pyproject", None, "abc", None, False, "/")
+    b = PutVersionInfo("p", "1", "pyproject", None, "abc", None, False, "/")
+    assert a.fingerprint() == b.fingerprint()
+
+    c = PutVersionInfo("p", "2", "pyproject", None, "abc", None, False, "/")
+    assert a.fingerprint() != c.fingerprint()


### PR DESCRIPTION
## Summary
- Detect the program-under-test's name, version, source (pyproject / setup.cfg / importlib.metadata fallback), and git state (SHA, branch, dirty) once per run; stamp onto every `PytestProcessInfo` record.
- Surface the detected label in the Status window header and the About tab; add a target-project-path preference with a Browse button on the Configuration tab.
- Wire the previously unreachable `RunMode.CHECK`: resume if the PUT fingerprint matches the prior run, otherwise restart. Dirty working tree always invalidates (safer for developers iterating on code).

## Test plan
- [x] `python -m pytest tests/test_put_version.py` — 13 new unit tests (pyproject static/dynamic, setup.cfg, importlib.metadata fallback, override, git clean/dirty fingerprint, unknown fallback, label formatting)
- [x] `python -m pytest tests/test_pytest_runner/` — simple, multiprocess, resume, singleton, soft_stop, stop all pass (new fields flow through to every DB record)
- [x] `python -m pytest tests/test_interfaces.py tests/test_pytest_process_info_db.py tests/test_pytest_process.py tests/test_time_axis.py tests/test_coverage_calculation.py tests/test_platform.py tests/test_file_util.py tests/test_uuid.py`
- [x] `python -m ruff check src tests && python -m ruff format --check src tests` — clean
- [ ] Manual: launch `python -m pytest_fly`, verify PUT header in Status window and full block on About tab; toggle Check mode and confirm log output on matching/changed fingerprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)