### PR TITLE
Show memory used/total in GB alongside percent — v0.3.33

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.32"
+version = "0.3.33"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/system_metrics_window.py
+++ b/src/pytest_fly/gui/run_tab/system_metrics_window.py
@@ -36,6 +36,7 @@ class _Series:
     label: str
     color: QColor
     getter: Callable[[SystemMonitorSample], float]
+    legend_formatter: Callable[[SystemMonitorSample], str] | None = None
 
 
 class _MetricChart(QWidget):
@@ -150,7 +151,12 @@ class _MetricChart(QWidget):
         legend_parts: list[tuple[str, QColor]] = []
         latest = self._samples[-1] if self._samples else None
         for series in self._series:
-            value_text = self._format_y_label(series.getter(latest)) if latest is not None else "--"
+            if latest is None:
+                value_text = "--"
+            elif series.legend_formatter is not None:
+                value_text = series.legend_formatter(latest)
+            else:
+                value_text = self._format_y_label(series.getter(latest))
             legend_parts.append((f"{series.label}: {value_text}", series.color))
 
         legend_x = margin_left + get_text_dimensions(self._title + "    ").width()
@@ -198,7 +204,14 @@ class SystemMetricsWindow(QGroupBox):
         )
         self._memory_chart = _MetricChart(
             title="Memory",
-            series=[_Series(label="usage", color=MEMORY_LINE_COLOR, getter=lambda s: s.memory_percent)],
+            series=[
+                _Series(
+                    label="usage",
+                    color=MEMORY_LINE_COLOR,
+                    getter=lambda s: s.memory_percent,
+                    legend_formatter=lambda s: f"{s.memory_used_gb:.1f}/{s.memory_total_gb:.1f} GB ({s.memory_percent:.0f}%)",
+                )
+            ],
             unit="%",
             y_max_fixed=100.0,
         )

--- a/src/pytest_fly/pytest_runner/system_monitor.py
+++ b/src/pytest_fly/pytest_runner/system_monitor.py
@@ -22,6 +22,8 @@ class SystemMonitorSample:
     time_stamp: float
     cpu_percent: float  # 0.0 - 100.0 (psutil.cpu_percent; system-wide)
     memory_percent: float  # 0.0 - 100.0 (psutil.virtual_memory().percent)
+    memory_used_gb: float  # GiB used (psutil.virtual_memory().used)
+    memory_total_gb: float  # GiB total (psutil.virtual_memory().total)
     disk_read_mbps: float  # MB/s read since the previous sample
     disk_write_mbps: float  # MB/s written since the previous sample
     net_sent_mbps: float  # MB/s sent since the previous sample
@@ -29,6 +31,7 @@ class SystemMonitorSample:
 
 
 _BYTES_PER_MB = 1024.0 * 1024.0
+_BYTES_PER_GB = 1024.0 * 1024.0 * 1024.0
 
 
 class SystemMonitor(Process):
@@ -62,7 +65,10 @@ class SystemMonitor(Process):
             elapsed = max(now - prev_time, 1e-6)
 
             cpu_pct = psutil.cpu_percent(interval=None)
-            mem_pct = psutil.virtual_memory().percent
+            vm = psutil.virtual_memory()
+            mem_pct = vm.percent
+            mem_used_gb = vm.used / _BYTES_PER_GB
+            mem_total_gb = vm.total / _BYTES_PER_GB
 
             cur_disk = psutil.disk_io_counters()
             cur_net = psutil.net_io_counters()
@@ -85,6 +91,8 @@ class SystemMonitor(Process):
                 time_stamp=now,
                 cpu_percent=cpu_pct,
                 memory_percent=mem_pct,
+                memory_used_gb=mem_used_gb,
+                memory_total_gb=mem_total_gb,
                 disk_read_mbps=disk_read_mbps,
                 disk_write_mbps=disk_write_mbps,
                 net_sent_mbps=net_sent_mbps,


### PR DESCRIPTION
## Summary
- Memory chart in the Run tab's System Performance panel now displays used/total in GB in addition to the percentage (e.g. `usage: 12.3/31.7 GB (38%)`)
- `SystemMonitorSample` carries `memory_used_gb` and `memory_total_gb`, populated from `psutil.virtual_memory()`
- `_Series` gained an optional `legend_formatter` so individual series can override the default legend text without changing the y-axis plot

## Test plan
- [ ] Launch `python -m pytest_fly` and confirm the Memory sub-chart legend shows `usage: <used>/<total> GB (<pct>%)` and updates each tick
- [ ] Confirm CPU/Disk/Network chart legends are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)