### PR TITLE
Strip trailing blank lines in table tooltips — v0.3.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.20"
+version = "0.3.21"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -227,6 +227,10 @@ def tool_tip_limiter(text: str | None, line_limit: int | None = None) -> str:
         line_limit = get_pref().tooltip_line_limit
     source = _extract_pytest_failure_section(text) or text
     lines = source.splitlines()
+    # Trailing whitespace-only lines would otherwise dominate the tooltip — stripping them
+    # here keeps the line-limit budget spent on meaningful content.
+    while lines and not lines[-1].strip():
+        lines.pop()
     if len(lines) > line_limit:
-        return "...\n" + "\n".join(lines[len(lines) - line_limit :])
-    return source
+        return "...\n" + "\n".join(lines[-line_limit:])
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Strip trailing whitespace-only lines in `tool_tip_limiter` before applying the line limit so real failure content keeps its place in the tooltip.
- Bump to v0.3.21.

## Test plan
- [ ] Trigger a failing test whose pytest output ends with blank lines and confirm the tooltip no longer has a large blank tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)