### PR TITLE
Add per-tick performance logging to diagnose UI lag — v0.3.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.23"
+version = "0.3.24"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -73,6 +73,13 @@ class Configuration(QWidget):
         self.verbose_checkbox.stateChanged.connect(self.update_verbose)
         layout.addWidget(self.verbose_checkbox)
 
+        # Performance logging — logs per-tick phase timings to diagnose UI lag.
+        self.perf_logging_checkbox = QCheckBox("Performance Logging")
+        self.perf_logging_checkbox.setToolTip("Log per-tick phase timings (DB query, tab updates, etc.) to help diagnose UI lag.")
+        self.perf_logging_checkbox.setChecked(to_bool_strict(pref.perf_logging))
+        self.perf_logging_checkbox.stateChanged.connect(self.update_perf_logging)
+        layout.addWidget(self.perf_logging_checkbox)
+
         layout.addWidget(QLabel(""))  # space
 
         # Test order option
@@ -124,6 +131,11 @@ class Configuration(QWidget):
         """Persist the verbose checkbox state to preferences."""
         pref = get_pref()
         pref.verbose = self.verbose_checkbox.isChecked()
+
+    def update_perf_logging(self):
+        """Persist the performance-logging checkbox state to preferences."""
+        pref = get_pref()
+        pref.perf_logging = self.perf_logging_checkbox.isChecked()
 
     def update_test_order(self):
         """Persist the test order preference based on the checkbox state."""

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -7,6 +7,7 @@ between the :class:`~pytest_fly.db.PytestProcessInfoDB`, the
 GUI tabs.
 """
 
+import time
 from pathlib import Path
 
 from PySide6.QtCore import QCoreApplication, QRect, QTimer
@@ -21,7 +22,7 @@ from typeguard import typechecked
 
 from ..__version__ import application_name
 from ..db import PytestProcessInfoDB
-from ..interfaces import PutVersionInfo
+from ..interfaces import PutVersionInfo, PytestRunnerState
 from ..logger import get_logger
 from ..preferences import get_pref
 from ..pytest_runner.pytest_runner import PytestRunState
@@ -31,7 +32,7 @@ from .configuration_tab.configuration import Configuration
 from .coverage_tab import CoverageTab
 from .coverage_tracker import CoverageTracker
 from .graph_tab import GraphTab
-from .gui_util import compute_average_parallelism, compute_time_window, get_font, get_text_dimensions, group_process_infos_by_name
+from .gui_util import PhaseTimer, compute_average_parallelism, compute_time_window, get_font, get_text_dimensions, group_process_infos_by_name
 from .run_tab import RunTab
 from .table_tab import TableTab
 
@@ -198,31 +199,54 @@ class FlyAppMainWindow(QMainWindow):
         typical result sets).  Grouping, time-window, and run-state computation
         happen once in :func:`build_tick_data` and the resulting :class:`TickData`
         is shared across all tabs.
+
+        Per-phase wall-clock timings are captured via :class:`PhaseTimer` and
+        emitted once per tick to help diagnose UI lag.  Logged at ``info`` when
+        ``pref.perf_logging`` is enabled, otherwise at ``debug``.
         """
+        timer = PhaseTimer()
+        tick_start = time.perf_counter()
+
         with PytestProcessInfoDB(self.data_dir) as db:
-            process_infos = db.query(self.run_tab.control_window.run_guid)
-            last_pass_data = db.query_last_pass()
+            with timer.time("db_query"):
+                process_infos = db.query(self.run_tab.control_window.run_guid)
+            with timer.time("db_last_pass"):
+                last_pass_data = db.query_last_pass()
 
         control = self.run_tab.control_window
-        tick = build_tick_data(
-            process_infos,
-            prior_durations=control.prior_durations,
-            num_processes=control.num_processes,
-            current_run_start=control.current_run_start,
-            singleton_names=control.singleton_names,
-            put_version_info=control.put_version_info,
-        )
-        tick.last_pass_data = last_pass_data
-        tick.soft_stop_requested = control._soft_stop_requested
+        with timer.time("build"):
+            tick = build_tick_data(
+                process_infos,
+                prior_durations=control.prior_durations,
+                num_processes=control.num_processes,
+                current_run_start=control.current_run_start,
+                singleton_names=control.singleton_names,
+                put_version_info=control.put_version_info,
+            )
+            tick.last_pass_data = last_pass_data
+            tick.soft_stop_requested = control._soft_stop_requested
 
-        self._coverage_tracker.handle_new_run(control.run_guid)
-        self._coverage_tracker.update(tick)
-        self._coverage_tracker.apply_to_tick(tick)
+        with timer.time("cov"):
+            self._coverage_tracker.handle_new_run(control.run_guid)
+            self._coverage_tracker.update(tick)
+            self._coverage_tracker.apply_to_tick(tick)
 
-        self.graph_tab.update_tick(tick)
-        self.table_tab.update_tick(tick)
-        self.run_tab.update_tick(tick)
-        self.coverage_tab.update_tick(tick)
+        with timer.time("graph"):
+            self.graph_tab.update_tick(tick)
+        with timer.time("table"):
+            self.table_tab.update_tick(tick)
+        with timer.time("run"):
+            self.run_tab.update_tick(tick)
+        with timer.time("cov_tab"):
+            self.coverage_tab.update_tick(tick)
+
+        total_ms = (time.perf_counter() - tick_start) * 1000.0
+        n_completed = sum(1 for rs in tick.run_states.values() if rs.get_state() in (PytestRunnerState.PASS, PytestRunnerState.FAIL))
+        message = f"tick total={total_ms:.1f}ms {timer.format()} n_rows={len(process_infos)} n_tests={len(tick.infos_by_name)} n_completed={n_completed}"
+        if get_pref().perf_logging:
+            log.info(message)
+        else:
+            log.debug(message)
 
 
 @typechecked()

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -84,6 +84,44 @@ class PlainTextWidget(QPlainTextEdit):
         self.updateGeometry()
 
 
+class PhaseTimer:
+    """Record elapsed wall-clock time (milliseconds) for named phases of a single operation.
+
+    Usage::
+
+        timer = PhaseTimer()
+        with timer.time("db_query"):
+            ...
+        with timer.time("build"):
+            ...
+        log.info(timer.format())  # "db_query=18.1 build=9.3"
+
+    Durations are stored in insertion order so the formatted output is stable.
+    """
+
+    def __init__(self) -> None:
+        self.phases: dict[str, float] = {}
+        self._current_name: str | None = None
+        self._current_start: float | None = None
+
+    def time(self, name: str) -> "PhaseTimer":
+        self._current_name = name
+        return self
+
+    def __enter__(self) -> "PhaseTimer":
+        self._current_start = time.perf_counter()
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        assert self._current_name is not None and self._current_start is not None
+        self.phases[self._current_name] = (time.perf_counter() - self._current_start) * 1000.0
+        self._current_name = None
+        self._current_start = None
+
+    def format(self) -> str:
+        return " ".join(f"{name}={ms:.1f}" for name, ms in self.phases.items())
+
+
 def group_process_infos_by_name(process_infos: list[PytestProcessInfo]) -> dict[str, list[PytestProcessInfo]]:
     """
     Group a flat list of process info records by test name.

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -59,6 +59,8 @@ class FlyPreferences(Pref):
 
     target_project_path: str = attrib(default="")  # absolute path to the program under test; empty means auto-detect from cwd at run time
 
+    perf_logging: bool = attrib(default=False)  # log per-tick phase timings (db query, build_tick_data, each tab update) to diagnose UI lag
+
 
 def get_pref() -> FlyPreferences:
     """Return a :class:`FlyPreferences` instance (reads from / auto-saves to disk)."""


### PR DESCRIPTION
## Summary
- Add `PhaseTimer` helper in `gui_util.py` and instrument `FlyAppMainWindow._update_tick` so each tick emits one structured log line with per-phase durations (`db_query`, `db_last_pass`, `build`, `cov`, `graph`, `table`, `run`, `cov_tab`) plus row/test/completed counters.
- Add a `perf_logging` preference (default `False`) and expose it as a **Performance Logging** checkbox on the Configuration tab — toggle from the GUI, no manual DB edit needed.
- Gated logging level: `log.info` when the pref is on, else `log.debug` — so enabling it surfaces the data in the normal Balsa log without a log-level change.
- Bump to v0.3.24.

Motivation: on a ~200-test suite the GUI goes laggy mid-run and we had no data on where the time goes. This PR adds the measurement; the follow-up fix comes once the dominant phase is known.

## Test plan
- [ ] `python -m ruff check src` passes
- [ ] Launch the app, open Configuration → toggle **Performance Logging** on
- [ ] Run a small suite and confirm one `tick total=... db_query=... ...` line appears in the log per `refresh_rate` seconds
- [ ] Run against a larger suite (~200 tests) and confirm the phase breakdown is visible
- [ ] Toggle off and confirm lines drop back to debug level

🤖 Generated with [Claude Code](https://claude.com/claude-code)