### PR TITLE
Add Complete percentage to Status panel — v0.3.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.31"
+version = "0.3.32"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -47,6 +47,8 @@ class StatusWindow(QGroupBox):
             current_pass_count = counts[PytestRunnerState.PASS]
             current_fail_count = counts[PytestRunnerState.FAIL]
             total_completed = current_pass_count + current_fail_count
+            complete_fraction = total_completed / total_tests
+            lines.append(f"Complete: {total_completed}/{total_tests} ({complete_fraction:.2%})")
             prefix = "Pass rate: "
             if total_completed > 0:
                 pass_rate = current_pass_count / total_completed


### PR DESCRIPTION
## Summary
- Add a `Complete: X/Y (Z%)` line to the Status panel, displayed above `Pass rate`
- Bump version to 0.3.32

## Test plan
- [x] `pytest tests/test_gui_display.py` passes (43 passed)
- [ ] Manual: launch app, start a run, confirm `Complete` line renders above `Pass rate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)