### PR TITLE
Let Status panel fill the top pane — v0.3.35

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.34"
+version = "0.3.35"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/run_tab.py
+++ b/src/pytest_fly/gui/run_tab/run_tab.py
@@ -32,17 +32,15 @@ class RunTab(QWidget):
         self.system_metrics_window = SystemMetricsWindow(self)
         self.failed_tests_window = FailedTestsWindow(self)
 
-        # Match StatusWindow's height to ControlWindow's so the two panels line up.
-        # ControlWindow has Fixed size policy (set in its __init__), so its sizeHint is stable.
-        self.status_window.setFixedHeight(self.control_window.sizeHint().height())
-
         top_container = QWidget()
         top_layout = QHBoxLayout()
         top_layout.setContentsMargins(0, 0, 0, 0)
-        top_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
         top_container.setLayout(top_layout)
+        # ControlWindow is Fixed-size and pinned to the top. StatusWindow and SystemMetricsWindow
+        # fill the full vertical space of the top pane (up to the splitter divider) so the
+        # status text never has to scroll.
         top_layout.addWidget(self.control_window, alignment=Qt.AlignmentFlag.AlignTop)
-        top_layout.addWidget(self.status_window, alignment=Qt.AlignmentFlag.AlignTop)
+        top_layout.addWidget(self.status_window)
         top_layout.addWidget(self.system_metrics_window, stretch=1)
 
         # Vertical splitter: user drags the divider between the top row and the failed-tests pane.

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -17,7 +17,7 @@ class StatusWindow(QGroupBox):
         self.setTitle("Status")
         layout = QVBoxLayout()
         self.setLayout(layout)
-        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.MinimumExpanding)
         self.status_widget = PlainTextWidget(self, "Loading...")
         layout.addWidget(self.status_widget)
 


### PR DESCRIPTION
## Summary
- Status panel previously had a fixed height matching ControlWindow plus an AlignTop alignment, so long status text (PUT label, pass-rate, per-state counts, parallelism, coverage, ETA) triggered scroll bars.
- Removed both caps and bumped StatusWindow's vertical size policy to `MinimumExpanding` so it fills the full top pane of the splitter.
- The splitter divider remains user-draggable and persisted in preferences — so the user still controls how much space Status gets overall.

## Test plan
- [x] `pytest tests/test_gui_widgets.py tests/test_gui_display.py` — 52 passed
- [ ] Visually confirm Status panel fills top pane and no scroll bars appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)