### PR TITLE
Add offset-time X-axis labels to System Performance charts — v0.3.31

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.30"
+version = "0.3.31"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/graph_tab/time_axis.py
+++ b/src/pytest_fly/gui/graph_tab/time_axis.py
@@ -63,7 +63,7 @@ def _choose_interval(time_window: float) -> float:
     return _INTERVALS[-1]
 
 
-def _format_tick_label(elapsed_seconds: float) -> str:
+def format_elapsed_label(elapsed_seconds: float) -> str:
     """Format an elapsed-time value into a compact label (e.g. ``'30s'``, ``'2m'``, ``'3h'``, ``'1h30m'``)."""
     if elapsed_seconds < 60:
         return f"{int(elapsed_seconds)}s"
@@ -98,7 +98,7 @@ def compute_grid_ticks(min_ts: float | None, max_ts: float | None, width_pixels:
     ticks: list[tuple[float, str]] = []
     elapsed = 0.0
     while elapsed <= mapping.time_window:
-        ticks.append((mapping.elapsed_to_x(elapsed), _format_tick_label(elapsed)))
+        ticks.append((mapping.elapsed_to_x(elapsed), format_elapsed_label(elapsed)))
         elapsed += interval
 
     return ticks

--- a/src/pytest_fly/gui/run_tab/system_metrics_window.py
+++ b/src/pytest_fly/gui/run_tab/system_metrics_window.py
@@ -22,7 +22,7 @@ from PySide6.QtWidgets import QGridLayout, QGroupBox, QSizePolicy, QWidget
 from ...colors import CPU_LINE_COLOR, DISK_READ_COLOR, DISK_WRITE_COLOR, GRID_LINE_COLOR, MEMORY_LINE_COLOR, NET_RECV_COLOR, NET_SENT_COLOR
 from ...preferences import get_pref
 from ...pytest_runner.system_monitor import SystemMonitorSample
-from ..graph_tab.time_axis import TimeAxisMapping, compute_grid_ticks
+from ..graph_tab.time_axis import TimeAxisMapping, compute_grid_ticks, format_elapsed_label
 from ..gui_util import get_text_dimensions, window_text_color
 
 _Y_GRID_PCTS = [0.25, 0.50, 0.75, 1.00]
@@ -129,6 +129,19 @@ class _MetricChart(QWidget):
         painter.setPen(QPen(GRID_LINE_COLOR, 1))
         for x, _label in grid_ticks:
             painter.drawLine(int(margin_left + x), margin_top, int(margin_left + x), margin_top + chart_h)
+
+        # Time-offset tick labels along the bottom — right edge is 0, earlier ticks read as negative
+        # (e.g. ``-30s``, ``-2m``).  Skip the first and last ticks to avoid edge overlap.
+        if self._min_ts is not None and self._max_ts is not None and len(grid_ticks) > 2:
+            time_span = max(self._max_ts - self._min_ts, 1.0)
+            painter.setPen(QPen(text_color, 1))
+            label_y = margin_top + chart_h + char_h
+            for x, _elapsed_label in grid_ticks[1:-1]:
+                offset_seconds = time_span - (x / chart_w) * time_span
+                label = "0" if offset_seconds <= 0 else f"-{format_elapsed_label(offset_seconds)}"
+                label_w = get_text_dimensions(label).width()
+                label_x = int(margin_left + x) - label_w // 2
+                painter.drawText(label_x, label_y, label)
 
         # Title and legend (with current values) across the top
         painter.setPen(QPen(text_color, 1))

--- a/tests/test_time_axis.py
+++ b/tests/test_time_axis.py
@@ -1,6 +1,6 @@
 """Tests for time_axis pure utility functions."""
 
-from pytest_fly.gui.graph_tab.time_axis import TimeAxisMapping, _choose_interval, _format_tick_label, compute_grid_ticks
+from pytest_fly.gui.graph_tab.time_axis import TimeAxisMapping, _choose_interval, compute_grid_ticks, format_elapsed_label
 
 
 def test_choose_interval_short():
@@ -35,28 +35,28 @@ def test_choose_interval_very_long():
     assert interval == 86400
 
 
-def test_format_tick_label_seconds():
-    assert _format_tick_label(0) == "0s"
-    assert _format_tick_label(30) == "30s"
-    assert _format_tick_label(59) == "59s"
+def testformat_elapsed_label_seconds():
+    assert format_elapsed_label(0) == "0s"
+    assert format_elapsed_label(30) == "30s"
+    assert format_elapsed_label(59) == "59s"
 
 
-def test_format_tick_label_minutes():
-    assert _format_tick_label(60) == "1m"
-    assert _format_tick_label(120) == "2m"
-    assert _format_tick_label(300) == "5m"
+def testformat_elapsed_label_minutes():
+    assert format_elapsed_label(60) == "1m"
+    assert format_elapsed_label(120) == "2m"
+    assert format_elapsed_label(300) == "5m"
 
 
-def test_format_tick_label_mixed():
-    assert _format_tick_label(90) == "1m30s"
-    assert _format_tick_label(150) == "2m30s"
+def testformat_elapsed_label_mixed():
+    assert format_elapsed_label(90) == "1m30s"
+    assert format_elapsed_label(150) == "2m30s"
 
 
-def test_format_tick_label_hours():
-    assert _format_tick_label(3600) == "1h"
-    assert _format_tick_label(7200) == "2h"
-    assert _format_tick_label(3600 + 30 * 60) == "1h30m"
-    assert _format_tick_label(5 * 3600 + 15 * 60) == "5h15m"
+def testformat_elapsed_label_hours():
+    assert format_elapsed_label(3600) == "1h"
+    assert format_elapsed_label(7200) == "2h"
+    assert format_elapsed_label(3600 + 30 * 60) == "1h30m"
+    assert format_elapsed_label(5 * 3600 + 15 * 60) == "5h15m"
 
 
 def test_time_axis_mapping_basic():


### PR DESCRIPTION
## Summary
- Draw tick labels along the bottom of each System Performance sub-chart.
- Labels show time offset from the right edge (now = 0), e.g. `-30s`, `-2m`.
- Skip the first and last ticks to avoid edge overlap.

## Test plan
- [x] `ruff check` passes.
- [x] `pytest tests/test_time_axis.py` passes.
- [ ] Launch the app and visually confirm the new X-axis labels on the CPU/Memory/Disk/Network charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)