### PR TITLE
Add system performance widget to Run tab — v0.3.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.28"
+version = "0.3.29"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/colors.py
+++ b/src/pytest_fly/colors.py
@@ -38,3 +38,11 @@ GRID_LINE_COLOR = QColor(180, 180, 180, 100)
 # Coverage chart colors (used on the Coverage tab).
 COVERAGE_LINE_COLOR = QColor(34, 139, 34)  # forest green
 COVERAGE_FILL_COLOR = QColor(34, 139, 34, 40)  # translucent green fill
+
+# System-metrics chart colors (used on the Run tab's system performance widget).
+CPU_LINE_COLOR = QColor(220, 20, 60)  # crimson
+MEMORY_LINE_COLOR = QColor(30, 144, 255)  # dodger blue
+DISK_READ_COLOR = QColor(255, 140, 0)  # dark orange
+DISK_WRITE_COLOR = QColor(148, 0, 211)  # dark violet
+NET_SENT_COLOR = QColor(34, 139, 34)  # forest green
+NET_RECV_COLOR = QColor(64, 224, 208)  # turquoise

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -15,12 +15,20 @@ from pytest_fly.gui.gui_util import get_text_dimensions
 from pytest_fly.interfaces import TestOrder
 from pytest_fly.logger import get_logger
 from pytest_fly.platform.platform_info import get_performance_core_count
-from pytest_fly.preferences import get_pref, refresh_rate_default, tooltip_line_limit_default, utilization_high_threshold_default, utilization_low_threshold_default
+from pytest_fly.preferences import (
+    chart_window_minutes_default,
+    get_pref,
+    refresh_rate_default,
+    tooltip_line_limit_default,
+    utilization_high_threshold_default,
+    utilization_low_threshold_default,
+)
 
 log = get_logger()
 
 minimum_refresh_rate = 1.0
 minimum_tooltip_line_limit = 1
+minimum_chart_window_minutes = 0.5
 
 
 def _add_labeled_lineedit(
@@ -97,6 +105,13 @@ class Configuration(QWidget):
 
         tooltip_label = f"Tooltip Line Limit (min {minimum_tooltip_line_limit}, {tooltip_line_limit_default} default)"
         self.tooltip_line_limit_lineedit = _add_labeled_lineedit(layout, tooltip_label, str(pref.tooltip_line_limit), QIntValidator(), self.update_tooltip_line_limit, char_width=6)
+
+        layout.addWidget(QLabel(""))  # space
+
+        chart_window_label = f"System Metrics Chart Window (minutes, {minimum_chart_window_minutes} minimum, {chart_window_minutes_default} default)"
+        self.chart_window_minutes_lineedit = _add_labeled_lineedit(
+            layout, chart_window_label, str(pref.chart_window_minutes), QDoubleValidator(), self.update_chart_window_minutes, char_width=6
+        )
 
         layout.addWidget(QLabel(""))  # space
 
@@ -192,6 +207,14 @@ class Configuration(QWidget):
         pref = get_pref()
         if value.isnumeric():
             pref.tooltip_line_limit = max(int(value), minimum_tooltip_line_limit)
+
+    def update_chart_window_minutes(self, value: str):
+        """Persist the Run-tab system-metrics chart window (clamped to *minimum_chart_window_minutes*)."""
+        pref = get_pref()
+        try:
+            pref.chart_window_minutes = max(float(value), minimum_chart_window_minutes)
+        except ValueError:
+            pass
 
     def update_target_project_path(self, value: str):
         """Persist the target-project path override (empty = auto-detect)."""

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -9,6 +9,7 @@ GUI tabs.
 
 import time
 from pathlib import Path
+from queue import Empty
 
 from PySide6.QtCore import QCoreApplication, QRect, QTimer
 from PySide6.QtGui import QIcon
@@ -26,6 +27,7 @@ from ..interfaces import PutVersionInfo, PytestRunnerState
 from ..logger import get_logger
 from ..preferences import get_pref
 from ..pytest_runner.pytest_runner import PytestRunState
+from ..pytest_runner.system_monitor import SystemMonitor, SystemMonitorSample
 from ..tick_data import TickData
 from .about_tab.about import About
 from .configuration_tab.configuration import Configuration
@@ -157,6 +159,11 @@ class FlyAppMainWindow(QMainWindow):
 
         self.setCentralWidget(self.tab_widget)
 
+        # System-wide performance monitor subprocess — sampled at a fixed 1 s cadence independent
+        # of the GUI refresh rate, drained non-blocking on each tick.
+        self._system_monitor = SystemMonitor(update_rate=1.0)
+        self._system_monitor.start()
+
         # timer for periodic updates
         self.timer = QTimer(self, interval=int(round(pref.refresh_rate * 1000)))
         self.timer.timeout.connect(self._update_tick)
@@ -184,6 +191,9 @@ class FlyAppMainWindow(QMainWindow):
             QCoreApplication.processEvents()
             pytest_runner.join(30.0)
 
+        self._system_monitor.request_stop()
+        self._system_monitor.join(5.0)
+
         event.accept()
 
     def _force_stop_single_test(self, test_name: str):
@@ -191,6 +201,18 @@ class FlyAppMainWindow(QMainWindow):
         control = self.run_tab.control_window
         if control.pytest_runner is not None and control.pytest_runner.is_running():
             control.pytest_runner.force_stop_test(test_name)
+
+    def _drain_system_monitor(self) -> None:
+        """Drain queued system-resource samples into the Run tab's metrics widget."""
+        samples: list[SystemMonitorSample] = []
+        queue = self._system_monitor.system_monitor_queue
+        while True:
+            try:
+                samples.append(queue.get_nowait())
+            except Empty:
+                break
+        if samples:
+            self.run_tab.system_metrics_window.ingest_samples(samples)
 
     def _update_tick(self):
         """Timer event handler — query the DB and refresh all tabs.
@@ -230,6 +252,9 @@ class FlyAppMainWindow(QMainWindow):
             self._coverage_tracker.handle_new_run(control.run_guid)
             self._coverage_tracker.update(tick)
             self._coverage_tracker.apply_to_tick(tick)
+
+        with timer.time("sysmon"):
+            self._drain_system_monitor()
 
         with timer.time("graph"):
             self.graph_tab.update_tick(tick)

--- a/src/pytest_fly/gui/run_tab/run_tab.py
+++ b/src/pytest_fly/gui/run_tab/run_tab.py
@@ -2,15 +2,17 @@
 
 from pathlib import Path
 
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QHBoxLayout, QVBoxLayout, QWidget
+from PySide6.QtCore import QByteArray, Qt
+from PySide6.QtWidgets import QHBoxLayout, QSplitter, QVBoxLayout, QWidget
 from typeguard import typechecked
 
 from ...logger import get_logger
+from ...preferences import get_pref
 from ...tick_data import TickData
 from .control_window import ControlWindow
 from .failed_tests_window import FailedTestsWindow
 from .status_window import StatusWindow
+from .system_metrics_window import SystemMetricsWindow
 
 log = get_logger()
 
@@ -25,26 +27,55 @@ class RunTab(QWidget):
         outer_layout = QVBoxLayout()
         self.setLayout(outer_layout)
 
-        top_layout = QHBoxLayout()
-        top_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
-
         self.control_window = ControlWindow(self, data_dir)
         self.status_window = StatusWindow(self)
+        self.system_metrics_window = SystemMetricsWindow(self)
         self.failed_tests_window = FailedTestsWindow(self)
 
         # Match StatusWindow's height to ControlWindow's so the two panels line up.
         # ControlWindow has Fixed size policy (set in its __init__), so its sizeHint is stable.
         self.status_window.setFixedHeight(self.control_window.sizeHint().height())
 
+        top_container = QWidget()
+        top_layout = QHBoxLayout()
+        top_layout.setContentsMargins(0, 0, 0, 0)
+        top_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+        top_container.setLayout(top_layout)
         top_layout.addWidget(self.control_window, alignment=Qt.AlignmentFlag.AlignTop)
         top_layout.addWidget(self.status_window, alignment=Qt.AlignmentFlag.AlignTop)
-        top_layout.addStretch()
+        top_layout.addWidget(self.system_metrics_window, stretch=1)
 
-        outer_layout.addLayout(top_layout)
-        outer_layout.addWidget(self.failed_tests_window, stretch=1)
+        # Vertical splitter: user drags the divider between the top row and the failed-tests pane.
+        # State is persisted via FlyPreferences.run_tab_splitter_state (QSplitter.saveState() hex).
+        self.splitter = QSplitter(Qt.Orientation.Vertical)
+        self.splitter.setChildrenCollapsible(False)
+        self.splitter.addWidget(top_container)
+        self.splitter.addWidget(self.failed_tests_window)
+        self.splitter.setStretchFactor(0, 0)
+        self.splitter.setStretchFactor(1, 1)
+        self._restore_splitter_state()
+        self.splitter.splitterMoved.connect(self._on_splitter_moved)
+
+        outer_layout.addWidget(self.splitter)
 
     def update_tick(self, tick: TickData):
         """Forward pre-computed tick data to the status window, failed tests pane, and control panel."""
         self.status_window.update_tick(tick)
         self.failed_tests_window.update_tick(tick)
+        self.system_metrics_window.update_tick()
         self.control_window.update()
+
+    def _restore_splitter_state(self) -> None:
+        """Restore the saved splitter divider position, if any."""
+        saved = get_pref().run_tab_splitter_state
+        if not saved:
+            return
+        try:
+            self.splitter.restoreState(QByteArray.fromHex(saved.encode("ascii")))
+        except (ValueError, UnicodeEncodeError) as exc:
+            log.debug(f"could not restore run-tab splitter state: {exc}")
+
+    def _on_splitter_moved(self, pos: int, index: int) -> None:
+        """Persist the splitter divider position so the layout restores on next launch."""
+        state_hex = bytes(self.splitter.saveState().toHex()).decode("ascii")
+        get_pref().run_tab_splitter_state = state_hex

--- a/src/pytest_fly/gui/run_tab/run_tab.py
+++ b/src/pytest_fly/gui/run_tab/run_tab.py
@@ -77,5 +77,4 @@ class RunTab(QWidget):
 
     def _on_splitter_moved(self, pos: int, index: int) -> None:
         """Persist the splitter divider position so the layout restores on next launch."""
-        state_hex = bytes(self.splitter.saveState().toHex()).decode("ascii")
-        get_pref().run_tab_splitter_state = state_hex
+        get_pref().run_tab_splitter_state = self.splitter.saveState().toHex().data().decode("ascii")

--- a/src/pytest_fly/gui/run_tab/system_metrics_window.py
+++ b/src/pytest_fly/gui/run_tab/system_metrics_window.py
@@ -1,0 +1,245 @@
+"""
+Run-tab system-performance widget — stacked charts of system-wide CPU, memory,
+disk I/O, and network I/O sampled by :class:`SystemMonitor` in a separate process.
+
+The widget keeps a time-pruned ring buffer of :class:`SystemMonitorSample` records
+and repaints from that buffer.  Sampling runs in a subprocess (owned by the main
+window), so the GUI thread only does a non-blocking queue drain + a `QPainter`
+repaint per tick.
+
+Chart style follows ``coverage_tab._CoverageChart`` — custom ``QPainter`` with
+``TimeAxisMapping`` + ``compute_grid_ticks`` from the graph-tab time-axis module.
+"""
+
+import time
+from collections import deque
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+from PySide6.QtGui import QColor, QPainter, QPen
+from PySide6.QtWidgets import QGridLayout, QGroupBox, QSizePolicy, QWidget
+
+from ...colors import CPU_LINE_COLOR, DISK_READ_COLOR, DISK_WRITE_COLOR, GRID_LINE_COLOR, MEMORY_LINE_COLOR, NET_RECV_COLOR, NET_SENT_COLOR
+from ...preferences import get_pref
+from ...pytest_runner.system_monitor import SystemMonitorSample
+from ..graph_tab.time_axis import TimeAxisMapping, compute_grid_ticks
+from ..gui_util import get_text_dimensions, window_text_color
+
+_Y_GRID_PCTS = [0.25, 0.50, 0.75, 1.00]
+_MIN_CHART_HEIGHT = 70  # pixels — each sub-chart minimum
+
+
+@dataclass(frozen=True)
+class _Series:
+    """One line series on a :class:`_MetricChart`."""
+
+    label: str
+    color: QColor
+    getter: Callable[[SystemMonitorSample], float]
+
+
+class _MetricChart(QWidget):
+    """Single time-series chart for one metric family (e.g. CPU or Network)."""
+
+    def __init__(self, title: str, series: list[_Series], unit: str, y_max_fixed: float | None):
+        """
+        :param title: Panel title shown in the top-left of the chart.
+        :param series: Line series painted over the same axes.
+        :param unit: Unit suffix for y-axis tick labels (``"%"`` or ``"MB/s"``).
+        :param y_max_fixed: Fixed y-axis maximum (e.g. ``100.0`` for percent).  ``None`` → auto-scale
+            to the largest sample in the current window, with a small minimum so the axis never flattens.
+        """
+        super().__init__()
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.setMinimumHeight(_MIN_CHART_HEIGHT)
+
+        self._title = title
+        self._series = series
+        self._unit = unit
+        self._y_max_fixed = y_max_fixed
+
+        self._samples: list[SystemMonitorSample] = []
+        self._min_ts: float | None = None
+        self._max_ts: float | None = None
+
+    def update_data(self, samples: list[SystemMonitorSample], min_ts: float | None, max_ts: float | None):
+        self._samples = samples
+        self._min_ts = min_ts
+        self._max_ts = max_ts
+        self.update()
+
+    def _current_y_max(self) -> float:
+        if self._y_max_fixed is not None:
+            return self._y_max_fixed
+        peak = 0.0
+        for sample in self._samples:
+            for series in self._series:
+                value = series.getter(sample)
+                if value > peak:
+                    peak = value
+        return max(peak * 1.15, 1.0)  # 15% headroom, but never collapse to zero
+
+    def _format_y_label(self, value: float) -> str:
+        if self._unit == "%":
+            return f"{int(round(value))}%"
+        if value >= 100:
+            return f"{value:.0f}{self._unit}"
+        if value >= 10:
+            return f"{value:.1f}{self._unit}"
+        return f"{value:.2f}{self._unit}"
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        w = self.width()
+        h = self.height()
+        char_h = get_text_dimensions("X").height()
+
+        y_max = self._current_y_max()
+        max_label = self._format_y_label(y_max)
+        margin_left = get_text_dimensions(max_label + " ").width()
+        margin_top = char_h + 4  # room for title + legend
+        margin_bottom = char_h + 4  # room for x-axis tick labels
+        chart_w = w - margin_left - 4
+        chart_h = h - margin_top - margin_bottom
+
+        if chart_w <= 0 or chart_h <= 0:
+            painter.end()
+            return
+
+        text_color = window_text_color(self)
+
+        # Horizontal grid lines + y labels
+        painter.setPen(QPen(GRID_LINE_COLOR, 1))
+        for pct in _Y_GRID_PCTS:
+            y = margin_top + int(chart_h * (1.0 - pct))
+            painter.drawLine(margin_left, y, w - 4, y)
+
+        painter.setPen(QPen(text_color, 1))
+        for pct in _Y_GRID_PCTS:
+            y = margin_top + int(chart_h * (1.0 - pct))
+            label = self._format_y_label(y_max * pct)
+            label_w = get_text_dimensions(label).width()
+            painter.drawText(margin_left - label_w - 4, y + 4, label)
+
+        # Vertical grid lines + x tick labels (bottom chart only would be ideal, but painting
+        # on every sub-chart keeps each chart standalone and is cheap).
+        grid_ticks = compute_grid_ticks(self._min_ts, self._max_ts, chart_w)
+        painter.setPen(QPen(GRID_LINE_COLOR, 1))
+        for x, _label in grid_ticks:
+            painter.drawLine(int(margin_left + x), margin_top, int(margin_left + x), margin_top + chart_h)
+
+        # Title and legend (with current values) across the top
+        painter.setPen(QPen(text_color, 1))
+        painter.drawText(margin_left, char_h, self._title)
+
+        legend_parts: list[tuple[str, QColor]] = []
+        latest = self._samples[-1] if self._samples else None
+        for series in self._series:
+            value_text = self._format_y_label(series.getter(latest)) if latest is not None else "--"
+            legend_parts.append((f"{series.label}: {value_text}", series.color))
+
+        legend_x = margin_left + get_text_dimensions(self._title + "    ").width()
+        for text, color in legend_parts:
+            painter.setPen(QPen(color, 1))
+            painter.drawText(legend_x, char_h, text)
+            legend_x += get_text_dimensions(text + "   ").width()
+
+        # Data lines
+        if self._samples and self._min_ts is not None and self._max_ts is not None and self._max_ts > self._min_ts:
+            mapping = TimeAxisMapping(min_ts=self._min_ts, max_ts=self._max_ts, width_pixels=chart_w)
+            for series in self._series:
+                painter.setPen(QPen(series.color, 2))
+                prev_x: int | None = None
+                prev_y: int | None = None
+                for sample in self._samples:
+                    x = margin_left + int(mapping.ts_to_x(sample.time_stamp))
+                    value = series.getter(sample)
+                    clamped = max(0.0, min(value, y_max))
+                    y = margin_top + int(chart_h * (1.0 - (clamped / y_max if y_max > 0 else 0.0)))
+                    if prev_x is not None and prev_y is not None:
+                        painter.drawLine(prev_x, prev_y, x, y)
+                    prev_x = x
+                    prev_y = y
+
+        painter.end()
+
+
+class SystemMetricsWindow(QGroupBox):
+    """Container panel with four stacked sub-charts (CPU, Memory, Disk, Network)."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setTitle("System Performance")
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        layout = QGridLayout()
+        self.setLayout(layout)
+
+        self._cpu_chart = _MetricChart(
+            title="CPU",
+            series=[_Series(label="usage", color=CPU_LINE_COLOR, getter=lambda s: s.cpu_percent)],
+            unit="%",
+            y_max_fixed=100.0,
+        )
+        self._memory_chart = _MetricChart(
+            title="Memory",
+            series=[_Series(label="usage", color=MEMORY_LINE_COLOR, getter=lambda s: s.memory_percent)],
+            unit="%",
+            y_max_fixed=100.0,
+        )
+        self._disk_chart = _MetricChart(
+            title="Disk",
+            series=[
+                _Series(label="read", color=DISK_READ_COLOR, getter=lambda s: s.disk_read_mbps),
+                _Series(label="write", color=DISK_WRITE_COLOR, getter=lambda s: s.disk_write_mbps),
+            ],
+            unit="MB/s",
+            y_max_fixed=None,
+        )
+        self._network_chart = _MetricChart(
+            title="Network",
+            series=[
+                _Series(label="sent", color=NET_SENT_COLOR, getter=lambda s: s.net_sent_mbps),
+                _Series(label="recv", color=NET_RECV_COLOR, getter=lambda s: s.net_recv_mbps),
+            ],
+            unit="MB/s",
+            y_max_fixed=None,
+        )
+
+        # 2x2 grid: CPU + Memory stacked in the left column, Disk + Network stacked in the right column.
+        layout.addWidget(self._cpu_chart, 0, 0)
+        layout.addWidget(self._memory_chart, 1, 0)
+        layout.addWidget(self._disk_chart, 0, 1)
+        layout.addWidget(self._network_chart, 1, 1)
+        layout.setRowStretch(0, 1)
+        layout.setRowStretch(1, 1)
+        layout.setColumnStretch(0, 1)
+        layout.setColumnStretch(1, 1)
+
+        self._samples: deque[SystemMonitorSample] = deque()
+
+    def ingest_samples(self, samples: Iterable[SystemMonitorSample]) -> None:
+        """Append new samples to the ring buffer (called once per GUI tick)."""
+        for sample in samples:
+            self._samples.append(sample)
+
+    def update_tick(self) -> None:
+        """Prune stale samples and repaint all four sub-charts."""
+        window_seconds = max(get_pref().chart_window_minutes, 0.5) * 60.0
+        now = time.time()
+        cutoff = now - window_seconds
+        while self._samples and self._samples[0].time_stamp < cutoff:
+            self._samples.popleft()
+
+        # Time axis always spans the full configured window ending at "now" so the charts
+        # animate smoothly (the right edge is always the current moment).
+        min_ts = now - window_seconds
+        max_ts = now
+        samples_list = list(self._samples)
+
+        self._cpu_chart.update_data(samples_list, min_ts, max_ts)
+        self._memory_chart.update_data(samples_list, min_ts, max_ts)
+        self._disk_chart.update_data(samples_list, min_ts, max_ts)
+        self._network_chart.update_data(samples_list, min_ts, max_ts)

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -15,6 +15,7 @@ from ...gui.gui_util import format_runtime, tool_tip_limiter
 from ...interfaces import PyTestFlyExitCode, PytestRunnerState
 from ...platform.platform_info import get_performance_core_count
 from ...preferences import get_pref
+from ...pytest_runner.process_monitor import normalize_cpu_percent
 from ...tick_data import TickData
 
 
@@ -255,7 +256,7 @@ class TableTab(QGroupBox):
 
                 # CPU and Memory
                 if final_info is not None and final_info.cpu_percent is not None:
-                    cpu_normalized = min(final_info.cpu_percent / p_cores, 100.0)
+                    cpu_normalized = normalize_cpu_percent(final_info.cpu_percent, p_cores)
                     cpu_text = f"{cpu_normalized:.1f}%"
                 else:
                     cpu_normalized = None

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -23,6 +23,7 @@ utilization_high_threshold_default = 0.8
 utilization_low_threshold_default = 0.5
 run_with_coverage_default = True
 tooltip_line_limit_default = 40  # max lines shown in pytest-output tooltips before truncation
+chart_window_minutes_default = 5.0  # width of the system-metrics chart time window on the Run tab, in minutes
 
 
 class ParallelismControl(IntEnum):
@@ -56,6 +57,10 @@ class FlyPreferences(Pref):
     test_order: TestOrder = attrib(default=TestOrder.PYTEST)  # 0=pytest default order, 1=coverage efficiency order
 
     tooltip_line_limit: int = attrib(default=tooltip_line_limit_default)  # max lines of pytest output shown in a tooltip before truncation
+
+    chart_window_minutes: float = attrib(default=chart_window_minutes_default)  # Run-tab system-metrics chart window (minutes)
+
+    run_tab_splitter_state: str = attrib(default="")  # Run-tab top-vs-failed-tests splitter (QSplitter.saveState() hex-encoded)
 
     target_project_path: str = attrib(default="")  # absolute path to the program under test; empty means auto-detect from cwd at run time
 

--- a/src/pytest_fly/pytest_runner/process_monitor.py
+++ b/src/pytest_fly/pytest_runner/process_monitor.py
@@ -24,6 +24,16 @@ class PytestProcessMonitorInfo:
     time_stamp: float  # time stamp of the info update
 
 
+def normalize_cpu_percent(cpu_percent: float, cores: int) -> float:
+    """Normalize psutil's per-process CPU percent (0-100 * cores) to a single-core-equivalent 0-100 scale.
+
+    psutil reports cpu_percent summed across cores (so a fully-busy 8-core machine reads ~800%); divide by
+    the performance-core count to get a 0-100 figure and clamp, so one busy core on an 8-core box reads
+    ~12.5% rather than ~100%.
+    """
+    return min(cpu_percent / max(cores, 1), 100.0)
+
+
 class ProcessMonitor(Process):
     """
     Subprocess that periodically samples CPU and memory usage of a target

--- a/src/pytest_fly/pytest_runner/system_monitor.py
+++ b/src/pytest_fly/pytest_runner/system_monitor.py
@@ -1,0 +1,101 @@
+"""
+System-wide resource monitor subprocess — periodically samples CPU, memory,
+disk I/O, and network I/O and makes readings available via a shared queue.
+
+Shares the same shape as :class:`pytest_fly.pytest_runner.process_monitor.ProcessMonitor`
+(a :class:`multiprocessing.Process` with a `Queue`-based drain and a `request_stop()`
+event) so the GUI can drain it with identical plumbing.
+"""
+
+import time
+from dataclasses import dataclass
+from multiprocessing import Event, Process, Queue
+
+import psutil
+from typeguard import typechecked
+
+
+@dataclass(frozen=True)
+class SystemMonitorSample:
+    """A single system-wide resource sample."""
+
+    time_stamp: float
+    cpu_percent: float  # 0.0 - 100.0 (psutil.cpu_percent; system-wide)
+    memory_percent: float  # 0.0 - 100.0 (psutil.virtual_memory().percent)
+    disk_read_mbps: float  # MB/s read since the previous sample
+    disk_write_mbps: float  # MB/s written since the previous sample
+    net_sent_mbps: float  # MB/s sent since the previous sample
+    net_recv_mbps: float  # MB/s received since the previous sample
+
+
+_BYTES_PER_MB = 1024.0 * 1024.0
+
+
+class SystemMonitor(Process):
+    """Subprocess that periodically samples system-wide resource usage."""
+
+    @typechecked()
+    def __init__(self, update_rate: float = 1.0):
+        """
+        :param update_rate: Seconds between samples.  Fixed cadence, independent of the GUI refresh rate,
+            so charts stay smooth even when the GUI refresh rate is tuned up.
+        """
+        super().__init__(daemon=True)
+        self._update_rate = update_rate
+        self._stop_event = Event()
+        self.system_monitor_queue: Queue = Queue()
+
+    def run(self):
+        """Sample resources at ``_update_rate`` intervals until stop is requested."""
+        psutil.cpu_percent(interval=None)  # prime psutil's CPU counter; ignore the first 0.0
+
+        prev_disk = psutil.disk_io_counters()
+        prev_net = psutil.net_io_counters()
+        prev_time = time.time()
+
+        while not self._stop_event.is_set():
+            self._stop_event.wait(self._update_rate)
+            if self._stop_event.is_set():
+                break
+
+            now = time.time()
+            elapsed = max(now - prev_time, 1e-6)
+
+            cpu_pct = psutil.cpu_percent(interval=None)
+            mem_pct = psutil.virtual_memory().percent
+
+            cur_disk = psutil.disk_io_counters()
+            cur_net = psutil.net_io_counters()
+
+            if cur_disk is not None and prev_disk is not None:
+                disk_read_mbps = max(cur_disk.read_bytes - prev_disk.read_bytes, 0) / _BYTES_PER_MB / elapsed
+                disk_write_mbps = max(cur_disk.write_bytes - prev_disk.write_bytes, 0) / _BYTES_PER_MB / elapsed
+            else:
+                disk_read_mbps = 0.0
+                disk_write_mbps = 0.0
+
+            if cur_net is not None and prev_net is not None:
+                net_sent_mbps = max(cur_net.bytes_sent - prev_net.bytes_sent, 0) / _BYTES_PER_MB / elapsed
+                net_recv_mbps = max(cur_net.bytes_recv - prev_net.bytes_recv, 0) / _BYTES_PER_MB / elapsed
+            else:
+                net_sent_mbps = 0.0
+                net_recv_mbps = 0.0
+
+            sample = SystemMonitorSample(
+                time_stamp=now,
+                cpu_percent=cpu_pct,
+                memory_percent=mem_pct,
+                disk_read_mbps=disk_read_mbps,
+                disk_write_mbps=disk_write_mbps,
+                net_sent_mbps=net_sent_mbps,
+                net_recv_mbps=net_recv_mbps,
+            )
+            self.system_monitor_queue.put(sample)
+
+            prev_disk = cur_disk
+            prev_net = cur_net
+            prev_time = now
+
+    def request_stop(self):
+        """Signal the monitor loop to exit after the current sample."""
+        self._stop_event.set()


### PR DESCRIPTION
## Summary
- New 2x2 system metrics panel (CPU, Memory, Disk, Network) on the Run tab, sampled by a dedicated `SystemMonitor` subprocess at a fixed 1 s cadence so the GUI thread is never blocked.
- Chart time window is user-configurable in the Configuration tab (default 5 min).
- Run tab's top row and Failed Tests pane are now split by a resizable `QSplitter` whose divider position is persisted via `pref.run_tab_splitter_state`.
- CPU-percent normalization extracted into a shared `normalize_cpu_percent()` helper so the Table tab and the new CPU chart agree on semantics.

## Test plan
- [ ] Launch `python -m pytest_fly`, confirm the metrics panel appears to the right of Status and the four charts animate once per second.
- [ ] Change **System Metrics Chart Window** in Configuration (e.g. 1 → 15) and confirm the x-axis reflows on the next tick.
- [ ] Drag the Run-tab splitter divider, restart the app, confirm the divider position is restored.
- [ ] Verify the Table tab's CPU column still shows the same values as before (behavior unchanged — now goes through the shared helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)