### PR TITLE
Add pytest-fly metadata to About box, unify tooltip formatting — v0.3.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.22"
+version = "0.3.23"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/about_tab/about.py
+++ b/src/pytest_fly/gui/about_tab/about.py
@@ -7,6 +7,7 @@ import humanize
 from PySide6.QtCore import QObject, QThread, Signal
 from PySide6.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
 
+from pytest_fly.gui.about_tab.project_info import get_project_info
 from pytest_fly.gui.gui_util import PlainTextWidget
 from pytest_fly.logger import get_log_directory
 from pytest_fly.platform.platform_info import get_performance_core_count, get_platform_info
@@ -16,6 +17,9 @@ from pytest_fly.put_version import detect_put_version
 # Preferred display order for Program Under Test fields; any fields not listed
 # here are appended in dataclass declaration order.
 _PUT_FIELD_ORDER = ("name", "version", "author", "source", "git_describe", "git_sha", "git_branch", "git_dirty", "project_root")
+
+# Display order for pytest-fly's own metadata fields.
+_PYTEST_FLY_FIELD_ORDER = ("name", "version", "description", "author", "license", "home_url", "repository_url")
 
 
 class AboutDataWorker(QObject):
@@ -27,6 +31,23 @@ class AboutDataWorker(QObject):
 
     def run(self):
         text_lines = []
+
+        fly_info = get_project_info()
+        fly_fields = {
+            "name": fly_info.application_name,
+            "version": fly_info.version,
+            "description": fly_info.description,
+            "author": fly_info.author,
+            "license": fly_info.license,
+            "home_url": fly_info.home_url,
+            "repository_url": fly_info.repository_url,
+        }
+        text_lines.append("pytest-fly:")
+        for key in _PYTEST_FLY_FIELD_ORDER:
+            value = fly_fields.get(key)
+            if value:
+                text_lines.append(f"    {key}: {value}")
+        text_lines.append("")
 
         pref = get_pref()
         project_root = Path(pref.target_project_path).resolve() if pref.target_project_path else Path.cwd()

--- a/src/pytest_fly/gui/about_tab/project_info.py
+++ b/src/pytest_fly/gui/about_tab/project_info.py
@@ -1,9 +1,15 @@
-"""Reads project metadata (name, version, author) from ``pyproject.toml``."""
+"""Reads pytest-fly's own project metadata (name, version, author, license, URLs)."""
+
+from __future__ import annotations
 
 import tomllib
 from dataclasses import dataclass
 from functools import cache
+from importlib import metadata
 from pathlib import Path
+
+_PACKAGE_NAME = "pytest-fly"
+_UNKNOWN = "Unknown"
 
 
 @dataclass(frozen=True)
@@ -11,36 +17,133 @@ class ProjectInfo:
     application_name: str
     author: str
     version: str
+    license: str = _UNKNOWN
+    description: str = _UNKNOWN
+    home_url: str = _UNKNOWN
+    repository_url: str = _UNKNOWN
 
     def __str__(self):
         return f"{self.application_name}\n{self.version}\n{self.author}"
 
 
+def _license_from_classifiers(classifiers) -> str | None:
+    for classifier in classifiers or []:
+        if isinstance(classifier, str) and classifier.startswith("License ::"):
+            tail = classifier.split("::")[-1].strip()
+            if tail:
+                return tail
+    return None
+
+
+def _from_installed_metadata() -> ProjectInfo | None:
+    try:
+        meta = metadata.metadata(_PACKAGE_NAME)
+    except metadata.PackageNotFoundError:
+        return None
+
+    name = meta.get("Name") or _UNKNOWN
+    version = meta.get("Version") or _UNKNOWN
+    author = meta.get("Author") or meta.get("Author-email") or _UNKNOWN
+    description = meta.get("Summary") or _UNKNOWN
+
+    license_name = _license_from_classifiers(meta.get_all("Classifier")) or meta.get("License-Expression") or meta.get("License") or _UNKNOWN
+    # A License field copied from a file can be many lines; keep the first non-empty line.
+    if license_name and license_name != _UNKNOWN:
+        for line in license_name.splitlines():
+            stripped = line.strip()
+            if stripped:
+                license_name = stripped
+                break
+
+    home_url = _UNKNOWN
+    repository_url = _UNKNOWN
+    for value in meta.get_all("Project-URL") or []:
+        label, _, url = value.partition(",")
+        key = label.strip().lower()
+        url = url.strip()
+        if key in ("home", "homepage") and home_url == _UNKNOWN:
+            home_url = url
+        elif key in ("repository", "source") and repository_url == _UNKNOWN:
+            repository_url = url
+    home_page = meta.get("Home-page")
+    if home_url == _UNKNOWN and home_page:
+        home_url = home_page
+    if repository_url == _UNKNOWN and home_url != _UNKNOWN:
+        repository_url = home_url
+    if home_url == _UNKNOWN and repository_url != _UNKNOWN:
+        home_url = repository_url
+
+    return ProjectInfo(
+        application_name=name,
+        author=author,
+        version=version,
+        license=license_name,
+        description=description,
+        home_url=home_url,
+        repository_url=repository_url,
+    )
+
+
+def _from_pyproject() -> ProjectInfo | None:
+    pyproject_dir = Path(__file__).resolve().parent
+    pyproject_data = None
+    while True:
+        pyproject_path = pyproject_dir / "pyproject.toml"
+        if pyproject_path.is_file():
+            try:
+                with open(pyproject_path, "rb") as file:
+                    pyproject_data = tomllib.load(file)
+            except (OSError, tomllib.TOMLDecodeError):
+                return None
+            break
+        parent = pyproject_dir.parent
+        if parent == pyproject_dir:
+            return None
+        pyproject_dir = parent
+
+    project = pyproject_data.get("project", {}) or {}
+    name = project.get("name", _UNKNOWN)
+    version = project.get("version", _UNKNOWN)
+    description = project.get("description", _UNKNOWN)
+    authors = project.get("authors", []) or []
+    author = authors[0].get("name", _UNKNOWN) if authors else _UNKNOWN
+
+    license_name = _license_from_classifiers(project.get("classifiers"))
+    if not license_name:
+        license_obj = project.get("license")
+        if isinstance(license_obj, str):
+            license_name = license_obj
+        elif isinstance(license_obj, dict) and "text" in license_obj:
+            license_name = license_obj["text"]
+    if not license_name:
+        license_name = _UNKNOWN
+
+    urls = project.get("urls", {}) or {}
+    home_url = urls.get("Home") or urls.get("Homepage") or _UNKNOWN
+    repository_url = urls.get("Repository") or urls.get("Source") or home_url
+
+    return ProjectInfo(
+        application_name=name,
+        author=author,
+        version=version,
+        license=license_name,
+        description=description,
+        home_url=home_url,
+        repository_url=repository_url,
+    )
+
+
 @cache
 def get_project_info() -> ProjectInfo:
-    pyproject_dir = Path(__file__).resolve().parent
-
-    pyproject_data = None
-    while pyproject_data is None:
-        pyproject_path = Path(pyproject_dir, "pyproject.toml")
-        if pyproject_path.exists() and pyproject_path.is_file():
-            with open(pyproject_path, "rb") as file:
-                pyproject_data = tomllib.load(file)
-                break
-        else:
-            pyproject_dir = pyproject_dir.parent
-            if len(str(pyproject_dir)) < 10:
-                break
-
-    if pyproject_data is None:
-        project_info = ProjectInfo("Unknown", "Unknown", "Unknown")
-    else:
-        project_info_dict = pyproject_data.get("project", {})
-        application_name = project_info_dict.get("name", "Unknown")
-        version = project_info_dict.get("version", "Unknown")
-        authors = project_info_dict.get("authors", [])
-        author = authors[0].get("name", "Unknown") if authors else "Unknown"
-
-        project_info = ProjectInfo(application_name, author, version)
-
-    return project_info
+    # Prefer pyproject.toml when running from a source checkout so the version
+    # matches the code actually executing; fall back to installed metadata for
+    # wheel installs where pyproject.toml isn't shipped.
+    info = _from_pyproject()
+    if info is not None and info.version != _UNKNOWN:
+        return info
+    fallback = _from_installed_metadata()
+    if fallback is not None:
+        return fallback
+    if info is not None:
+        return info
+    return ProjectInfo(_UNKNOWN, _UNKNOWN, _UNKNOWN)

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -196,41 +196,42 @@ def window_text_color(widget: QWidget) -> QColor:
     return widget.palette().color(QPalette.WindowText)
 
 
-def _extract_pytest_failure_section(text: str) -> str | None:
-    """Return the pytest FAILURES section (plus any trailing short-summary) or None if not present.
-
-    Pytest emits a banner like ``==== FAILURES ====`` before per-test tracebacks.
-    The interesting content for a failing run lives from that banner through the
-    end of the output — teardown logs typically appear *before* it, so trimming
-    to this region keeps the actual failure details visible in the tooltip.
-    """
-    lines = text.splitlines()
-    for i, line in enumerate(lines):
-        if line.strip("= ") == "FAILURES":
-            return "\n".join(lines[i:])
-    return None
+# Per-line width cap. Pytest tracebacks and captured-output lines are often 200+ chars
+# wide, which makes Qt's tooltip balloon stretch off-screen. Truncate to a readable width.
+_TOOLTIP_WIDTH_LIMIT = 120
 
 
 @typechecked
-def tool_tip_limiter(text: str | None, line_limit: int | None = None) -> str:
+def tool_tip_limiter(text: str | None, line_limit: int | None = None, width_limit: int = _TOOLTIP_WIDTH_LIMIT) -> str:
     """
-    Prepare tooltip text from pytest output: prefer the FAILURES section when present,
-    then cap at *line_limit* lines (falling back to the user preference).
+    Prepare tooltip text from pytest output: keep the last *line_limit* lines
+    (falling back to the user preference) and truncate any individual lines longer
+    than *width_limit* characters. Applied identically to PASS and FAIL output —
+    for a FAIL run the tail naturally contains the FAILURES section and short
+    summary; for a PASS run it contains the session summary.
 
     :param text: The original tooltip text
     :param line_limit: Max lines to show; if None, reads from user preferences
+    :param width_limit: Max characters per line before ellipsizing
     :return: The limited tooltip text
     """
     if text is None:
         return ""
     if line_limit is None:
         line_limit = get_pref().tooltip_line_limit
-    source = _extract_pytest_failure_section(text) or text
-    lines = source.splitlines()
+
+    lines = text.splitlines()
     # Trailing whitespace-only lines would otherwise dominate the tooltip — stripping them
     # here keeps the line-limit budget spent on meaningful content.
     while lines and not lines[-1].strip():
         lines.pop()
-    if len(lines) > line_limit:
-        return "...\n" + "\n".join(lines[-line_limit:])
-    return "\n".join(lines)
+
+    truncated = len(lines) > line_limit
+    if truncated:
+        lines = lines[-line_limit:]
+
+    if width_limit > 3:
+        lines = [line if len(line) <= width_limit else line[: width_limit - 3] + "..." for line in lines]
+
+    body = "\n".join(lines)
+    return "...\n" + body if truncated else body

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -22,7 +22,7 @@ refresh_rate_default = 3.0
 utilization_high_threshold_default = 0.8
 utilization_low_threshold_default = 0.5
 run_with_coverage_default = True
-tooltip_line_limit_default = 200  # max lines shown in pytest-output tooltips before truncation
+tooltip_line_limit_default = 40  # max lines shown in pytest-output tooltips before truncation
 
 
 class ParallelismControl(IntEnum):


### PR DESCRIPTION
## Summary
- About tab now shows pytest-fly's own name, version, description, author, license, and home/repository URLs at the top, sourced from `pyproject.toml` (with `importlib.metadata` as a wheel-install fallback).
- Unified `tool_tip_limiter`: one tail + width-cap path for both PASS and FAIL output. Removed the FAILURES-section extraction and the PASS-specific line cap — the tail naturally contains the failures + short summary on a FAIL and the session summary on a PASS.
- Added a 120-character per-line width cap so long tracebacks no longer stretch the tooltip balloon off-screen.
- Lowered `tooltip_line_limit_default` from 200 to 40 so the unified cap keeps PASS tooltips readable out-of-the-box; users who want longer FAIL tracebacks can raise it in the Configuration tab.

## Test plan
- [x] `pytest tests/ -k "tooltip or tool_tip or table or about"` passes
- [ ] Launch the GUI and confirm the About tab shows the new `pytest-fly:` section
- [ ] Hover a PASS row and confirm the tooltip is concise
- [ ] Hover a FAIL row and confirm the FAILURES tail is visible with lines capped at 120 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)