### PR TITLE
Simplify run mode UI, add table header sort, preserve resume data — v0.3.30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.29"
+version = "0.3.30"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -12,7 +12,7 @@ from tobool import to_bool_strict
 
 from pytest_fly.gui.about_tab.project_info import get_project_info
 from pytest_fly.gui.gui_util import get_text_dimensions
-from pytest_fly.interfaces import TestOrder
+from pytest_fly.interfaces import RunMode, TestOrder
 from pytest_fly.logger import get_logger
 from pytest_fly.platform.platform_info import get_performance_core_count
 from pytest_fly.preferences import (
@@ -76,8 +76,27 @@ class Configuration(QWidget):
 
         pref = get_pref()
 
+        # One-time reconciliation: existing users with run_mode == RESUME should see
+        # the new "Resume Without Program Check" box already checked so the UI
+        # reflects their persisted behavior.
+        if pref.run_mode == RunMode.RESUME and not pref.resume_skip_put_check:
+            pref.resume_skip_put_check = True
+
+        # Resume-mode behavior option
+        self.resume_skip_put_check_checkbox = QCheckBox("Resume Without Program Check (default: off)")
+        self.resume_skip_put_check_checkbox.setToolTip(
+            "When unchecked, pytest-fly checks the program under test (PUT) for modifications\n"
+            "and runs a full Restart if the PUT has changed.\n"
+            "When checked, pytest-fly forces a Resume even if the PUT has changed."
+        )
+        self.resume_skip_put_check_checkbox.setChecked(to_bool_strict(pref.resume_skip_put_check))
+        self.resume_skip_put_check_checkbox.stateChanged.connect(self.update_resume_skip_put_check)
+        layout.addWidget(self.resume_skip_put_check_checkbox)
+
+        layout.addWidget(QLabel(""))  # space
+
         # Test order option
-        self.coverage_order_checkbox = QCheckBox("Order tests by coverage efficiency")
+        self.coverage_order_checkbox = QCheckBox("Order Tests by Coverage Efficiency (default: off)")
         self.coverage_order_checkbox.setChecked(int(pref.test_order) == TestOrder.COVERAGE)
         self.coverage_order_checkbox.stateChanged.connect(self.update_test_order)
         layout.addWidget(self.coverage_order_checkbox)
@@ -163,6 +182,14 @@ class Configuration(QWidget):
         """Persist the test order preference based on the checkbox state."""
         pref = get_pref()
         pref.test_order = TestOrder.COVERAGE if self.coverage_order_checkbox.isChecked() else TestOrder.PYTEST
+
+    def update_resume_skip_put_check(self):
+        """Persist the resume-skip-PUT-check checkbox and keep run_mode consistent."""
+        pref = get_pref()
+        checked = self.resume_skip_put_check_checkbox.isChecked()
+        pref.resume_skip_put_check = checked
+        if pref.run_mode != RunMode.RESTART:
+            pref.run_mode = RunMode.RESUME if checked else RunMode.CHECK
 
     def update_processes(self, value: str):
         """Persist the process-count value to preferences."""

--- a/src/pytest_fly/gui/coverage_tracker.py
+++ b/src/pytest_fly/gui/coverage_tracker.py
@@ -68,6 +68,11 @@ class CoverageTracker:
             try:
                 coverage_pct, self._covered_lines, self._total_lines = calculate_coverage("current", self._data_dir, write_report=False)
                 if coverage_pct is not None:
+                    # Seed the first data point at current_run_start so the chart always has
+                    # at least two points — needed for a visible line/fill, especially in RESUME
+                    # mode when no new tests run and only one calculation happens this run.
+                    if not self._coverage_history and tick.current_run_start is not None:
+                        self._coverage_history.append((tick.current_run_start, coverage_pct))
                     self._coverage_history.append((time.time(), coverage_pct))
             except Exception as e:
                 log.warning(f"coverage calculation failed: {e}")

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -153,16 +153,21 @@ class ControlWindow(QGroupBox):
         # In RESUME mode (or CHECK-as-RESUME), copy the complete prior-run records for
         # previously-passed tests into the current run so they appear in all GUI tabs
         # (table, graph, status) with their original data (runtime, CPU, memory, output, etc.).
+        # Timestamps are shifted uniformly so the copied records fall within the current
+        # run's time window; the Progress Graph uses current_run_start as its origin, so
+        # records retaining their historical timestamps would render off the visible axis.
         if effective_mode == RunMode.RESUME:
             skipped_node_ids = all_node_ids - {t.node_id for t in tests}
             if skipped_node_ids:
-                prior_by_name = {}
+                prior_by_name: dict[str, list] = {}
                 for r in prior_results:
                     prior_by_name.setdefault(r.name, []).append(r)
-                with PytestProcessInfoDB(self.data_dir) as db:
-                    for node_id in sorted(skipped_node_ids):
-                        for record in prior_by_name.get(node_id, []):
-                            db.write(replace(record, run_guid=self.run_guid))
+                records_to_copy = [rec for nid in sorted(skipped_node_ids) for rec in prior_by_name.get(nid, [])]
+                if records_to_copy:
+                    delta = self.current_run_start - min(r.time_stamp for r in records_to_copy)
+                    with PytestProcessInfoDB(self.data_dir) as db:
+                        for record in records_to_copy:
+                            db.write(replace(record, run_guid=self.run_guid, time_stamp=record.time_stamp + delta))
 
         # Reorder so previously-failed tests run first (within their singleton group).
         # RESTART means "start over" — ignore prior results entirely so execution order

--- a/src/pytest_fly/gui/run_tab/run_mode_control_box.py
+++ b/src/pytest_fly/gui/run_tab/run_mode_control_box.py
@@ -1,4 +1,4 @@
-"""Radio-button group for selecting the run mode (Restart / Resume / Check)."""
+"""Radio-button group for selecting the run mode (Resume / Restart)."""
 
 from PySide6.QtWidgets import QButtonGroup, QGroupBox, QRadioButton, QVBoxLayout
 
@@ -6,7 +6,7 @@ from pytest_fly.preferences import RunMode, get_pref
 
 
 class RunModeControlBox(QGroupBox):
-    """Radio-button group for selecting the run mode (Restart / Resume / Check)."""
+    """Radio-button group for selecting the run mode (Resume / Restart)."""
 
     def __init__(self, parent):
         super().__init__("Run Mode", parent)
@@ -14,29 +14,23 @@ class RunModeControlBox(QGroupBox):
         self.setLayout(layout)
 
         self.run_mode_group = QButtonGroup(self)
+        self.run_mode_resume = QRadioButton("Resume")
+        self.run_mode_resume.setToolTip("Resume test run. Only run tests that either failed or were not run.\nPUT-change handling is configured in the Configuration tab.")
         self.run_mode_restart = QRadioButton("Restart")
         self.run_mode_restart.setToolTip("Always rerun all tests from scratch.")
-        self.run_mode_resume = QRadioButton("Resume")
-        self.run_mode_resume.setToolTip("Resume test run. Only run tests\nthat either failed or were not run.")
-        self.run_mode_check = QRadioButton("Check")
-        self.run_mode_check.setToolTip("Resume if the program under test has not\nchanged since the prior run; otherwise restart.")
 
-        self.run_mode_group.addButton(self.run_mode_restart)
         self.run_mode_group.addButton(self.run_mode_resume)
-        self.run_mode_group.addButton(self.run_mode_check)
+        self.run_mode_group.addButton(self.run_mode_restart)
 
-        layout.addWidget(self.run_mode_restart)
         layout.addWidget(self.run_mode_resume)
-        layout.addWidget(self.run_mode_check)
+        layout.addWidget(self.run_mode_restart)
 
         pref = get_pref()
+        self.run_mode_resume.setChecked(pref.run_mode in (RunMode.RESUME, RunMode.CHECK))
         self.run_mode_restart.setChecked(pref.run_mode == RunMode.RESTART)
-        self.run_mode_resume.setChecked(pref.run_mode == RunMode.RESUME)
-        self.run_mode_check.setChecked(pref.run_mode == RunMode.CHECK)
 
-        self.run_mode_restart.toggled.connect(self.update_preferences)
         self.run_mode_resume.toggled.connect(self.update_preferences)
-        self.run_mode_check.toggled.connect(self.update_preferences)
+        self.run_mode_restart.toggled.connect(self.update_preferences)
 
     def update_preferences(self):
         """Sync the selected radio button back to user preferences."""
@@ -44,6 +38,4 @@ class RunModeControlBox(QGroupBox):
         if self.run_mode_restart.isChecked():
             pref.run_mode = RunMode.RESTART
         elif self.run_mode_resume.isChecked():
-            pref.run_mode = RunMode.RESUME
-        elif self.run_mode_check.isChecked():
-            pref.run_mode = RunMode.CHECK
+            pref.run_mode = RunMode.RESUME if pref.resume_skip_put_check else RunMode.CHECK

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -51,6 +51,27 @@ def set_utilization_color(item: QTableWidgetItem, value: float, high_threshold: 
         item.setForeground(QBrush())
 
 
+_SORT_KEY_ROLE = Qt.ItemDataRole.UserRole + 1
+
+
+class _SortableItem(QTableWidgetItem):
+    """QTableWidgetItem that sorts by a numeric key stored at _SORT_KEY_ROLE when present.
+
+    Falls back to text comparison directly (not super().__lt__) because routing through
+    QTableWidgetItem's C++ operator< from a Python subclass has caused access violations
+    on Windows/PySide6 when no numeric key is set.
+    """
+
+    def __lt__(self, other: QTableWidgetItem) -> bool:
+        if isinstance(other, QTableWidgetItem):
+            a = self.data(_SORT_KEY_ROLE)
+            b = other.data(_SORT_KEY_ROLE)
+            if a is not None and b is not None:
+                return a < b
+            return self.text() < other.text()
+        return NotImplemented
+
+
 class TableTab(QGroupBox):
     """Tab showing a per-test table with state, CPU, memory, and runtime columns."""
 
@@ -71,6 +92,8 @@ class TableTab(QGroupBox):
         self.table_widget.setColumnCount(len(Columns))
         self.table_widget.setHorizontalHeaderLabels(["Name", "State", "CPU", "Memory", "Runtime", "Coverage", "Last Pass Start", "Last Pass Duration"])
         self.table_widget.horizontalHeader().setStretchLastSection(True)
+        self.table_widget.horizontalHeader().setSortIndicatorShown(True)
+        self.table_widget.horizontalHeader().sectionDoubleClicked.connect(self._on_header_double_clicked)
         self.table_widget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.table_widget.customContextMenuRequested.connect(self.show_context_menu)
 
@@ -81,6 +104,8 @@ class TableTab(QGroupBox):
         self._current_run_states: dict = {}
         self._current_infos_by_name: dict = {}  # test node_id -> list[PytestProcessInfo]; source for full (untruncated) copy-to-clipboard
         self._row_by_name: dict[str, int] = {}  # test_name -> row index, for in-place updates
+        self._sort_column: int | None = None
+        self._sort_order: Qt.SortOrder = Qt.SortOrder.AscendingOrder
 
     def show_context_menu(self, position: QPoint):
         """Show a right-click context menu allowing the user to copy pytest output or force-stop a running test.
@@ -164,9 +189,33 @@ class TableTab(QGroupBox):
     def _get_or_create_item(self, row: int, col: int) -> QTableWidgetItem:
         item = self.table_widget.item(row, col)
         if item is None:
-            item = QTableWidgetItem()
+            item = _SortableItem()
             self.table_widget.setItem(row, col, item)
         return item
+
+    def _on_header_double_clicked(self, col: int) -> None:
+        if self._sort_column == col:
+            self._sort_order = Qt.SortOrder.DescendingOrder if self._sort_order == Qt.SortOrder.AscendingOrder else Qt.SortOrder.AscendingOrder
+        else:
+            self._sort_column = col
+            self._sort_order = Qt.SortOrder.AscendingOrder
+        self._apply_sort()
+
+    def _apply_sort(self) -> None:
+        if self._sort_column is None:
+            return
+        self.table_widget.sortItems(self._sort_column, self._sort_order)
+        self.table_widget.horizontalHeader().setSortIndicator(self._sort_column, self._sort_order)
+        self._rebuild_row_by_name()
+
+    def _rebuild_row_by_name(self) -> None:
+        self._row_by_name.clear()
+        for row in range(self.table_widget.rowCount()):
+            item = self.table_widget.item(row, Columns.NAME.value)
+            if item is not None:
+                name = item.data(Qt.ItemDataRole.UserRole)
+                if name is not None:
+                    self._row_by_name[name] = row
 
     @staticmethod
     def _set_text_if_changed(item: QTableWidgetItem, text: str) -> None:
@@ -250,8 +299,10 @@ class TableTab(QGroupBox):
                 # Runtime: elapsed from first "running" entry; live while still running
                 if start_time is not None:
                     end_time = final_info.time_stamp if final_info is not None else time.time()
-                    runtime_text = format_runtime(end_time - start_time)
+                    elapsed_seconds = end_time - start_time
+                    runtime_text = format_runtime(elapsed_seconds)
                 else:
+                    elapsed_seconds = None
                     runtime_text = ""
 
                 # CPU and Memory
@@ -265,6 +316,7 @@ class TableTab(QGroupBox):
 
                 cpu_item = self._get_or_create_item(row_number, Columns.CPU.value)
                 self._set_text_if_changed(cpu_item, cpu_text)
+                cpu_item.setData(_SORT_KEY_ROLE, cpu_normalized if cpu_normalized is not None else float("-inf"))
                 if cpu_normalized is not None:
                     set_utilization_color(cpu_item, cpu_normalized / 100.0, utilization_high_threshold, utilization_low_threshold)
                 else:
@@ -272,15 +324,19 @@ class TableTab(QGroupBox):
 
                 memory_item = self._get_or_create_item(row_number, Columns.MEMORY.value)
                 self._set_text_if_changed(memory_item, memory_text)
+                memory_value = final_info.memory_percent if (final_info is not None and final_info.memory_percent is not None) else None
+                memory_item.setData(_SORT_KEY_ROLE, memory_value if memory_value is not None else float("-inf"))
 
                 runtime_item = self._get_or_create_item(row_number, Columns.RUNTIME.value)
                 self._set_text_if_changed(runtime_item, runtime_text)
+                runtime_item.setData(_SORT_KEY_ROLE, elapsed_seconds if elapsed_seconds is not None else float("-inf"))
 
                 # Per-test coverage
                 coverage_pct = tick.per_test_coverage.get(test_name)
                 coverage_text = f"{coverage_pct:.1%}" if coverage_pct is not None else ""
                 coverage_item = self._get_or_create_item(row_number, Columns.COVERAGE.value)
                 self._set_text_if_changed(coverage_item, coverage_text)
+                coverage_item.setData(_SORT_KEY_ROLE, coverage_pct if coverage_pct is not None else float("-inf"))
 
                 # Last pass data (persists across runs)
                 last_pass = tick.last_pass_data.get(test_name)
@@ -289,14 +345,23 @@ class TableTab(QGroupBox):
                     last_pass_start_text = datetime.fromtimestamp(last_pass_start_ts).strftime("%Y-%m-%d %H:%M:%S")
                     last_pass_duration_text = format_runtime(last_pass_duration)
                 else:
+                    last_pass_start_ts = None
+                    last_pass_duration = None
                     last_pass_start_text = ""
                     last_pass_duration_text = ""
                 last_pass_start_item = self._get_or_create_item(row_number, Columns.LAST_PASS_START.value)
                 self._set_text_if_changed(last_pass_start_item, last_pass_start_text)
+                last_pass_start_item.setData(_SORT_KEY_ROLE, last_pass_start_ts if last_pass_start_ts is not None else float("-inf"))
                 last_pass_duration_item = self._get_or_create_item(row_number, Columns.LAST_PASS_DURATION.value)
                 self._set_text_if_changed(last_pass_duration_item, last_pass_duration_text)
+                last_pass_duration_item.setData(_SORT_KEY_ROLE, last_pass_duration if last_pass_duration is not None else float("-inf"))
 
             if new_rows_added:
                 self.table_widget.resizeColumnsToContents()
+
+            if self._sort_column is not None:
+                self.table_widget.sortItems(self._sort_column, self._sort_order)
+                self.table_widget.horizontalHeader().setSortIndicator(self._sort_column, self._sort_order)
+                self._rebuild_row_by_name()
         finally:
             self.table_widget.setUpdatesEnabled(True)

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -52,7 +52,9 @@ class FlyPreferences(Pref):
     utilization_high_threshold: float = attrib(default=utilization_high_threshold_default)  # above this threshold is considered high utilization
     utilization_low_threshold: float = attrib(default=utilization_low_threshold_default)  # below this threshold is considered low utilization
 
-    run_mode: RunMode = attrib(default=RunMode.CHECK)  # 0=restart all tests, 1=resume, 2=resume if possible (i.e., the program version under test has not changed)
+    run_mode: RunMode = attrib(default=RunMode.CHECK)  # RESTART=0, RESUME=1, CHECK=2 (Resume with PUT-change check — see resume_skip_put_check)
+
+    resume_skip_put_check: bool = attrib(default=False)  # when True, Resume forces a resume even if the PUT has changed; when False, a PUT change triggers a Restart
 
     test_order: TestOrder = attrib(default=TestOrder.PYTEST)  # 0=pytest default order, 1=coverage efficiency order
 

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -242,6 +242,52 @@ def test_table_tab_last_pass_columns(app):
     assert last_pass_by_name["tests/test_c.py"] == ("", "")
 
 
+def test_table_tab_double_click_name_sorts(app):
+    """Double-clicking the Name header should sort rows alphabetically without crashing.
+
+    Regression test for the access violation that occurred when _SortableItem.__lt__
+    fell through to super().__lt__ for columns without a numeric sort key.
+    """
+    from pytest_fly.gui.table_tab.table_tab import Columns
+
+    table = TableTab()
+    guid = "test-guid-sort"
+    now = time.time()
+
+    # Three tests whose alphabetical order differs from their insertion order,
+    # so a successful sort is observable.
+    infos = [
+        _make_process_info(guid, "tests/test_zebra.py", None, PyTestFlyExitCode.NONE, time_stamp=now),
+        _make_process_info(guid, "tests/test_apple.py", None, PyTestFlyExitCode.NONE, time_stamp=now),
+        _make_process_info(guid, "tests/test_mango.py", None, PyTestFlyExitCode.NONE, time_stamp=now),
+    ]
+    tick = build_tick_data(infos)
+    table.update_tick(tick)
+
+    # Simulate a double-click on the Name column header via the wired signal.
+    table.table_widget.horizontalHeader().sectionDoubleClicked.emit(Columns.NAME.value)
+
+    names_ascending = [table.table_widget.item(r, Columns.NAME.value).text() for r in range(table.table_widget.rowCount())]
+    assert names_ascending == ["tests/test_apple.py", "tests/test_mango.py", "tests/test_zebra.py"]
+    assert table._sort_column == Columns.NAME.value
+    # _row_by_name must be rebuilt to match the new visual order
+    assert table._row_by_name["tests/test_apple.py"] == 0
+    assert table._row_by_name["tests/test_mango.py"] == 1
+    assert table._row_by_name["tests/test_zebra.py"] == 2
+
+    # Double-click again → descending
+    table.table_widget.horizontalHeader().sectionDoubleClicked.emit(Columns.NAME.value)
+    names_descending = [table.table_widget.item(r, Columns.NAME.value).text() for r in range(table.table_widget.rowCount())]
+    assert names_descending == ["tests/test_zebra.py", "tests/test_mango.py", "tests/test_apple.py"]
+    assert table._row_by_name["tests/test_zebra.py"] == 0
+    assert table._row_by_name["tests/test_apple.py"] == 2
+
+    # Subsequent update_tick must preserve the active sort
+    table.update_tick(tick)
+    names_after_update = [table.table_widget.item(r, Columns.NAME.value).text() for r in range(table.table_widget.rowCount())]
+    assert names_after_update == ["tests/test_zebra.py", "tests/test_mango.py", "tests/test_apple.py"]
+
+
 # ---------------------------------------------------------------------------
 # GraphTab tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Run mode UI**: Run tab now shows only Resume (on top) and Restart; the PUT-change check lives in a new Configuration checkbox **Resume Without Program Check** with a tooltip explaining both states.
- **Resume with no work**: copied prior-run records now have their timestamps shifted into the current run window, and `CoverageTracker` seeds a baseline point at `current_run_start` — so the Progress Graph and Coverage tab display prior data instead of appearing empty.
- **Table header sort**: double-clicking any column header sorts by that column (numeric keys for CPU/Memory/Runtime/Coverage/Last Pass, text fallback for Name/State). Avoids a PySide6 access violation by doing direct text comparison instead of `super().__lt__`.
- **Config polish**: `Order Tests by Coverage Efficiency (default: off)` and `Resume Without Program Check (default: off)` now match existing Title Case + lowercase parenthetical pattern.

## Test plan
- [x] `ruff check` + `ruff format --check` pass.
- [x] `pytest tests/test_gui_display.py` — 43 tests pass, including new `test_table_tab_double_click_name_sorts` regression guard.
- [x] `pytest tests/test_interfaces.py tests/test_pytest_process_info_db.py` — no regressions.
- [ ] Manual: launch app, exercise Resume-with-no-work and verify Coverage chart + Progress Graph draw prior data.
- [ ] Manual: double-click each column header; verify ascending → descending toggle and sort indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)