### PR TITLE
Document Prioritize Never-Run Tests option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,12 @@ analogous to putting the tests in the same module in `pytest-fly`.
 
 `pytest-fly` orders tests to surface actionable information earlier:
 
-1. Tests that failed in the prior run are re-run first, so developers get faster feedback on tests they are 
+1. When **Prioritize Never-Run Tests** is enabled in the Configuration tab, tests with no record in
+the database (across any program-under-test version) are promoted to the front of the queue, giving
+developers adding new tests immediate feedback. This takes precedence over failed-first and
+coverage-efficiency ordering.
+2. Tests that failed in the prior run are re-run first, so developers get faster feedback on tests they are 
 likely fixing.
-2. When prior run data is available, tests with higher coverage efficiency (lines/second) are run earlier. 
+3. When prior run data is available, tests with higher coverage efficiency (lines/second) are run earlier. 
 This way, if there is a problem in the code, it is more likely to be found earlier in the test run.
-3. `singleton` tests are run last to maximize parallel throughput before exclusive execution begins.
+4. `singleton` tests are run last to maximize parallel throughput before exclusive execution begins.


### PR DESCRIPTION
## Summary
- Adds a new entry in the **Test Scheduling** section of the README describing the Prioritize Never-Run Tests option added in PR #89.
- Clarifies that the option takes precedence over failed-first and coverage-efficiency ordering when enabled.

## Test plan
- [x] Markdown renders correctly (numbered list reflows from 3 items to 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)