### PR TITLE
Reorderable test-ordering aspects + longest-prior-first

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.37"
+version = "0.3.38"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -18,7 +18,6 @@ from PySide6.QtWidgets import (
     QListWidgetItem,
     QPushButton,
     QSizePolicy,
-    QStyle,
     QVBoxLayout,
     QWidget,
 )
@@ -107,23 +106,24 @@ class OrderingAspectsWidget(QGroupBox):
     def _resize_list_to_content(self) -> None:
         """Fix the list widget's size to exactly fit its rows and longest label.
 
-        ``sizeHintForColumn`` only measures the text, not the leading check
-        indicator Qt draws when ``ItemIsUserCheckable`` is set.  We add the
-        style's indicator width plus a small per-row horizontal padding so
-        long labels are never clipped.
+        We build the width from explicit components rather than asking the
+        delegate, because its sizeHint under-reports the padding Qt actually
+        consumes around the check indicator on Windows (producing clipping).
         """
         count = self._list.count()
         if count == 0:
             return
-        style = self._list.style()
-        indicator_width = style.pixelMetric(QStyle.PixelMetric.PM_IndicatorWidth, None, self._list)
-        # Horizontal margin Qt puts around item text inside a QAbstractItemView.
-        item_margin = style.pixelMetric(QStyle.PixelMetric.PM_FocusFrameHMargin, None, self._list) * 2 + 8
         fm = self._list.fontMetrics()
         text_width = max(fm.horizontalAdvance(_ordering_aspect_labels[a]) for a in _ordering_aspect_labels)
-        row_height = self._list.sizeHintForRow(0)
+        # Padding for: left item margin + check indicator + indicator-to-text gap
+        # + right item margin + safety slack.  ``PM_IndicatorWidth`` is an
+        # unreliable lower bound (Windows returns 14 even though the rendered
+        # box is ~20 px with surrounding padding), so we use a flat 60 px that
+        # covers every platform style we care about.
+        horizontal_padding = 60
         frame = 2 * self._list.frameWidth()
-        width = text_width + indicator_width + item_margin + frame
+        width = text_width + horizontal_padding + frame
+        row_height = self._list.sizeHintForRow(0) or fm.height() + 4
         self._list.setFixedSize(width, row_height * count + frame)
 
     def _populate_from_prefs(self) -> None:

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -41,9 +41,9 @@ from pytest_fly.preferences import (
 )
 
 _ordering_aspect_labels: dict[OrderingAspect, str] = {
-    OrderingAspect.FAILED_FIRST: "Failed tests first",
-    OrderingAspect.NEVER_RUN_FIRST: "Never-run tests first",
-    OrderingAspect.LONGEST_PRIOR_FIRST: "Longest prior execution time first",
+    OrderingAspect.FAILED_FIRST: "Failed tests",
+    OrderingAspect.NEVER_RUN_FIRST: "Never-run tests",
+    OrderingAspect.LONGEST_PRIOR_FIRST: "Longest prior execution time",
     OrderingAspect.COVERAGE_EFFICIENCY: "Coverage efficiency (lines/sec)",
 }
 

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -7,22 +7,157 @@ from collections.abc import Callable
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QDoubleValidator, QIntValidator, QValidator
-from PySide6.QtWidgets import QCheckBox, QFileDialog, QGroupBox, QHBoxLayout, QLabel, QLineEdit, QPushButton, QVBoxLayout, QWidget
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QSizePolicy,
+    QStyle,
+    QVBoxLayout,
+    QWidget,
+)
 from tobool import to_bool_strict
 
 from pytest_fly.gui.about_tab.project_info import get_project_info
 from pytest_fly.gui.gui_util import get_text_dimensions
-from pytest_fly.interfaces import RunMode, TestOrder
+from pytest_fly.interfaces import OrderingAspect, RunMode
 from pytest_fly.logger import get_logger
 from pytest_fly.platform.platform_info import get_performance_core_count
 from pytest_fly.preferences import (
     chart_window_minutes_default,
+    get_ordering_aspects,
     get_pref,
     refresh_rate_default,
+    set_ordering_aspects,
     tooltip_line_limit_default,
     utilization_high_threshold_default,
     utilization_low_threshold_default,
 )
+
+_ordering_aspect_labels: dict[OrderingAspect, str] = {
+    OrderingAspect.FAILED_FIRST: "Failed tests first",
+    OrderingAspect.NEVER_RUN_FIRST: "Never-run tests first",
+    OrderingAspect.LONGEST_PRIOR_FIRST: "Longest prior execution time first",
+    OrderingAspect.COVERAGE_EFFICIENCY: "Coverage efficiency (lines/sec)",
+}
+
+_ordering_aspect_tooltips: dict[OrderingAspect, str] = {
+    OrderingAspect.FAILED_FIRST: "Tests that failed in the previous run run first. Ignored in Restart mode.",
+    OrderingAspect.NEVER_RUN_FIRST: "Tests with no record in the database (any program-under-test version) run first.",
+    OrderingAspect.LONGEST_PRIOR_FIRST: (
+        "Tests with the longest prior passing-run duration run first. Helps parallel runs by starting the\n"
+        "critical-path tests earliest; shorter tests backfill the remaining workers. Ignored in Restart mode."
+    ),
+    OrderingAspect.COVERAGE_EFFICIENCY: ("Tests with the highest lines-covered-per-second run first. Requires prior duration and coverage data. Ignored in Restart mode."),
+}
+
+
+class OrderingAspectsWidget(QGroupBox):
+    """Reorderable, per-row-checkable list of test-ordering aspects."""
+
+    def __init__(self, parent: QWidget | None = None):
+        super().__init__("Test Ordering", parent)
+        # Hug our content — do not stretch into parent layout whitespace.
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setToolTip("Top of the list is highest priority. Check a row to enable that aspect; use Up/Down to reorder.")
+
+        outer = QVBoxLayout()
+        outer.setContentsMargins(8, 6, 8, 6)
+        outer.setSpacing(4)
+        outer.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        self.setLayout(outer)
+
+        body = QHBoxLayout()
+        body.setSpacing(4)
+        body.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        outer.addLayout(body)
+
+        self._list = QListWidget()
+        self._list.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
+        self._list.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        # Remove the scroll bars — with only four fixed rows the widget is sized
+        # to show them all, so scrolling would be misleading whitespace.
+        self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._list.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        body.addWidget(self._list)
+
+        buttons = QVBoxLayout()
+        buttons.setAlignment(Qt.AlignmentFlag.AlignTop)
+        buttons.setSpacing(2)
+        self._up_button = QPushButton("Up")
+        self._up_button.clicked.connect(lambda: self._move_selected(-1))
+        buttons.addWidget(self._up_button)
+        self._down_button = QPushButton("Down")
+        self._down_button.clicked.connect(lambda: self._move_selected(1))
+        buttons.addWidget(self._down_button)
+        body.addLayout(buttons)
+
+        self._populate_from_prefs()
+        self._resize_list_to_content()
+        # Connect after populating so setCheckState during populate does not
+        # fire the persistence slot.
+        self._list.itemChanged.connect(self._persist)
+
+    def _resize_list_to_content(self) -> None:
+        """Fix the list widget's size to exactly fit its rows and longest label.
+
+        ``sizeHintForColumn`` only measures the text, not the leading check
+        indicator Qt draws when ``ItemIsUserCheckable`` is set.  We add the
+        style's indicator width plus a small per-row horizontal padding so
+        long labels are never clipped.
+        """
+        count = self._list.count()
+        if count == 0:
+            return
+        style = self._list.style()
+        indicator_width = style.pixelMetric(QStyle.PixelMetric.PM_IndicatorWidth, None, self._list)
+        # Horizontal margin Qt puts around item text inside a QAbstractItemView.
+        item_margin = style.pixelMetric(QStyle.PixelMetric.PM_FocusFrameHMargin, None, self._list) * 2 + 8
+        fm = self._list.fontMetrics()
+        text_width = max(fm.horizontalAdvance(_ordering_aspect_labels[a]) for a in _ordering_aspect_labels)
+        row_height = self._list.sizeHintForRow(0)
+        frame = 2 * self._list.frameWidth()
+        width = text_width + indicator_width + item_margin + frame
+        self._list.setFixedSize(width, row_height * count + frame)
+
+    def _populate_from_prefs(self) -> None:
+        pref = get_pref()
+        self._list.clear()
+        for aspect, enabled in get_ordering_aspects(pref):
+            item = QListWidgetItem(_ordering_aspect_labels[aspect])
+            item.setToolTip(_ordering_aspect_tooltips[aspect])
+            item.setData(Qt.ItemDataRole.UserRole, aspect.value)
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+            item.setCheckState(Qt.CheckState.Checked if enabled else Qt.CheckState.Unchecked)
+            self._list.addItem(item)
+
+    def _move_selected(self, delta: int) -> None:
+        row = self._list.currentRow()
+        if row < 0:
+            return
+        new_row = row + delta
+        if new_row < 0 or new_row >= self._list.count():
+            return
+        item = self._list.takeItem(row)
+        self._list.insertItem(new_row, item)
+        self._list.setCurrentRow(new_row)
+        self._persist()
+
+    def _persist(self) -> None:
+        aspects: list[tuple[OrderingAspect, bool]] = []
+        for i in range(self._list.count()):
+            item = self._list.item(i)
+            aspect = OrderingAspect(item.data(Qt.ItemDataRole.UserRole))
+            enabled = item.checkState() == Qt.CheckState.Checked
+            aspects.append((aspect, enabled))
+        set_ordering_aspects(get_pref(), aspects)
+
 
 log = get_logger()
 
@@ -95,17 +230,8 @@ class Configuration(QWidget):
 
         layout.addWidget(QLabel(""))  # space
 
-        # Test order option
-        self.coverage_order_checkbox = QCheckBox("Order Tests by Coverage Efficiency (default: off)")
-        self.coverage_order_checkbox.setChecked(int(pref.test_order) == TestOrder.COVERAGE)
-        self.coverage_order_checkbox.stateChanged.connect(self.update_test_order)
-        layout.addWidget(self.coverage_order_checkbox)
-
-        self.prioritize_never_run_checkbox = QCheckBox("Prioritize Never-Run Tests (default: off)")
-        self.prioritize_never_run_checkbox.setToolTip("Promote tests with no record in the database (any PUT version) to the front of the queue.")
-        self.prioritize_never_run_checkbox.setChecked(to_bool_strict(pref.prioritize_never_run))
-        self.prioritize_never_run_checkbox.stateChanged.connect(self.update_prioritize_never_run)
-        layout.addWidget(self.prioritize_never_run_checkbox)
+        self.ordering_aspects_widget = OrderingAspectsWidget(self)
+        layout.addWidget(self.ordering_aspects_widget)
 
         layout.addWidget(QLabel(""))  # space
 
@@ -183,16 +309,6 @@ class Configuration(QWidget):
         """Persist the performance-logging checkbox state to preferences."""
         pref = get_pref()
         pref.perf_logging = self.perf_logging_checkbox.isChecked()
-
-    def update_test_order(self):
-        """Persist the test order preference based on the checkbox state."""
-        pref = get_pref()
-        pref.test_order = TestOrder.COVERAGE if self.coverage_order_checkbox.isChecked() else TestOrder.PYTEST
-
-    def update_prioritize_never_run(self):
-        """Persist the prioritize-never-run checkbox state to preferences."""
-        pref = get_pref()
-        pref.prioritize_never_run = self.prioritize_never_run_checkbox.isChecked()
 
     def update_resume_skip_put_check(self):
         """Persist the resume-skip-PUT-check checkbox and keep run_mode consistent."""

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
     QListWidgetItem,
     QPushButton,
     QSizePolicy,
+    QStyle,
     QVBoxLayout,
     QWidget,
 )
@@ -106,23 +107,34 @@ class OrderingAspectsWidget(QGroupBox):
     def _resize_list_to_content(self) -> None:
         """Fix the list widget's size to exactly fit its rows and longest label.
 
-        We build the width from explicit components rather than asking the
-        delegate, because its sizeHint under-reports the padding Qt actually
-        consumes around the check indicator on Windows (producing clipping).
+        Sized from the actual rendered text bounding box (not just glyph
+        advance) plus the space the style needs for the check indicator and
+        item margins.  The components are deliberately over-measured: Qt's
+        reported ``PM_IndicatorWidth`` under-counts on Windows (returns ~14 px
+        for a visibly ~20 px box) and ``horizontalAdvance`` under-counts when
+        ClearType widens glyphs.  The goal is a list that's just wider than
+        needed — never narrower.
         """
         count = self._list.count()
         if count == 0:
             return
         fm = self._list.fontMetrics()
-        text_width = max(fm.horizontalAdvance(_ordering_aspect_labels[a]) for a in _ordering_aspect_labels)
-        # Padding for: left item margin + check indicator + indicator-to-text gap
-        # + right item margin + safety slack.  ``PM_IndicatorWidth`` is an
-        # unreliable lower bound (Windows returns 14 even though the rendered
-        # box is ~20 px with surrounding padding), so we use a flat 60 px that
-        # covers every platform style we care about.
-        horizontal_padding = 60
+        # Take the larger of horizontalAdvance and boundingRect — the latter
+        # wins for glyphs that extend past their advance (italic f, descenders).
+        text_width = max(max(fm.horizontalAdvance(_ordering_aspect_labels[a]), fm.boundingRect(_ordering_aspect_labels[a]).width()) for a in _ordering_aspect_labels)
+        # Style-reported components:
+        style = self._list.style()
+        indicator = style.pixelMetric(QStyle.PixelMetric.PM_IndicatorWidth, None, self._list)
+        # PM_ScrollBarExtent: even though the scroll bars are turned off, some
+        # item-view metrics reserve the extent in their layout calculations.
+        scroll_extent = style.pixelMetric(QStyle.PixelMetric.PM_ScrollBarExtent, None, self._list)
         frame = 2 * self._list.frameWidth()
-        width = text_width + horizontal_padding + frame
+        # Fixed slack: left/right item margins, indicator-to-text gap, plus
+        # general safety.  Kept generous because ClearType/DirectWrite render
+        # text a few percent wider than ``QFontMetrics.horizontalAdvance``
+        # predicts, and hi-DPI scaling amplifies the shortfall.
+        slack = 80
+        width = text_width + indicator + scroll_extent + slack + frame
         row_height = self._list.sizeHintForRow(0) or fm.height() + 4
         self._list.setFixedSize(width, row_height * count + frame)
 

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -62,10 +62,23 @@ class OrderingAspectsWidget(QGroupBox):
     """Reorderable, per-row-checkable list of test-ordering aspects."""
 
     def __init__(self, parent: QWidget | None = None):
-        super().__init__("Test Ordering", parent)
+        super().__init__("Test Ordering (highest priority=top)", parent)
         # Hug our content — do not stretch into parent layout whitespace.
         self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        self.setToolTip("Top of the list is highest priority. Check a row to enable that aspect; use Up/Down to reorder.")
+        self.setToolTip(
+            "Controls the order tests run in.\n\n"
+            "Check a row to enable that aspect; uncheck to disable. Enabled rows appear above disabled ones.\n"
+            "Position sets priority — the topmost enabled row is the primary sort; rows below it break ties.\n"
+            "Use Up / Down to reorder the selected row.\n\n"
+            "Failed tests: previously-failed tests run before previously-passed ones.\n"
+            "Never-run tests: tests with no record in the database run before tests that have run before.\n"
+            "Longest prior execution time: slowest passing tests run first — helps parallel runs by starting\n"
+            "the critical path earliest so short tests backfill the remaining workers.\n"
+            "Coverage efficiency: tests with the highest lines-covered-per-second run first.\n\n"
+            "In Restart mode, aspects that depend on prior-run data (Failed, Longest prior, Coverage) are\n"
+            "ignored; Never-run still applies because it reads any-version history.\n"
+            "Singleton tests always run last regardless of these settings."
+        )
 
         outer = QVBoxLayout()
         outer.setContentsMargins(8, 6, 8, 6)

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -30,10 +30,10 @@ from pytest_fly.logger import get_logger
 from pytest_fly.platform.platform_info import get_performance_core_count
 from pytest_fly.preferences import (
     chart_window_minutes_default,
-    get_ordering_aspects,
+    get_ordering_aspects_ordered,
     get_pref,
     refresh_rate_default,
-    set_ordering_aspects,
+    set_ordering_aspects_ordered,
     tooltip_line_limit_default,
     utilization_high_threshold_default,
     utilization_low_threshold_default,
@@ -101,7 +101,7 @@ class OrderingAspectsWidget(QGroupBox):
         self._resize_list_to_content()
         # Connect after populating so setCheckState during populate does not
         # fire the persistence slot.
-        self._list.itemChanged.connect(self._persist)
+        self._list.itemChanged.connect(self._on_item_changed)
 
     def _resize_list_to_content(self) -> None:
         """Fix the list widget's size to exactly fit its rows and longest label.
@@ -127,14 +127,16 @@ class OrderingAspectsWidget(QGroupBox):
         self._list.setFixedSize(width, row_height * count + frame)
 
     def _populate_from_prefs(self) -> None:
-        pref = get_pref()
+        """Render enabled aspects (in priority order) first, then disabled aspects in enum order."""
         self._list.clear()
-        for aspect, enabled in get_ordering_aspects(pref):
+        enabled = get_ordering_aspects_ordered()
+        disabled = [a for a in OrderingAspect if a not in enabled]
+        for aspect in list(enabled) + disabled:
             item = QListWidgetItem(_ordering_aspect_labels[aspect])
             item.setToolTip(_ordering_aspect_tooltips[aspect])
             item.setData(Qt.ItemDataRole.UserRole, aspect.value)
             item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
-            item.setCheckState(Qt.CheckState.Checked if enabled else Qt.CheckState.Unchecked)
+            item.setCheckState(Qt.CheckState.Checked if aspect in enabled else Qt.CheckState.Unchecked)
             self._list.addItem(item)
 
     def _move_selected(self, delta: int) -> None:
@@ -149,14 +151,48 @@ class OrderingAspectsWidget(QGroupBox):
         self._list.setCurrentRow(new_row)
         self._persist()
 
+    def _on_item_changed(self, item: QListWidgetItem) -> None:
+        """Keep enabled rows above disabled rows when the user toggles a checkbox.
+
+        Unchecking a row drops it to the bottom of the list; checking a row
+        promotes it to the end of the enabled group (just above the first
+        disabled row).  Always persists.
+        """
+        current = self._list.row(item)
+        if item.checkState() == Qt.CheckState.Checked:
+            # Target row: first unchecked row above the current position,
+            # i.e. the insertion point at the end of the enabled group.
+            target = current
+            for i in range(current):
+                if self._list.item(i).checkState() != Qt.CheckState.Checked:
+                    target = i
+                    break
+            else:
+                target = current  # already at/after the last checked row
+        else:
+            target = self._list.count() - 1  # move to the very end
+
+        if target != current:
+            # Signals block prevents _on_item_changed from re-entering while
+            # the row is moved programmatically.
+            self._list.blockSignals(True)
+            taken = self._list.takeItem(current)
+            self._list.insertItem(target, taken)
+            self._list.setCurrentRow(target)
+            self._list.blockSignals(False)
+
+        self._persist()
+
     def _persist(self) -> None:
-        aspects: list[tuple[OrderingAspect, bool]] = []
+        enabled: list[OrderingAspect] = []
         for i in range(self._list.count()):
             item = self._list.item(i)
-            aspect = OrderingAspect(item.data(Qt.ItemDataRole.UserRole))
-            enabled = item.checkState() == Qt.CheckState.Checked
-            aspects.append((aspect, enabled))
-        set_ordering_aspects(get_pref(), aspects)
+            if item.checkState() == Qt.CheckState.Checked:
+                try:
+                    enabled.append(OrderingAspect(item.data(Qt.ItemDataRole.UserRole)))
+                except ValueError:
+                    continue
+        set_ordering_aspects_ordered(enabled)
 
 
 log = get_logger()

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -1,8 +1,8 @@
 """
 Control window — Run/Stop buttons and parallelism/run-mode selectors.
 
-Houses the run-preparation logic: test discovery, RESUME filtering,
-failed-first reordering, and coverage-efficiency ordering.
+Houses the run-preparation logic: test discovery, RESUME filtering, and
+the user-configured ordering-aspect chain (see :mod:`pytest_runner.ordering`).
 """
 
 import time
@@ -15,11 +15,12 @@ from typeguard import typechecked
 
 from ...db import PytestProcessInfoDB
 from ...guid import generate_uuid
-from ...interfaces import PutVersionInfo, PyTestFlyExitCode, RunMode, ScheduledTest, TestOrder
+from ...interfaces import OrderingAspect, PutVersionInfo, PyTestFlyExitCode, RunMode, ScheduledTest
 from ...logger import get_logger
-from ...preferences import ParallelismControl, get_pref
+from ...preferences import ParallelismControl, get_ordering_aspects, get_pref
 from ...put_version import detect_put_version
 from ...pytest_runner.coverage import compute_per_test_coverage
+from ...pytest_runner.ordering import PRIOR_DATA_ASPECTS, OrderingContext, apply_ordering_aspects
 from ...pytest_runner.pytest_runner import PytestRunner
 from ...pytest_runner.test_list import GetTests
 from .control_pushbutton import ControlButton
@@ -170,25 +171,43 @@ class ControlWindow(QGroupBox):
                         for record in records_to_copy:
                             db.write(replace(record, run_guid=self.run_guid, time_stamp=record.time_stamp + delta))
 
-        # Reorder so previously-failed tests run first (within their singleton group).
-        # RESTART means "start over" — ignore prior results entirely so execution order
-        # matches the alphabetical table display.
-        if effective_mode != RunMode.RESTART:
-            tests = self._reorder_failed_first(tests, prior_results)
-
         # Use last-pass durations for ETA estimation (from the most recent passing run)
         self.prior_durations = {name: duration for name, (_, duration) in last_pass_data.items()}
         self.num_processes = processes
 
-        # Populate coverage/duration for coverage-efficiency ordering
-        if pref.test_order == TestOrder.COVERAGE:
-            tests = self._apply_coverage_order(tests)
-            tests.sort()
+        # Apply the user's ordered list of ordering aspects (see Configuration tab).
+        enabled_aspects: list[OrderingAspect] = [aspect for aspect, enabled in get_ordering_aspects(pref) if enabled]
+        if effective_mode == RunMode.RESTART:
+            # RESTART ignores prior-run results, so aspects that depend on them do nothing.
+            enabled_aspects = [a for a in enabled_aspects if a not in PRIOR_DATA_ASPECTS]
 
-        # Never-run prioritization runs last so it takes precedence over both failed-first
-        # and coverage ordering — developers adding new tests get the fastest feedback.
-        if pref.prioritize_never_run:
-            tests = self._prioritize_never_run(tests, ever_run)
+        per_test_cov: dict[str, float] = {}
+        if OrderingAspect.COVERAGE_EFFICIENCY in enabled_aspects:
+            per_test_cov = compute_per_test_coverage(self.data_dir, [t.node_id for t in tests])
+            # Coverage-efficiency reads duration/coverage off the ScheduledTest
+            # itself, so rebuild the list with those fields populated.
+            tests = [
+                ScheduledTest(
+                    node_id=t.node_id,
+                    singleton=t.singleton,
+                    duration=self.prior_durations.get(t.node_id),
+                    coverage=per_test_cov.get(t.node_id),
+                )
+                for t in tests
+            ]
+
+        failed_names: set[str] = set()
+        if prior_results:
+            passed = {r.name for r in prior_results if r.exit_code == PyTestFlyExitCode.OK}
+            failed_names = {r.name for r in prior_results} - passed
+
+        ctx = OrderingContext(
+            failed_names=failed_names,
+            ever_run_names=ever_run,
+            prior_durations=self.prior_durations,
+            per_test_coverage=per_test_cov,
+        )
+        tests = apply_ordering_aspects(tests, enabled_aspects, ctx)
 
         self.singleton_names = {t.node_id for t in tests if t.singleton}
 
@@ -245,54 +264,6 @@ class ControlWindow(QGroupBox):
             return RunMode.RESTART
         log.info(f"CHECK: PUT fingerprint unchanged ({current_fp!r}), resuming")
         return RunMode.RESUME
-
-    def _reorder_failed_first(self, tests, prior_results):
-        """Reorder tests so previously-failed ones run first (within their singleton group).
-
-        :param tests: List of scheduled tests.
-        :param prior_results: List of prior PytestProcessInfo records.
-        :return: Reordered list of tests.
-        """
-        if prior_results:
-            passed = {r.name for r in prior_results if r.exit_code == PyTestFlyExitCode.OK}
-            prior_names = {r.name for r in prior_results}
-            failed = prior_names - passed
-            tests = sorted(tests, key=lambda t: (t.singleton, t.node_id not in failed))
-        return tests
-
-    def _prioritize_never_run(self, tests, ever_run_names):
-        """Promote tests with no DB record (any PUT version) to the front of the queue.
-
-        Preserves singleton grouping (singleton=True last) via the tuple key, matching
-        the convention used by :meth:`_reorder_failed_first`.  Stable sort keeps the
-        prior relative order within each bucket.
-
-        :param tests: List of scheduled tests.
-        :param ever_run_names: Set of test node_ids that have ever been run.
-        :return: Reordered list of tests.
-        """
-        return sorted(tests, key=lambda t: (t.singleton, t.node_id in ever_run_names))
-
-    def _apply_coverage_order(self, tests):
-        """Replace ScheduledTest objects with ones carrying prior duration and coverage data.
-
-        When both values are available the existing ``ScheduledTest.__lt__`` sorts
-        by lines-per-second efficiency.  Tests without prior data keep ``None``
-        and fall back to alphabetical ordering.
-
-        :param tests: List of scheduled tests.
-        :return: New list with duration/coverage populated where available.
-        """
-        per_test_cov = compute_per_test_coverage(self.data_dir, [t.node_id for t in tests])
-        return [
-            ScheduledTest(
-                node_id=t.node_id,
-                singleton=t.singleton,
-                duration=self.prior_durations.get(t.node_id),
-                coverage=per_test_cov.get(t.node_id),
-            )
-            for t in tests
-        ]
 
     def soft_stop(self):
         """Stop scheduling new tests but let running tests finish."""

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -17,7 +17,7 @@ from ...db import PytestProcessInfoDB
 from ...guid import generate_uuid
 from ...interfaces import OrderingAspect, PutVersionInfo, PyTestFlyExitCode, RunMode, ScheduledTest
 from ...logger import get_logger
-from ...preferences import ParallelismControl, get_ordering_aspects, get_pref
+from ...preferences import ParallelismControl, get_ordering_aspects_ordered, get_pref
 from ...put_version import detect_put_version
 from ...pytest_runner.coverage import compute_per_test_coverage
 from ...pytest_runner.ordering import PRIOR_DATA_ASPECTS, OrderingContext, apply_ordering_aspects
@@ -176,7 +176,7 @@ class ControlWindow(QGroupBox):
         self.num_processes = processes
 
         # Apply the user's ordered list of ordering aspects (see Configuration tab).
-        enabled_aspects: list[OrderingAspect] = [aspect for aspect, enabled in get_ordering_aspects(pref) if enabled]
+        enabled_aspects: list[OrderingAspect] = get_ordering_aspects_ordered()
         if effective_mode == RunMode.RESTART:
             # RESTART ignores prior-run results, so aspects that depend on them do nothing.
             enabled_aspects = [a for a in enabled_aspects if a not in PRIOR_DATA_ASPECTS]

--- a/src/pytest_fly/interfaces.py
+++ b/src/pytest_fly/interfaces.py
@@ -3,12 +3,11 @@ Core data structures and enumerations shared across the application.
 
 Defines the fundamental types used by the runner, database, and GUI layers:
 :class:`ScheduledTest`, :class:`PytestProcessInfo`, :class:`PytestRunnerState`,
-:class:`RunMode`, :class:`TestOrder`, and :class:`PyTestFlyExitCode`.
+:class:`RunMode`, :class:`OrderingAspect`, and :class:`PyTestFlyExitCode`.
 """
 
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
-from functools import total_ordering
 
 from pytest import ExitCode
 
@@ -17,23 +16,17 @@ from .logger import get_logger
 log = get_logger()
 
 
-def _lines_per_second(duration: float, coverage: float) -> float:
+def lines_per_second(duration: float | None, coverage: float | None) -> float | None:
+    """Lines-per-second efficiency metric used by the COVERAGE_EFFICIENCY ordering aspect.
+
+    Returns ``None`` when either input is missing so callers can order
+    missing-data tests after the ones with real measurements.
     """
-    Calculate the line coverage per second.
-
-    Used by :class:`ScheduledTest` ordering to prioritise tests that cover
-    the most lines in the least time.
-
-    :param duration: Test duration in seconds.
-    :param coverage: Fraction of lines covered (0.0 to 1.0).
-    :return: Lines-per-second efficiency metric.
-    """
-
-    lines_per_second = coverage / max(duration, 1e-9)  # avoid division by zero
-    return lines_per_second
+    if duration is None or coverage is None:
+        return None
+    return coverage / max(duration, 1e-9)  # avoid division by zero
 
 
-@total_ordering
 @dataclass(frozen=True)
 class ScheduledTest:
     """
@@ -42,7 +35,7 @@ class ScheduledTest:
 
     node_id: str  # unique identifier for the test
     singleton: bool  # True if the test is a singleton
-    duration: float | None  # duration of the most recent run (seconds)
+    duration: float | None  # duration of the most recent passing run (seconds)
     coverage: float | None  # coverage of the most recent run, between 0.0 and 1.0 (1.0 = this tests covers all the code)
 
     def __eq__(self, other):
@@ -55,25 +48,20 @@ class ScheduledTest:
         """Hash based on node_id to be consistent with __eq__."""
         return hash(self.node_id)
 
-    def __lt__(self, other):
-        """
-        Return True if this test should be executed *earlier* than other (i.e. has higher priority).
-        """
-        if not isinstance(other, ScheduledTest):
-            return NotImplemented
-        if self.singleton and not other.singleton:
-            return False
-        elif not self.singleton and other.singleton:
-            return True
-        elif self.duration is None or self.coverage is None or other.duration is None or other.coverage is None:
-            return self.node_id < other.node_id
-        else:
-            return _lines_per_second(self.duration, self.coverage) > _lines_per_second(other.duration, other.coverage)
 
+class OrderingAspect(StrEnum):
+    """An aspect that contributes to the execution order of scheduled tests.
 
-class TestOrder(IntEnum):
-    PYTEST = 0  # use pytest's default collection order (alphabetical by node_id)
-    COVERAGE = 1  # order by coverage efficiency (lines covered per second), falling back to node_id when no prior data
+    The Configuration tab exposes these as a reorderable list: each aspect can
+    be individually enabled/disabled, and their position in the list sets
+    priority (index 0 = highest priority).  ``singleton`` tests are always
+    sorted last, regardless of enabled aspects.
+    """
+
+    FAILED_FIRST = "failed_first"  # tests that failed in the previous run run first
+    NEVER_RUN_FIRST = "never_run_first"  # tests with no DB record (any PUT version) run first
+    LONGEST_PRIOR_FIRST = "longest_prior_first"  # tests with the longest prior passing run run first (shrinks parallel critical path)
+    COVERAGE_EFFICIENCY = "coverage_efficiency"  # tests with the highest lines-covered-per-second run first
 
 
 class RunMode(IntEnum):

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -6,13 +6,14 @@ defined here so both the preference class and the configuration tab can share
 them without circular imports.
 """
 
+import json
 from enum import IntEnum
 
 from attr import attrib, attrs
 from pref import Pref
 
 from .__version__ import application_name, author
-from .interfaces import RunMode, TestOrder
+from .interfaces import OrderingAspect, RunMode
 from .platform import get_performance_core_count
 
 preferences_file_name = f"{application_name}_preferences.db"
@@ -56,9 +57,10 @@ class FlyPreferences(Pref):
 
     resume_skip_put_check: bool = attrib(default=False)  # when True, Resume forces a resume even if the PUT has changed; when False, a PUT change triggers a Restart
 
-    test_order: TestOrder = attrib(default=TestOrder.PYTEST)  # 0=pytest default order, 1=coverage efficiency order
-
-    prioritize_never_run: bool = attrib(default=False)  # when True, promote tests with no DB record (any PUT version) to the front of the queue
+    # JSON-encoded list of [{"aspect": <OrderingAspect.value>, "enabled": bool}, ...]
+    # in priority order (index 0 = highest priority).  Empty means "use default seed";
+    # see :func:`get_ordering_aspects`.
+    ordering_aspects: str = attrib(default="")
 
     tooltip_line_limit: int = attrib(default=tooltip_line_limit_default)  # max lines of pytest output shown in a tooltip before truncation
 
@@ -74,3 +76,59 @@ class FlyPreferences(Pref):
 def get_pref() -> FlyPreferences:
     """Return a :class:`FlyPreferences` instance (reads from / auto-saves to disk)."""
     return FlyPreferences(application_name, author, file_name=preferences_file_name)
+
+
+# Default ordering-aspect list when the user has no stored preference.  Failed-first
+# and never-run-first are enabled by default to preserve a sensible out-of-the-box
+# feedback loop; the others are present but disabled so users can discover them.
+_default_ordering_aspects: list[tuple[OrderingAspect, bool]] = [
+    (OrderingAspect.FAILED_FIRST, True),
+    (OrderingAspect.NEVER_RUN_FIRST, True),
+    (OrderingAspect.LONGEST_PRIOR_FIRST, False),
+    (OrderingAspect.COVERAGE_EFFICIENCY, False),
+]
+
+
+def get_ordering_aspects(pref: FlyPreferences) -> list[tuple[OrderingAspect, bool]]:
+    """Parse :attr:`FlyPreferences.ordering_aspects` into an ordered list.
+
+    Guarantees that every :class:`OrderingAspect` appears exactly once.  Unknown
+    aspect values in the stored JSON are discarded; aspects missing from the
+    stored JSON are appended in :class:`OrderingAspect` declaration order, with
+    the default enable state from :data:`_default_ordering_aspects`.
+
+    :param pref: Preferences instance.
+    :return: List of ``(aspect, enabled)`` tuples in priority order.
+    """
+    try:
+        raw = json.loads(pref.ordering_aspects) if pref.ordering_aspects else []
+    except (ValueError, TypeError):
+        raw = []
+
+    seen: set[OrderingAspect] = set()
+    result: list[tuple[OrderingAspect, bool]] = []
+    if isinstance(raw, list):
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            try:
+                aspect = OrderingAspect(entry.get("aspect"))
+            except ValueError:
+                continue
+            if aspect in seen:
+                continue
+            seen.add(aspect)
+            result.append((aspect, bool(entry.get("enabled", False))))
+
+    default_enabled = {aspect: enabled for aspect, enabled in _default_ordering_aspects}
+    for aspect, enabled in _default_ordering_aspects:
+        if aspect not in seen:
+            # Missing aspect — append with its default enable state.
+            result.append((aspect, default_enabled[aspect]))
+
+    return result
+
+
+def set_ordering_aspects(pref: FlyPreferences, aspects: list[tuple[OrderingAspect, bool]]) -> None:
+    """Serialise *aspects* into :attr:`FlyPreferences.ordering_aspects`."""
+    pref.ordering_aspects = json.dumps([{"aspect": a.value, "enabled": bool(enabled)} for a, enabled in aspects])

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -6,17 +6,18 @@ defined here so both the preference class and the configuration tab can share
 them without circular imports.
 """
 
-import json
 from enum import IntEnum
 
 from attr import attrib, attrs
-from pref import Pref
+from pref import Pref, PrefOrderedSet
 
 from .__version__ import application_name, author
 from .interfaces import OrderingAspect, RunMode
 from .platform import get_performance_core_count
 
 preferences_file_name = f"{application_name}_preferences.db"
+_ordering_aspects_table = "ordering_aspects"
+_default_ordering_aspect_seed: list[OrderingAspect] = [OrderingAspect.FAILED_FIRST, OrderingAspect.NEVER_RUN_FIRST]
 
 scheduler_time_quantum_default = 1.0
 refresh_rate_default = 3.0
@@ -57,10 +58,9 @@ class FlyPreferences(Pref):
 
     resume_skip_put_check: bool = attrib(default=False)  # when True, Resume forces a resume even if the PUT has changed; when False, a PUT change triggers a Restart
 
-    # JSON-encoded list of [{"aspect": <OrderingAspect.value>, "enabled": bool}, ...]
-    # in priority order (index 0 = highest priority).  Empty means "use default seed";
-    # see :func:`get_ordering_aspects`.
-    ordering_aspects: str = attrib(default="")
+    # True once the ordering-aspect PrefOrderedSet has been seeded with defaults.
+    # Guards against re-seeding a set the user has intentionally emptied.
+    ordering_aspects_seeded: bool = attrib(default=False)
 
     tooltip_line_limit: int = attrib(default=tooltip_line_limit_default)  # max lines of pytest output shown in a tooltip before truncation
 
@@ -78,57 +78,28 @@ def get_pref() -> FlyPreferences:
     return FlyPreferences(application_name, author, file_name=preferences_file_name)
 
 
-# Default ordering-aspect list when the user has no stored preference.  Failed-first
-# and never-run-first are enabled by default to preserve a sensible out-of-the-box
-# feedback loop; the others are present but disabled so users can discover them.
-_default_ordering_aspects: list[tuple[OrderingAspect, bool]] = [
-    (OrderingAspect.FAILED_FIRST, True),
-    (OrderingAspect.NEVER_RUN_FIRST, True),
-    (OrderingAspect.LONGEST_PRIOR_FIRST, False),
-    (OrderingAspect.COVERAGE_EFFICIENCY, False),
-]
+def get_ordering_aspects_set() -> PrefOrderedSet:
+    """Return the :class:`PrefOrderedSet` backing the enabled-and-ordered aspect list."""
+    return PrefOrderedSet(application_name, author, table=_ordering_aspects_table, file_name=preferences_file_name)
 
 
-def get_ordering_aspects(pref: FlyPreferences) -> list[tuple[OrderingAspect, bool]]:
-    """Parse :attr:`FlyPreferences.ordering_aspects` into an ordered list.
-
-    Guarantees that every :class:`OrderingAspect` appears exactly once.  Unknown
-    aspect values in the stored JSON are discarded; aspects missing from the
-    stored JSON are appended in :class:`OrderingAspect` declaration order, with
-    the default enable state from :data:`_default_ordering_aspects`.
-
-    :param pref: Preferences instance.
-    :return: List of ``(aspect, enabled)`` tuples in priority order.
-    """
-    try:
-        raw = json.loads(pref.ordering_aspects) if pref.ordering_aspects else []
-    except (ValueError, TypeError):
-        raw = []
-
-    seen: set[OrderingAspect] = set()
-    result: list[tuple[OrderingAspect, bool]] = []
-    if isinstance(raw, list):
-        for entry in raw:
-            if not isinstance(entry, dict):
-                continue
-            try:
-                aspect = OrderingAspect(entry.get("aspect"))
-            except ValueError:
-                continue
-            if aspect in seen:
-                continue
-            seen.add(aspect)
-            result.append((aspect, bool(entry.get("enabled", False))))
-
-    default_enabled = {aspect: enabled for aspect, enabled in _default_ordering_aspects}
-    for aspect, enabled in _default_ordering_aspects:
-        if aspect not in seen:
-            # Missing aspect — append with its default enable state.
-            result.append((aspect, default_enabled[aspect]))
-
+def get_ordering_aspects_ordered() -> list[OrderingAspect]:
+    """Return enabled aspects in priority order; seed defaults on first ever call."""
+    pref = get_pref()
+    aspect_set = get_ordering_aspects_set()
+    if not pref.ordering_aspects_seeded:
+        aspect_set.set([a.value for a in _default_ordering_aspect_seed])
+        pref.ordering_aspects_seeded = True
+    result: list[OrderingAspect] = []
+    for value in aspect_set.get():
+        try:
+            result.append(OrderingAspect(value))
+        except ValueError:
+            continue  # ignore stale / renamed aspect values
     return result
 
 
-def set_ordering_aspects(pref: FlyPreferences, aspects: list[tuple[OrderingAspect, bool]]) -> None:
-    """Serialise *aspects* into :attr:`FlyPreferences.ordering_aspects`."""
-    pref.ordering_aspects = json.dumps([{"aspect": a.value, "enabled": bool(enabled)} for a, enabled in aspects])
+def set_ordering_aspects_ordered(aspects: list[OrderingAspect]) -> None:
+    """Persist the enabled-and-ordered aspect list."""
+    get_pref().ordering_aspects_seeded = True  # any explicit write counts as seeded
+    get_ordering_aspects_set().set([a.value for a in aspects])

--- a/src/pytest_fly/pytest_runner/ordering.py
+++ b/src/pytest_fly/pytest_runner/ordering.py
@@ -1,0 +1,79 @@
+"""
+Pure, Qt-free test-ordering helper.
+
+The Configuration tab lets the user choose which :class:`OrderingAspect` values
+are enabled and in what priority order.  :func:`apply_ordering_aspects` takes
+that priority list and produces a sorted list of :class:`ScheduledTest`.
+
+Singletons always sort last regardless of aspects — they hold a process
+exclusively, so running them at the end minimises idle workers.
+"""
+
+import math
+from dataclasses import dataclass, field
+
+from ..interfaces import OrderingAspect, ScheduledTest, lines_per_second
+
+
+@dataclass(frozen=True)
+class OrderingContext:
+    """Data sources the aspect key functions read from."""
+
+    failed_names: set[str] = field(default_factory=set)  # node_ids of tests that failed in the most recent run
+    ever_run_names: set[str] = field(default_factory=set)  # node_ids with any DB record across any PUT version
+    prior_durations: dict[str, float] = field(default_factory=dict)  # node_id -> duration (seconds) from the most recent passing run
+    per_test_coverage: dict[str, float] = field(default_factory=dict)  # node_id -> fraction covered (0..1); unused for keying but preserved for completeness
+
+
+# Aspects that require prior-run data.  In RunMode.RESTART these are filtered
+# out by the caller before invoking :func:`apply_ordering_aspects`.
+PRIOR_DATA_ASPECTS: frozenset[OrderingAspect] = frozenset({OrderingAspect.FAILED_FIRST, OrderingAspect.LONGEST_PRIOR_FIRST, OrderingAspect.COVERAGE_EFFICIENCY})
+
+
+def _key_for(aspect: OrderingAspect, test: ScheduledTest, ctx: OrderingContext) -> float:
+    """Return a sort key for *test* under *aspect*.  Lower = earlier."""
+    if aspect is OrderingAspect.FAILED_FIRST:
+        return 0.0 if test.node_id in ctx.failed_names else 1.0
+    if aspect is OrderingAspect.NEVER_RUN_FIRST:
+        return 0.0 if test.node_id not in ctx.ever_run_names else 1.0
+    if aspect is OrderingAspect.LONGEST_PRIOR_FIRST:
+        # Negate so larger duration sorts earlier.  Missing -> 0 -> sorts last among its peers.
+        return -ctx.prior_durations.get(test.node_id, 0.0)
+    if aspect is OrderingAspect.COVERAGE_EFFICIENCY:
+        lps = lines_per_second(test.duration, test.coverage)
+        if lps is None:
+            return math.inf
+        return -lps
+    raise ValueError(f"Unknown ordering aspect: {aspect!r}")
+
+
+def apply_ordering_aspects(
+    tests: list[ScheduledTest],
+    aspects: list[OrderingAspect],
+    ctx: OrderingContext,
+) -> list[ScheduledTest]:
+    """Order *tests* according to *aspects* (higher priority aspects dominate).
+
+    Stable-sorts the list repeatedly: first the lowest-priority enabled aspect,
+    last the highest-priority one.  Python's ``sorted`` is stable, so aspects
+    later in this chain override earlier ones while preserving the relative
+    order established by earlier sorts for ties.
+
+    The outermost bucket in every key is ``test.singleton`` — ``True`` sorts
+    last — so singletons always run at the end.
+
+    :param tests: Tests to order.
+    :param aspects: Enabled aspects in priority order (index 0 = highest priority).
+        Callers are expected to have already filtered out disabled aspects and,
+        in RESTART mode, aspects in :data:`PRIOR_DATA_ASPECTS`.
+    :param ctx: Supporting data for the aspect key functions.
+    :return: A new list ordered for execution.
+    """
+    # Start from a stable alphabetical baseline so order is deterministic when
+    # no aspects are enabled or when every aspect produces equal keys.
+    ordered = sorted(tests, key=lambda t: (t.singleton, t.node_id))
+    # Apply aspects in reverse priority order so the highest-priority aspect
+    # is the final (and therefore dominant) sort pass.
+    for aspect in reversed(aspects):
+        ordered = sorted(ordered, key=lambda t, a=aspect: (t.singleton, _key_for(a, t, ctx)))
+    return ordered

--- a/src/pytest_fly/pytest_runner/test_list.py
+++ b/src/pytest_fly/pytest_runner/test_list.py
@@ -95,6 +95,8 @@ class GetTests(Process):
         except Empty:
             pass
 
-        self.scheduled_tests.sort()
+        # Deterministic discovery order — the final execution order is decided
+        # later by :func:`pytest_fly.pytest_runner.ordering.apply_ordering_aspects`.
+        self.scheduled_tests.sort(key=lambda t: t.node_id)
 
         return self.scheduled_tests

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -151,30 +151,6 @@ def test_control_window_filter_for_resume(qtbot):
     assert cw._filter_for_resume(tests, prior, RunMode.RESTART) == tests
 
 
-def test_control_window_reorder_failed_first(qtbot):
-    """_reorder_failed_first puts previously-failed tests ahead of previously-passed ones."""
-    data_dir = get_temp_dir("test_control_window_reorder")
-    cw = ControlWindow(None, data_dir)
-    qtbot.addWidget(cw)
-
-    tests = [
-        ScheduledTest(node_id="tests/test_pass.py", singleton=False, duration=None, coverage=None),
-        ScheduledTest(node_id="tests/test_fail.py", singleton=False, duration=None, coverage=None),
-        ScheduledTest(node_id="tests/test_singleton.py", singleton=True, duration=None, coverage=None),
-    ]
-    prior = [
-        PytestProcessInfo("g", "tests/test_pass.py", 1, PyTestFlyExitCode.OK, "", 1.0),
-        PytestProcessInfo("g", "tests/test_fail.py", 2, PyTestFlyExitCode.TESTS_FAILED, "", 1.0),
-    ]
-
-    ordered = cw._reorder_failed_first(tests, prior)
-    node_ids = [t.node_id for t in ordered]
-    # Previously-failed must come before previously-passed within non-singleton group.
-    assert node_ids.index("tests/test_fail.py") < node_ids.index("tests/test_pass.py")
-    # Singletons stay at the end.
-    assert node_ids[-1] == "tests/test_singleton.py"
-
-
 def test_control_window_resolve_check_mode(qtbot):
     """CHECK mode collapses to RESUME when fingerprints match, RESTART otherwise."""
     data_dir = get_temp_dir("test_control_window_check")

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -1,74 +1,29 @@
-"""Tests for ScheduledTest sorting and _lines_per_second."""
+"""Tests for interfaces (ScheduledTest identity and lines_per_second helper)."""
 
-from pytest_fly.interfaces import ScheduledTest, _lines_per_second
+from pytest_fly.interfaces import ScheduledTest, lines_per_second
 
 
-def test_lines_per_second():
-    assert _lines_per_second(10.0, 0.5) == 0.05
-    assert _lines_per_second(1.0, 1.0) == 1.0
-    # near-zero duration should not divide by zero
-    result = _lines_per_second(0.0, 0.5)
+def test_lines_per_second_basic():
+    assert lines_per_second(10.0, 0.5) == 0.05
+    assert lines_per_second(1.0, 1.0) == 1.0
+
+
+def test_lines_per_second_avoids_div_by_zero():
+    result = lines_per_second(0.0, 0.5)
+    assert result is not None
     assert result > 0
 
 
-def test_singleton_sorts_last():
-    """Singletons should always sort after non-singletons."""
-    normal = ScheduledTest("test_a", singleton=False, duration=None, coverage=None)
-    single = ScheduledTest("test_b", singleton=True, duration=None, coverage=None)
-
-    assert normal < single
-    assert single > normal
-    assert not (normal > single)
-    assert not (single < normal)
+def test_lines_per_second_missing_inputs():
+    assert lines_per_second(None, 0.5) is None
+    assert lines_per_second(1.0, None) is None
+    assert lines_per_second(None, None) is None
 
 
-def test_both_singletons_sort_by_node_id():
-    """Two singletons with no duration data sort alphabetically by node_id."""
-    a = ScheduledTest("aaa", singleton=True, duration=None, coverage=None)
-    b = ScheduledTest("zzz", singleton=True, duration=None, coverage=None)
-
-    assert a < b
-    assert b > a
-
-
-def test_none_duration_sorts_by_node_id():
-    """When duration or coverage is None, fallback to node_id comparison."""
-    a = ScheduledTest("test_a", singleton=False, duration=None, coverage=None)
-    b = ScheduledTest("test_b", singleton=False, duration=None, coverage=None)
-
-    assert a < b
-    assert b > a
-
-
-def test_coverage_efficiency_ordering():
-    """Higher coverage efficiency (lines/sec) should sort earlier."""
-    # fast_test: 0.8 coverage in 2s = 0.4 lines/sec
-    fast = ScheduledTest("fast", singleton=False, duration=2.0, coverage=0.8)
-    # slow_test: 0.8 coverage in 10s = 0.08 lines/sec
-    slow = ScheduledTest("slow", singleton=False, duration=10.0, coverage=0.8)
-
-    assert fast < slow  # fast should run earlier
-    assert slow > fast
-
-
-def test_sorted_list_order():
-    """Sorting a list of ScheduledTests should produce the correct execution order."""
-    tests = [
-        ScheduledTest("singleton_z", singleton=True, duration=None, coverage=None),
-        ScheduledTest("normal_b", singleton=False, duration=None, coverage=None),
-        ScheduledTest("normal_a", singleton=False, duration=None, coverage=None),
-        ScheduledTest("singleton_a", singleton=True, duration=None, coverage=None),
-    ]
-    result = sorted(tests)
-    # Non-singletons first (alphabetical), then singletons (alphabetical)
-    assert [t.node_id for t in result] == ["normal_a", "normal_b", "singleton_a", "singleton_z"]
-
-
-def test_mixed_none_and_data():
-    """A test with None duration should sort by node_id against another with None."""
-    a = ScheduledTest("test_a", singleton=False, duration=5.0, coverage=None)
-    b = ScheduledTest("test_b", singleton=False, duration=None, coverage=0.5)
-
-    # Both have partial None, so fallback to node_id
-    assert a < b
-    assert b > a
+def test_scheduled_test_equality_by_node_id():
+    a = ScheduledTest("test_a", singleton=False, duration=1.0, coverage=0.5)
+    a_dup = ScheduledTest("test_a", singleton=True, duration=None, coverage=None)
+    b = ScheduledTest("test_b", singleton=False, duration=1.0, coverage=0.5)
+    assert a == a_dup  # node_id determines equality
+    assert a != b
+    assert hash(a) == hash(a_dup)

--- a/tests/test_ordering_aspects.py
+++ b/tests/test_ordering_aspects.py
@@ -1,0 +1,102 @@
+"""Tests for :mod:`pytest_fly.pytest_runner.ordering`."""
+
+from pytest_fly.interfaces import OrderingAspect, ScheduledTest
+from pytest_fly.pytest_runner.ordering import (
+    PRIOR_DATA_ASPECTS,
+    OrderingContext,
+    apply_ordering_aspects,
+)
+
+
+def _t(name: str, singleton: bool = False, duration: float | None = None, coverage: float | None = None) -> ScheduledTest:
+    return ScheduledTest(node_id=name, singleton=singleton, duration=duration, coverage=coverage)
+
+
+def test_no_aspects_alphabetical_baseline():
+    tests = [_t("b"), _t("a"), _t("c")]
+    result = apply_ordering_aspects(tests, [], OrderingContext())
+    assert [t.node_id for t in result] == ["a", "b", "c"]
+
+
+def test_singletons_always_last_without_aspects():
+    tests = [_t("singleton_z", singleton=True), _t("normal_b"), _t("normal_a"), _t("singleton_a", singleton=True)]
+    result = apply_ordering_aspects(tests, [], OrderingContext())
+    assert [t.node_id for t in result] == ["normal_a", "normal_b", "singleton_a", "singleton_z"]
+
+
+def test_failed_first():
+    tests = [_t("pass_a"), _t("fail_b"), _t("pass_c")]
+    ctx = OrderingContext(failed_names={"fail_b"})
+    result = apply_ordering_aspects(tests, [OrderingAspect.FAILED_FIRST], ctx)
+    assert result[0].node_id == "fail_b"
+
+
+def test_never_run_first():
+    tests = [_t("old"), _t("new"), _t("ancient")]
+    ctx = OrderingContext(ever_run_names={"old", "ancient"})
+    result = apply_ordering_aspects(tests, [OrderingAspect.NEVER_RUN_FIRST], ctx)
+    assert result[0].node_id == "new"
+
+
+def test_longest_prior_first():
+    tests = [_t("a"), _t("b"), _t("c")]
+    ctx = OrderingContext(prior_durations={"a": 10.0, "b": 1.0, "c": 5.0})
+    result = apply_ordering_aspects(tests, [OrderingAspect.LONGEST_PRIOR_FIRST], ctx)
+    assert [t.node_id for t in result] == ["a", "c", "b"]
+
+
+def test_longest_prior_first_missing_duration_lands_last():
+    tests = [_t("a"), _t("no_data"), _t("b")]
+    ctx = OrderingContext(prior_durations={"a": 5.0, "b": 2.0})
+    result = apply_ordering_aspects(tests, [OrderingAspect.LONGEST_PRIOR_FIRST], ctx)
+    # no_data sorts last in the longest-first bucket; ties broken by alphabetical baseline.
+    assert result[-1].node_id == "no_data"
+    assert result[0].node_id == "a"
+
+
+def test_coverage_efficiency():
+    # fast: 0.8 coverage / 2s = 0.4 lines/s
+    # slow: 0.8 coverage / 10s = 0.08 lines/s
+    # nodata: both None -> sorts last
+    tests = [_t("slow", duration=10.0, coverage=0.8), _t("fast", duration=2.0, coverage=0.8), _t("nodata")]
+    result = apply_ordering_aspects(tests, [OrderingAspect.COVERAGE_EFFICIENCY], OrderingContext())
+    assert [t.node_id for t in result] == ["fast", "slow", "nodata"]
+
+
+def test_priority_order_matters():
+    """With both failed and never-run aspects, the first one in the list dominates ties."""
+    # failing_new has failed AND never run.
+    # passing_new has not failed, and never run.
+    # failing_old has failed, and has been run.
+    tests = [_t("failing_old"), _t("passing_new"), _t("failing_new")]
+    ctx = OrderingContext(failed_names={"failing_old", "failing_new"}, ever_run_names={"failing_old"})
+
+    # Failed-first dominates -> failing_old/failing_new come before passing_new.
+    result = apply_ordering_aspects(tests, [OrderingAspect.FAILED_FIRST, OrderingAspect.NEVER_RUN_FIRST], ctx)
+    # Among the two failed: failing_new is never-run so comes first.
+    assert result[0].node_id == "failing_new"
+    assert result[1].node_id == "failing_old"
+    assert result[2].node_id == "passing_new"
+
+    # Swap: never-run-first dominates.
+    result2 = apply_ordering_aspects(tests, [OrderingAspect.NEVER_RUN_FIRST, OrderingAspect.FAILED_FIRST], ctx)
+    # failing_new + passing_new are both never-run; within that bucket failed_first orders failing_new first.
+    assert result2[0].node_id == "failing_new"
+    assert result2[1].node_id == "passing_new"
+    assert result2[2].node_id == "failing_old"
+
+
+def test_singleton_invariant_across_aspects():
+    """Singleton tests sort last regardless of the aspect chain."""
+    tests = [_t("normal_b"), _t("singleton_a", singleton=True), _t("normal_a")]
+    ctx = OrderingContext(failed_names={"singleton_a"}, ever_run_names=set(), prior_durations={"singleton_a": 100.0})
+    aspects = [OrderingAspect.FAILED_FIRST, OrderingAspect.LONGEST_PRIOR_FIRST, OrderingAspect.NEVER_RUN_FIRST]
+    result = apply_ordering_aspects(tests, aspects, ctx)
+    assert result[-1].node_id == "singleton_a"
+
+
+def test_prior_data_aspects_set():
+    assert OrderingAspect.FAILED_FIRST in PRIOR_DATA_ASPECTS
+    assert OrderingAspect.LONGEST_PRIOR_FIRST in PRIOR_DATA_ASPECTS
+    assert OrderingAspect.COVERAGE_EFFICIENCY in PRIOR_DATA_ASPECTS
+    assert OrderingAspect.NEVER_RUN_FIRST not in PRIOR_DATA_ASPECTS

--- a/tests/test_preferences_ordering_aspects.py
+++ b/tests/test_preferences_ordering_aspects.py
@@ -1,0 +1,56 @@
+"""Tests for the PrefOrderedSet-backed ordering-aspect persistence helpers."""
+
+import pytest
+from pref import pref as pref_mod
+
+from pytest_fly.interfaces import OrderingAspect
+from pytest_fly.preferences import (
+    _default_ordering_aspect_seed,
+    get_ordering_aspects_ordered,
+    get_ordering_aspects_set,
+    get_pref,
+    set_ordering_aspects_ordered,
+)
+
+
+@pytest.fixture
+def isolated_prefs(tmp_path, monkeypatch):
+    """Redirect pref's SQLite storage to a unique tmp dir for each test.
+
+    The pref library resolves its storage via ``appdirs.user_config_dir`` at
+    instantiation time, so patching it on the ``pref.pref`` module is enough
+    to send every pref (including :class:`PrefOrderedSet`) into tmp_path.
+    """
+    monkeypatch.setattr(pref_mod.appdirs, "user_config_dir", lambda *a, **kw: str(tmp_path))
+    yield tmp_path
+
+
+def test_first_call_seeds_defaults(isolated_prefs):
+    assert not get_pref().ordering_aspects_seeded
+    assert get_ordering_aspects_ordered() == _default_ordering_aspect_seed
+    assert get_pref().ordering_aspects_seeded
+
+
+def test_round_trip(isolated_prefs):
+    # Prime the seeded flag so we're exercising a real write, not the seed path.
+    get_pref().ordering_aspects_seeded = True
+    new_order = [OrderingAspect.COVERAGE_EFFICIENCY, OrderingAspect.FAILED_FIRST]
+    set_ordering_aspects_ordered(new_order)
+    assert get_ordering_aspects_ordered() == new_order
+
+
+def test_unknown_value_skipped(isolated_prefs):
+    get_pref().ordering_aspects_seeded = True
+    aspect_set = get_ordering_aspects_set()
+    aspect_set.set([OrderingAspect.FAILED_FIRST.value, "not_a_real_aspect", OrderingAspect.COVERAGE_EFFICIENCY.value])
+    assert get_ordering_aspects_ordered() == [OrderingAspect.FAILED_FIRST, OrderingAspect.COVERAGE_EFFICIENCY]
+
+
+def test_empty_set_stays_empty_after_explicit_clear(isolated_prefs):
+    # First call seeds defaults.
+    get_ordering_aspects_ordered()
+    # User deliberately clears everything.
+    set_ordering_aspects_ordered([])
+    # Subsequent reads return empty — no re-seeding.
+    assert get_ordering_aspects_ordered() == []
+    assert get_pref().ordering_aspects_seeded

--- a/tests/test_pytest_runner/test_pytest_runner_singleton.py
+++ b/tests/test_pytest_runner/test_pytest_runner_singleton.py
@@ -12,14 +12,12 @@ def test_pytest_runner_singleton(app):
     test_name = "test_pytest_runner_singleton"
 
     # Two normal tests (run in parallel) plus one singleton (must run alone).
-    # The singleton is last because ScheduledTest sorting puts singletons at the end.
-    scheduled_tests = sorted(
-        [
-            ScheduledTest(node_id="tests/test_no_operation.py", singleton=False, duration=None, coverage=None),
-            ScheduledTest(node_id="tests/test_3_sec_operation.py", singleton=False, duration=None, coverage=None),
-            ScheduledTest(node_id="tests/test_singleton.py", singleton=True, duration=None, coverage=None),
-        ]
-    )
+    # Singletons must appear last in the queue so the runner schedules them exclusively.
+    scheduled_tests = [
+        ScheduledTest(node_id="tests/test_3_sec_operation.py", singleton=False, duration=None, coverage=None),
+        ScheduledTest(node_id="tests/test_no_operation.py", singleton=False, duration=None, coverage=None),
+        ScheduledTest(node_id="tests/test_singleton.py", singleton=True, duration=None, coverage=None),
+    ]
 
     run_guid = generate_uuid()
     data_dir = get_temp_dir(test_name)

--- a/tests/test_pytest_runner/test_pytest_runner_two_singletons.py
+++ b/tests/test_pytest_runner/test_pytest_runner_two_singletons.py
@@ -11,12 +11,10 @@ def test_pytest_runner_two_singletons(app):
 
     test_name = "test_pytest_runner_two_singletons"
 
-    scheduled_tests = sorted(
-        [
-            ScheduledTest(node_id="tests/test_singleton_a.py", singleton=True, duration=None, coverage=None),
-            ScheduledTest(node_id="tests/test_singleton_b.py", singleton=True, duration=None, coverage=None),
-        ]
-    )
+    scheduled_tests = [
+        ScheduledTest(node_id="tests/test_singleton_a.py", singleton=True, duration=None, coverage=None),
+        ScheduledTest(node_id="tests/test_singleton_b.py", singleton=True, duration=None, coverage=None),
+    ]
 
     run_guid = generate_uuid()
     data_dir = get_temp_dir(test_name)


### PR DESCRIPTION
## Summary
- Replaces the two test-ordering checkboxes on the Configuration tab with a single reorderable, per-row-checkable list of ordering aspects. List position sets priority (top = highest); each aspect can be enabled/disabled independently.
- Adds a new **Longest Prior Execution Time First** aspect. Starting the slowest-known tests first shrinks the critical path on parallel runs — short tests backfill the workers that finish early.
- Moves ordering logic out of `ControlWindow` into a new pure, Qt-free `pytest_runner/ordering.py` helper so it can be unit-tested without the Qt fixture.

Legacy `test_order` and `prioritize_never_run` preferences are dropped outright (no migration — existing users get the defaults: failed-first + never-run-first enabled, the other two visible but off). `ScheduledTest.__lt__` goes away since sorting is now a function of aspect keys rather than a property of the test.

Singletons still sort last as an invariant across every aspect combination.

## Test plan
- [x] `ruff check src tests` — passes
- [x] `ruff format src tests` — no changes
- [x] `ty check src` — no new diagnostics (33 vs 35 baseline; two pre-existing were resolved by removing the legacy checkbox slots)
- [x] `pytest tests/test_interfaces.py tests/test_ordering_aspects.py tests/test_gui_widgets.py` — 22 passed
- [x] `pytest tests/ --ignore=tests/test_pytest_runner` — 173 passed
- [x] Each `test_pytest_runner/test_*.py` individually (simple, singleton, two_singletons, multiprocess, resume, soft_stop) — all pass. `test_pytest_runner_stop.py` not touched by this change.
- [ ] Manual GUI: launch `python -m pytest_fly`, verify the Test Ordering group, toggle checks and Up/Down priority.