### PR TITLE
Unify About box program-under-test section — v0.3.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.21"
+version = "0.3.22"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/about_tab/about.py
+++ b/src/pytest_fly/gui/about_tab/about.py
@@ -7,12 +7,15 @@ import humanize
 from PySide6.QtCore import QObject, QThread, Signal
 from PySide6.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
 
-from pytest_fly.gui.about_tab.project_info import get_project_info
 from pytest_fly.gui.gui_util import PlainTextWidget
 from pytest_fly.logger import get_log_directory
 from pytest_fly.platform.platform_info import get_performance_core_count, get_platform_info
 from pytest_fly.preferences import get_pref
 from pytest_fly.put_version import detect_put_version
+
+# Preferred display order for Program Under Test fields; any fields not listed
+# here are appended in dataclass declaration order.
+_PUT_FIELD_ORDER = ("name", "version", "author", "source", "git_describe", "git_sha", "git_branch", "git_dirty", "project_root")
 
 
 class AboutDataWorker(QObject):
@@ -24,15 +27,16 @@ class AboutDataWorker(QObject):
 
     def run(self):
         text_lines = []
-        for key, value in asdict(get_project_info()).items():
-            text_lines.append(f"{key}: {value}")
-        text_lines.append("")
 
         pref = get_pref()
         project_root = Path(pref.target_project_path).resolve() if pref.target_project_path else Path.cwd()
         put_info = detect_put_version(project_root)
+        put_fields = asdict(put_info)
         text_lines.append("Program Under Test:")
-        for key, value in asdict(put_info).items():
+        for key in _PUT_FIELD_ORDER:
+            if key in put_fields:
+                text_lines.append(f"    {key}: {put_fields.pop(key)}")
+        for key, value in put_fields.items():
             text_lines.append(f"    {key}: {value}")
         text_lines.append("")
 

--- a/src/pytest_fly/interfaces.py
+++ b/src/pytest_fly/interfaces.py
@@ -126,6 +126,7 @@ class PutVersionInfo:
     git_branch: str | None
     git_dirty: bool | None  # True if working tree has uncommitted changes
     project_root: str  # absolute path used for detection
+    author: str | None = None  # first author listed in pyproject.toml or setup.cfg, if any
 
     def fingerprint(self) -> str:
         """Stable string for equality comparison in :attr:`RunMode.CHECK`.

--- a/src/pytest_fly/put_version.py
+++ b/src/pytest_fly/put_version.py
@@ -50,19 +50,21 @@ def detect_put_version(project_root: Path | None = None, override: PutVersionInf
 
     root = (project_root or Path.cwd()).resolve()
 
-    name, version, source = None, None, "unknown"
+    name, version, author, source = None, None, None, "unknown"
 
-    pyproject_name, pyproject_version, pyproject_root = _read_pyproject(root)
+    pyproject_name, pyproject_version, pyproject_author, pyproject_root = _read_pyproject(root)
     if pyproject_name is not None or pyproject_version is not None:
         name, version, source = pyproject_name, pyproject_version, "pyproject"
+        author = pyproject_author
         if pyproject_root is not None:
             root = pyproject_root
 
     if version is None:
-        cfg_name, cfg_version, cfg_root = _read_setup_cfg(root)
+        cfg_name, cfg_version, cfg_author, cfg_root = _read_setup_cfg(root)
         if cfg_name is not None or cfg_version is not None:
             name = name or cfg_name
             version = cfg_version
+            author = author or cfg_author
             source = "setup.cfg"
             if cfg_root is not None:
                 root = cfg_root
@@ -84,6 +86,7 @@ def detect_put_version(project_root: Path | None = None, override: PutVersionInf
         git_branch=git_branch,
         git_dirty=git_dirty,
         project_root=str(root),
+        author=author,
     )
 
 
@@ -103,17 +106,17 @@ def _walk_up_for_file(start: Path, filename: str) -> Path | None:
     return None
 
 
-def _read_pyproject(start: Path) -> tuple[str | None, str | None, Path | None]:
-    """Return ``(name, version_or_None_if_dynamic, project_root)`` from the nearest ``pyproject.toml``."""
+def _read_pyproject(start: Path) -> tuple[str | None, str | None, str | None, Path | None]:
+    """Return ``(name, version_or_None_if_dynamic, author, project_root)`` from the nearest ``pyproject.toml``."""
     project_dir = _walk_up_for_file(start, "pyproject.toml")
     if project_dir is None:
-        return None, None, None
+        return None, None, None, None
     try:
         with open(project_dir / "pyproject.toml", "rb") as f:
             data = tomllib.load(f)
     except (OSError, tomllib.TOMLDecodeError) as e:
         log.debug(f"could not parse pyproject.toml at {project_dir}: {e}")
-        return None, None, project_dir
+        return None, None, None, project_dir
 
     project = data.get("project", {}) or {}
     name = project.get("name")
@@ -126,29 +129,39 @@ def _read_pyproject(start: Path) -> tuple[str | None, str | None, Path | None]:
         name = None
     if not isinstance(version, str):
         version = None
-    return name, version, project_dir
+    authors = project.get("authors") or []
+    author: str | None = None
+    if isinstance(authors, list):
+        for entry in authors:
+            if isinstance(entry, dict):
+                candidate = entry.get("name") or entry.get("email")
+                if isinstance(candidate, str) and candidate:
+                    author = candidate
+                    break
+    return name, version, author, project_dir
 
 
-def _read_setup_cfg(start: Path) -> tuple[str | None, str | None, Path | None]:
-    """Return ``(name, version, project_root)`` from the nearest ``setup.cfg``."""
+def _read_setup_cfg(start: Path) -> tuple[str | None, str | None, str | None, Path | None]:
+    """Return ``(name, version, author, project_root)`` from the nearest ``setup.cfg``."""
     project_dir = _walk_up_for_file(start, "setup.cfg")
     if project_dir is None:
-        return None, None, None
+        return None, None, None, None
     parser = configparser.ConfigParser()
     try:
         parser.read(project_dir / "setup.cfg", encoding="utf-8")
     except (OSError, configparser.Error) as e:
         log.debug(f"could not parse setup.cfg at {project_dir}: {e}")
-        return None, None, project_dir
+        return None, None, None, project_dir
     if not parser.has_section("metadata"):
-        return None, None, project_dir
+        return None, None, None, project_dir
     name = parser.get("metadata", "name", fallback=None)
     version = parser.get("metadata", "version", fallback=None)
     # setup.cfg can reference a file or attr for version; if it starts with "file:" / "attr:"
     # we can't resolve it without executing setup.py, so treat as missing.
     if version and version.strip().startswith(("file:", "attr:")):
         version = None
-    return name, version, project_dir
+    author = parser.get("metadata", "author", fallback=None) or parser.get("metadata", "author_email", fallback=None)
+    return name, version, author, project_dir
 
 
 def _importlib_metadata_version(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Drop the redundant `get_project_info()` block from the About tab — the tab now shows a single, ordered `Program Under Test:` section.
- Add an `author` field to `PutVersionInfo` populated from `pyproject.toml`'s `[project].authors` (falls back to `setup.cfg`'s `[metadata].author`).

## Test plan
- [ ] Open the About tab and confirm a single `Program Under Test:` section appears with `name`, `version`, `author`, `source`, and git metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)