### PR TITLE
Update table tab in place to reduce UI lag — v0.3.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.24"
+version = "0.3.25"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from enum import Enum
 
 from PySide6.QtCore import QPoint, Qt, Signal
-from PySide6.QtGui import QColor, QGuiApplication
+from PySide6.QtGui import QBrush, QColor, QGuiApplication
 from PySide6.QtWidgets import QGroupBox, QMenu, QScrollArea, QTableWidget, QTableWidgetItem, QVBoxLayout
 
 from ...gui.gui_util import format_runtime, tool_tip_limiter
@@ -34,7 +34,8 @@ def set_utilization_color(item: QTableWidgetItem, value: float):
     Colorize a table cell based on utilization thresholds from user preferences.
 
     Red if above the high threshold, yellow if above the low threshold,
-    otherwise the default color is kept.
+    otherwise the default foreground is restored (important for in-place
+    updates where a previously-colored item may drop back below threshold).
 
     :param item: The table-widget item to colorize.
     :param value: Utilization value in the range ``[0.0, 1.0]``.
@@ -45,7 +46,7 @@ def set_utilization_color(item: QTableWidgetItem, value: float):
     elif value > pref.utilization_low_threshold:
         item.setForeground(QColor("yellow"))
     else:
-        return
+        item.setForeground(QBrush())
 
 
 class TableTab(QGroupBox):
@@ -77,6 +78,7 @@ class TableTab(QGroupBox):
 
         self._current_run_states: dict = {}
         self._current_infos_by_name: dict = {}  # test node_id -> list[PytestProcessInfo]; source for full (untruncated) copy-to-clipboard
+        self._row_by_name: dict[str, int] = {}  # test_name -> row index, for in-place updates
 
     def show_context_menu(self, position: QPoint):
         """Show a right-click context menu allowing the user to copy pytest output or force-stop a running test.
@@ -155,88 +157,140 @@ class TableTab(QGroupBox):
     def reset(self):
         """Clear all table rows."""
         self.table_widget.setRowCount(0)
+        self._row_by_name.clear()
+
+    def _get_or_create_item(self, row: int, col: int) -> QTableWidgetItem:
+        item = self.table_widget.item(row, col)
+        if item is None:
+            item = QTableWidgetItem()
+            self.table_widget.setItem(row, col, item)
+        return item
+
+    @staticmethod
+    def _set_text_if_changed(item: QTableWidgetItem, text: str) -> None:
+        if item.text() != text:
+            item.setText(text)
+
+    @staticmethod
+    def _set_tooltip_if_changed(item: QTableWidgetItem, tooltip: str) -> None:
+        if item.toolTip() != tooltip:
+            item.setToolTip(tooltip)
+            item.setData(Qt.ItemDataRole.ToolTipRole, tooltip)
 
     def update_tick(self, tick: TickData):
-        """Refresh the table from pre-computed tick data."""
+        """Refresh the table in place from pre-computed tick data.
+
+        Rows persist across ticks and are keyed by test node_id via
+        ``_row_by_name``. Only cells whose text or tooltip actually changed
+        are rewritten; ``resizeColumnsToContents()`` runs only when new rows
+        are appended. If the set of tests shrinks (e.g., after a reset) the
+        table is fully rebuilt.
+        """
 
         self._current_run_states = tick.run_states
         self._current_infos_by_name = tick.infos_by_name
 
-        self.table_widget.clearContents()
-        self.table_widget.setRowCount(len(tick.infos_by_name))
+        # If any previously-known test is no longer present, fall back to a rebuild.
+        current_names = tick.infos_by_name.keys()
+        if self._row_by_name and not self._row_by_name.keys() <= current_names:
+            self.table_widget.setRowCount(0)
+            self._row_by_name.clear()
 
-        for row_number, test_name in enumerate(tick.infos_by_name):
-            process_infos = tick.infos_by_name[test_name]
-            pytest_run_state = tick.run_states[test_name]
+        p_cores = get_performance_core_count()
+        new_rows_added = False
 
-            display_name = pytest_run_state.get_name()
-            if test_name in tick.singleton_names:
-                display_name = f"{display_name} (singleton)"
-            name_item = QTableWidgetItem(display_name)
-            name_item.setData(Qt.ItemDataRole.UserRole, test_name)  # store node_id for context menu
-            self.table_widget.setItem(row_number, Columns.NAME.value, name_item)
+        self.table_widget.setUpdatesEnabled(False)
+        try:
+            if self.table_widget.rowCount() < len(tick.infos_by_name):
+                self.table_widget.setRowCount(len(tick.infos_by_name))
 
-            state_item = QTableWidgetItem()
-            state_text = pytest_run_state.get_string()
-            state_item.setText(state_text)
-            state_item.setForeground(pytest_run_state.get_qt_table_color())
+            for test_name, process_infos in tick.infos_by_name.items():
+                row_number = self._row_by_name.get(test_name)
+                if row_number is None:
+                    row_number = len(self._row_by_name)
+                    self._row_by_name[test_name] = row_number
+                    new_rows_added = True
 
-            if len(process_infos) > 1 and process_infos[-1].output is not None:
-                tooltip_text = tool_tip_limiter(process_infos[-1].output)
-            else:
-                tooltip_text = ""
-            state_item.setToolTip(tooltip_text)
-            state_item.setData(Qt.ItemDataRole.ToolTipRole, tooltip_text)
-            self.table_widget.setItem(row_number, Columns.STATE.value, state_item)
+                pytest_run_state = tick.run_states[test_name]
 
-            # Find the timestamp when the test started running and the final completed entry
-            start_time = None
-            final_info = None
-            for info in process_infos:
-                if info.pid is not None and start_time is None:
-                    start_time = info.time_stamp
-                if info.exit_code != PyTestFlyExitCode.NONE:
-                    final_info = info
+                # NAME
+                display_name = pytest_run_state.get_name()
+                if test_name in tick.singleton_names:
+                    display_name = f"{display_name} (singleton)"
+                name_item = self._get_or_create_item(row_number, Columns.NAME.value)
+                self._set_text_if_changed(name_item, display_name)
+                if name_item.data(Qt.ItemDataRole.UserRole) != test_name:
+                    name_item.setData(Qt.ItemDataRole.UserRole, test_name)
 
-            # Runtime: elapsed from first "running" entry; live while still running
-            if start_time is not None:
-                end_time = final_info.time_stamp if final_info is not None else time.time()
-                runtime_text = format_runtime(end_time - start_time)
-            else:
-                runtime_text = ""
+                # STATE
+                state_item = self._get_or_create_item(row_number, Columns.STATE.value)
+                self._set_text_if_changed(state_item, pytest_run_state.get_string())
+                state_item.setForeground(pytest_run_state.get_qt_table_color())
+                if len(process_infos) > 1 and process_infos[-1].output is not None:
+                    tooltip_text = tool_tip_limiter(process_infos[-1].output)
+                else:
+                    tooltip_text = ""
+                self._set_tooltip_if_changed(state_item, tooltip_text)
 
-            # CPU and Memory
-            p_cores = get_performance_core_count()
-            if final_info is not None and final_info.cpu_percent is not None:
-                cpu_normalized = min(final_info.cpu_percent / p_cores, 100.0)
-                cpu_text = f"{cpu_normalized:.1f}%"
-            else:
-                cpu_normalized = None
-                cpu_text = ""
-            memory_text = f"{final_info.memory_percent:.2f}%" if (final_info is not None and final_info.memory_percent is not None) else ""
+                # Find the timestamp when the test started running and the final completed entry
+                start_time = None
+                final_info = None
+                for info in process_infos:
+                    if info.pid is not None and start_time is None:
+                        start_time = info.time_stamp
+                    if info.exit_code != PyTestFlyExitCode.NONE:
+                        final_info = info
 
-            cpu_item = QTableWidgetItem(cpu_text)
-            if cpu_normalized is not None:
-                set_utilization_color(cpu_item, cpu_normalized / 100.0)
-            self.table_widget.setItem(row_number, Columns.CPU.value, cpu_item)
-            self.table_widget.setItem(row_number, Columns.MEMORY.value, QTableWidgetItem(memory_text))
-            self.table_widget.setItem(row_number, Columns.RUNTIME.value, QTableWidgetItem(runtime_text))
+                # Runtime: elapsed from first "running" entry; live while still running
+                if start_time is not None:
+                    end_time = final_info.time_stamp if final_info is not None else time.time()
+                    runtime_text = format_runtime(end_time - start_time)
+                else:
+                    runtime_text = ""
 
-            # Per-test coverage
-            coverage_pct = tick.per_test_coverage.get(test_name)
-            coverage_text = f"{coverage_pct:.1%}" if coverage_pct is not None else ""
-            self.table_widget.setItem(row_number, Columns.COVERAGE.value, QTableWidgetItem(coverage_text))
+                # CPU and Memory
+                if final_info is not None and final_info.cpu_percent is not None:
+                    cpu_normalized = min(final_info.cpu_percent / p_cores, 100.0)
+                    cpu_text = f"{cpu_normalized:.1f}%"
+                else:
+                    cpu_normalized = None
+                    cpu_text = ""
+                memory_text = f"{final_info.memory_percent:.2f}%" if (final_info is not None and final_info.memory_percent is not None) else ""
 
-            # Last pass data (persists across runs)
-            last_pass = tick.last_pass_data.get(test_name)
-            if last_pass is not None:
-                last_pass_start_ts, last_pass_duration = last_pass
-                last_pass_start_text = datetime.fromtimestamp(last_pass_start_ts).strftime("%Y-%m-%d %H:%M:%S")
-                last_pass_duration_text = format_runtime(last_pass_duration)
-            else:
-                last_pass_start_text = ""
-                last_pass_duration_text = ""
-            self.table_widget.setItem(row_number, Columns.LAST_PASS_START.value, QTableWidgetItem(last_pass_start_text))
-            self.table_widget.setItem(row_number, Columns.LAST_PASS_DURATION.value, QTableWidgetItem(last_pass_duration_text))
+                cpu_item = self._get_or_create_item(row_number, Columns.CPU.value)
+                self._set_text_if_changed(cpu_item, cpu_text)
+                if cpu_normalized is not None:
+                    set_utilization_color(cpu_item, cpu_normalized / 100.0)
+                else:
+                    cpu_item.setForeground(QBrush())
 
-        self.table_widget.resizeColumnsToContents()
+                memory_item = self._get_or_create_item(row_number, Columns.MEMORY.value)
+                self._set_text_if_changed(memory_item, memory_text)
+
+                runtime_item = self._get_or_create_item(row_number, Columns.RUNTIME.value)
+                self._set_text_if_changed(runtime_item, runtime_text)
+
+                # Per-test coverage
+                coverage_pct = tick.per_test_coverage.get(test_name)
+                coverage_text = f"{coverage_pct:.1%}" if coverage_pct is not None else ""
+                coverage_item = self._get_or_create_item(row_number, Columns.COVERAGE.value)
+                self._set_text_if_changed(coverage_item, coverage_text)
+
+                # Last pass data (persists across runs)
+                last_pass = tick.last_pass_data.get(test_name)
+                if last_pass is not None:
+                    last_pass_start_ts, last_pass_duration = last_pass
+                    last_pass_start_text = datetime.fromtimestamp(last_pass_start_ts).strftime("%Y-%m-%d %H:%M:%S")
+                    last_pass_duration_text = format_runtime(last_pass_duration)
+                else:
+                    last_pass_start_text = ""
+                    last_pass_duration_text = ""
+                last_pass_start_item = self._get_or_create_item(row_number, Columns.LAST_PASS_START.value)
+                self._set_text_if_changed(last_pass_start_item, last_pass_start_text)
+                last_pass_duration_item = self._get_or_create_item(row_number, Columns.LAST_PASS_DURATION.value)
+                self._set_text_if_changed(last_pass_duration_item, last_pass_duration_text)
+
+            if new_rows_added:
+                self.table_widget.resizeColumnsToContents()
+        finally:
+            self.table_widget.setUpdatesEnabled(True)


### PR DESCRIPTION
## Summary
- Refactor `TableTab.update_tick` to update rows in place (keyed by test node_id) instead of clearing and rebuilding the table every tick, reducing UI lag with large test suites
- Only call `resizeColumnsToContents()` when new rows are appended; wrap updates in `setUpdatesEnabled(False/True)`
- Fix `set_utilization_color` to restore the default foreground when a value drops back below threshold, needed now that cells persist across ticks
- Bump version to 0.3.25

## Test plan
- [ ] Launch the app and run a test suite; confirm the table tab updates smoothly without flicker
- [ ] Verify CPU cell colors transition correctly when utilization crosses thresholds
- [ ] Verify reset / RESTART clears the table as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)