### PR TITLE
Live pytest output streaming

### DIFF
--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -142,7 +142,7 @@ class FlyAppMainWindow(QMainWindow):
 
         self.run_tab = RunTab(self, self.data_dir)
         self.graph_tab = GraphTab()
-        self.table_tab = TableTab()
+        self.table_tab = TableTab(self.data_dir)
         self.coverage_tab = CoverageTab()
         self.configuration = Configuration()
         self.about = About(self)

--- a/src/pytest_fly/gui/run_tab/live_output_window.py
+++ b/src/pytest_fly/gui/run_tab/live_output_window.py
@@ -1,0 +1,115 @@
+"""Live output pane — shows the streaming pytest stdout/stderr of a currently-running test."""
+
+from pathlib import Path
+
+from PySide6.QtGui import QFontDatabase
+from PySide6.QtWidgets import QCheckBox, QComboBox, QGroupBox, QHBoxLayout, QPlainTextEdit, QSizePolicy, QVBoxLayout
+from typeguard import typechecked
+
+from ...interfaces import PytestRunnerState
+from ...pytest_runner.live_output import read_live_output
+from ...tick_data import TickData
+
+_NO_TESTS_RUNNING_PLACEHOLDER = "(no tests running)"
+_MAX_LINE_BLOCKS = 5000  # QPlainTextEdit max line count — bounds memory on very chatty tests
+
+
+class LiveOutputWindow(QGroupBox):
+    """Displays live pytest output for a selectable running test."""
+
+    @typechecked
+    def __init__(self, parent, data_dir: Path):
+        super().__init__(parent)
+        self.setTitle("Live Output")
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        self._data_dir = data_dir
+        self._running_names: list[str] = []
+        self._selected_name: str | None = None
+        self._last_text: str = ""
+
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        top_row = QHBoxLayout()
+        self._test_selector = QComboBox()
+        self._test_selector.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self._test_selector.addItem(_NO_TESTS_RUNNING_PLACEHOLDER)
+        self._test_selector.setEnabled(False)
+        self._test_selector.currentIndexChanged.connect(self._on_selector_changed)
+        top_row.addWidget(self._test_selector)
+
+        self._follow_tail_checkbox = QCheckBox("Follow tail")
+        self._follow_tail_checkbox.setChecked(True)
+        top_row.addWidget(self._follow_tail_checkbox)
+        layout.addLayout(top_row)
+
+        self._text_view = QPlainTextEdit()
+        self._text_view.setReadOnly(True)
+        self._text_view.setUndoRedoEnabled(False)
+        self._text_view.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        self._text_view.setFont(QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont))
+        self._text_view.setMaximumBlockCount(_MAX_LINE_BLOCKS)
+        self._text_view.verticalScrollBar().valueChanged.connect(self._on_scroll_changed)
+        layout.addWidget(self._text_view)
+
+    def update_tick(self, tick: TickData) -> None:
+        """Refresh combo-box membership and the live text for the selected test."""
+        running_names = [name for name, run_state in tick.run_states.items() if run_state.get_state() == PytestRunnerState.RUNNING]
+
+        if running_names != self._running_names:
+            self._rebuild_selector(running_names)
+
+        if self._selected_name is None:
+            if self._last_text:
+                self._text_view.clear()
+                self._last_text = ""
+            return
+
+        live_text = read_live_output(self._data_dir, self._selected_name)
+        if live_text is None:
+            live_text = ""
+        if live_text != self._last_text:
+            self._text_view.setPlainText(live_text)
+            self._last_text = live_text
+            if self._follow_tail_checkbox.isChecked():
+                scrollbar = self._text_view.verticalScrollBar()
+                scrollbar.setValue(scrollbar.maximum())
+
+    def _rebuild_selector(self, running_names: list[str]) -> None:
+        """Rebuild the combo-box while preserving the selected test if still running."""
+        previous_selection = self._selected_name
+        self._running_names = running_names
+        self._test_selector.blockSignals(True)
+        self._test_selector.clear()
+        if running_names:
+            self._test_selector.addItems(running_names)
+            self._test_selector.setEnabled(True)
+            if previous_selection in running_names:
+                self._test_selector.setCurrentIndex(running_names.index(previous_selection))
+                self._selected_name = previous_selection
+            else:
+                self._test_selector.setCurrentIndex(0)
+                self._selected_name = running_names[0]
+                self._last_text = ""
+                self._text_view.clear()
+        else:
+            self._test_selector.addItem(_NO_TESTS_RUNNING_PLACEHOLDER)
+            self._test_selector.setEnabled(False)
+            self._selected_name = None
+        self._test_selector.blockSignals(False)
+
+    def _on_selector_changed(self, index: int) -> None:
+        """User picked a different running test — switch the text view."""
+        if 0 <= index < len(self._running_names):
+            self._selected_name = self._running_names[index]
+            self._last_text = ""
+            self._text_view.clear()
+
+    def _on_scroll_changed(self, value: int) -> None:
+        """If the user manually scrolls away from the bottom, disable follow-tail."""
+        if not self._follow_tail_checkbox.isChecked():
+            return
+        scrollbar = self._text_view.verticalScrollBar()
+        if value < scrollbar.maximum():
+            self._follow_tail_checkbox.setChecked(False)

--- a/src/pytest_fly/gui/run_tab/run_tab.py
+++ b/src/pytest_fly/gui/run_tab/run_tab.py
@@ -11,6 +11,7 @@ from ...preferences import get_pref
 from ...tick_data import TickData
 from .control_window import ControlWindow
 from .failed_tests_window import FailedTestsWindow
+from .live_output_window import LiveOutputWindow
 from .status_window import StatusWindow
 from .system_metrics_window import SystemMetricsWindow
 
@@ -31,6 +32,7 @@ class RunTab(QWidget):
         self.status_window = StatusWindow(self)
         self.system_metrics_window = SystemMetricsWindow(self)
         self.failed_tests_window = FailedTestsWindow(self)
+        self.live_output_window = LiveOutputWindow(self, data_dir)
 
         top_container = QWidget()
         top_layout = QHBoxLayout()
@@ -43,12 +45,23 @@ class RunTab(QWidget):
         top_layout.addWidget(self.status_window)
         top_layout.addWidget(self.system_metrics_window, stretch=1)
 
-        # Vertical splitter: user drags the divider between the top row and the failed-tests pane.
+        # Bottom pane: a horizontal splitter so the user can size Failed Tests vs Live Output
+        # independently of the outer top/bottom divider.
+        self.bottom_splitter = QSplitter(Qt.Orientation.Horizontal)
+        self.bottom_splitter.setChildrenCollapsible(False)
+        self.bottom_splitter.addWidget(self.failed_tests_window)
+        self.bottom_splitter.addWidget(self.live_output_window)
+        self.bottom_splitter.setStretchFactor(0, 0)
+        self.bottom_splitter.setStretchFactor(1, 1)
+        self._restore_bottom_splitter_state()
+        self.bottom_splitter.splitterMoved.connect(self._on_bottom_splitter_moved)
+
+        # Vertical splitter: user drags the divider between the top row and the bottom pane.
         # State is persisted via FlyPreferences.run_tab_splitter_state (QSplitter.saveState() hex).
         self.splitter = QSplitter(Qt.Orientation.Vertical)
         self.splitter.setChildrenCollapsible(False)
         self.splitter.addWidget(top_container)
-        self.splitter.addWidget(self.failed_tests_window)
+        self.splitter.addWidget(self.bottom_splitter)
         self.splitter.setStretchFactor(0, 0)
         self.splitter.setStretchFactor(1, 1)
         self._restore_splitter_state()
@@ -57,9 +70,10 @@ class RunTab(QWidget):
         outer_layout.addWidget(self.splitter)
 
     def update_tick(self, tick: TickData):
-        """Forward pre-computed tick data to the status window, failed tests pane, and control panel."""
+        """Forward pre-computed tick data to all child windows in the Run tab."""
         self.status_window.update_tick(tick)
         self.failed_tests_window.update_tick(tick)
+        self.live_output_window.update_tick(tick)
         self.system_metrics_window.update_tick()
         self.control_window.update()
 
@@ -76,3 +90,17 @@ class RunTab(QWidget):
     def _on_splitter_moved(self, pos: int, index: int) -> None:
         """Persist the splitter divider position so the layout restores on next launch."""
         get_pref().run_tab_splitter_state = self.splitter.saveState().toHex().data().decode("ascii")
+
+    def _restore_bottom_splitter_state(self) -> None:
+        """Restore the saved bottom-splitter (failed-tests vs live-output) divider position, if any."""
+        saved = get_pref().run_tab_bottom_splitter_state
+        if not saved:
+            return
+        try:
+            self.bottom_splitter.restoreState(QByteArray.fromHex(saved.encode("ascii")))
+        except (ValueError, UnicodeEncodeError) as exc:
+            log.debug(f"could not restore run-tab bottom splitter state: {exc}")
+
+    def _on_bottom_splitter_moved(self, pos: int, index: int) -> None:
+        """Persist the bottom-splitter divider position so the layout restores on next launch."""
+        get_pref().run_tab_bottom_splitter_state = self.bottom_splitter.saveState().toHex().data().decode("ascii")

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -6,15 +6,18 @@ coverage, and last-pass information.
 import time
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 
 from PySide6.QtCore import QPoint, Qt, Signal
 from PySide6.QtGui import QBrush, QColor, QGuiApplication
 from PySide6.QtWidgets import QGroupBox, QMenu, QScrollArea, QTableWidget, QTableWidgetItem, QVBoxLayout
+from typeguard import typechecked
 
 from ...gui.gui_util import format_runtime, tool_tip_limiter
 from ...interfaces import PyTestFlyExitCode, PytestRunnerState
 from ...platform.platform_info import get_performance_core_count
 from ...preferences import get_pref
+from ...pytest_runner.live_output import read_live_output
 from ...pytest_runner.process_monitor import normalize_cpu_percent
 from ...tick_data import TickData
 
@@ -77,8 +80,11 @@ class TableTab(QGroupBox):
 
     force_stop_test_requested = Signal(str)  # emits the test node_id
 
-    def __init__(self):
+    @typechecked
+    def __init__(self, data_dir: Path):
         super().__init__()
+
+        self._data_dir = data_dir
 
         self.setTitle("Tests")
         layout = QVBoxLayout()
@@ -150,6 +156,13 @@ class TableTab(QGroupBox):
                     if info.output:
                         output_text = info.output
                         break
+
+            # If no completed-output record exists yet but the test is currently
+            # running, pull the live log tail directly from disk.
+            if not output_text and is_running and test_node_id is not None:
+                live_text = read_live_output(self._data_dir, test_node_id, max_bytes=10_000_000)
+                if live_text:
+                    output_text = live_text
 
             # Fallback to the tooltip text if no output is available yet.
             if not output_text:
@@ -281,7 +294,10 @@ class TableTab(QGroupBox):
                 state_item = self._get_or_create_item(row_number, Columns.STATE.value)
                 self._set_text_if_changed(state_item, pytest_run_state.get_string())
                 state_item.setForeground(pytest_run_state.get_qt_table_color())
-                if len(process_infos) > 1 and process_infos[-1].output is not None:
+                if pytest_run_state.get_state() == PytestRunnerState.RUNNING:
+                    live_text = read_live_output(self._data_dir, test_name)
+                    tooltip_text = tool_tip_limiter(live_text, line_limit=tooltip_line_limit) if live_text else ""
+                elif len(process_infos) > 1 and process_infos[-1].output is not None:
                     tooltip_text = tool_tip_limiter(process_infos[-1].output, line_limit=tooltip_line_limit)
                 else:
                     tooltip_text = ""

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -67,6 +67,7 @@ class FlyPreferences(Pref):
     chart_window_minutes: float = attrib(default=chart_window_minutes_default)  # Run-tab system-metrics chart window (minutes)
 
     run_tab_splitter_state: str = attrib(default="")  # Run-tab top-vs-failed-tests splitter (QSplitter.saveState() hex-encoded)
+    run_tab_bottom_splitter_state: str = attrib(default="")  # Run-tab bottom pane: failed-tests-vs-live-output splitter (QSplitter.saveState() hex-encoded)
 
     target_project_path: str = attrib(default="")  # absolute path to the program under test; empty means auto-detect from cwd at run time
 

--- a/src/pytest_fly/pytest_runner/live_output.py
+++ b/src/pytest_fly/pytest_runner/live_output.py
@@ -1,0 +1,70 @@
+"""
+Live pytest output files — single source of truth for the per-test log path and
+read/clear helpers.
+
+Each running test writes its stdout/stderr to ``data_dir/live_output/<safe>.log``
+(line-buffered) in :class:`PytestProcess`.  The GUI polls the tail of that file
+to render live output for RUNNING tests before the final completed output lands
+in the database.
+"""
+
+from pathlib import Path
+
+from ..file_util import sanitize_test_name
+
+_LIVE_OUTPUT_SUBDIR = "live_output"
+_TRUNCATION_MARKER = "...[truncated]...\n"
+
+
+def live_output_dir(data_dir: Path) -> Path:
+    """Return the directory that holds per-test live-output log files."""
+    return Path(data_dir, _LIVE_OUTPUT_SUBDIR)
+
+
+def live_output_path(data_dir: Path, test_name: str) -> Path:
+    """Return the live-output log file path for a given test node id."""
+    return Path(live_output_dir(data_dir), f"{sanitize_test_name(test_name)}.log")
+
+
+def read_live_output(data_dir: Path, test_name: str, max_bytes: int = 65536) -> str | None:
+    """Return the tail of the live-output log for a test, or ``None`` if missing.
+
+    Reads at most ``max_bytes`` from the end of the file.  If the file is
+    larger, the first (likely partial) line is dropped and a short truncation
+    marker is prepended so the user can see output is elided.
+
+    Decodes with ``errors="replace"`` so non-UTF-8 bytes don't crash the GUI.
+    """
+    path = live_output_path(data_dir, test_name)
+    try:
+        file_size = path.stat().st_size
+    except FileNotFoundError:
+        return None
+    with open(path, "rb") as fh:
+        truncated = file_size > max_bytes
+        if truncated:
+            fh.seek(-max_bytes, 2)
+        data = fh.read()
+    text = data.decode("utf-8", errors="replace")
+    if truncated:
+        newline_index = text.find("\n")
+        if newline_index != -1:
+            text = text[newline_index + 1 :]
+        text = _TRUNCATION_MARKER + text
+    return text
+
+
+def clear_live_output(data_dir: Path) -> None:
+    """Remove the entire live-output directory; safe if it does not exist."""
+    directory = live_output_dir(data_dir)
+    if not directory.exists():
+        return
+    for entry in directory.iterdir():
+        try:
+            entry.unlink()
+        except OSError:
+            pass
+    try:
+        directory.rmdir()
+    except OSError:
+        pass

--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -4,7 +4,6 @@ and a :class:`ProcessMonitor` that samples CPU/memory usage.
 """
 
 import contextlib
-import io
 import shutil
 import time
 import traceback
@@ -21,6 +20,7 @@ from ..db import PytestProcessInfoDB
 from ..file_util import sanitize_test_name
 from ..interfaces import PyTestFlyExitCode, PytestProcessInfo
 from ..logger import get_logger
+from .live_output import live_output_path
 from .process_monitor import ProcessMonitor
 
 log = get_logger(application_name)
@@ -73,35 +73,41 @@ class PytestProcess(Process):
             db.write(pytest_process_info)
 
         # Finally, actually run pytest!
-        # Redirect stdout and stderr so nothing goes to the console.
-        buf = io.StringIO()
-        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
-            # create a temp coverage file and then move it so if the file exists, the content is complete (the save is not necessarily instantaneous and atomic)
-            coverage_dir = Path(self.data_dir, "coverage")
-            coverage_dir.mkdir(parents=True, exist_ok=True)
-            safe_name = sanitize_test_name(self.name)
-            coverage_file_path = Path(coverage_dir, f"{safe_name}.coverage")
-            coverage_temp_file_path = Path(coverage_dir, f"{safe_name}.temp")
-            coverage_temp_file_path.unlink(missing_ok=True)
-            coverage = Coverage(coverage_temp_file_path)
-            coverage.start()
+        # Redirect stdout and stderr into a per-test log file so the GUI can tail live output
+        # while the test is running.  The file is line-buffered; ``-s`` (below) disables
+        # pytest's own capture so prints stream immediately.
+        live_path = live_output_path(self.data_dir, self.name)
+        live_path.parent.mkdir(parents=True, exist_ok=True)
+        live_path.unlink(missing_ok=True)
+        with open(live_path, "w", buffering=1, encoding="utf-8", errors="replace", newline="") as live_file:
+            with contextlib.redirect_stdout(live_file), contextlib.redirect_stderr(live_file):
+                # create a temp coverage file and then move it so if the file exists, the content is complete (the save is not necessarily instantaneous and atomic)
+                coverage_dir = Path(self.data_dir, "coverage")
+                coverage_dir.mkdir(parents=True, exist_ok=True)
+                safe_name = sanitize_test_name(self.name)
+                coverage_file_path = Path(coverage_dir, f"{safe_name}.coverage")
+                coverage_temp_file_path = Path(coverage_dir, f"{safe_name}.temp")
+                coverage_temp_file_path.unlink(missing_ok=True)
+                coverage = Coverage(coverage_temp_file_path)
+                coverage.start()
 
-            try:
-                # -rA: show full short test summary (all outcomes, untruncated assertion messages)
-                exit_code = pytest.main([self.name, "-rA"])
-            except Exception:
-                exit_code = PyTestFlyExitCode.INTERNAL_ERROR
                 try:
-                    buf.write(f"\n\npytest.main raised an exception:\n{traceback.format_exc()}")
-                except (ValueError, OSError):
-                    pass  # buf may be closed if the test redirected/closed stderr
+                    # -rA: show full short test summary (all outcomes, untruncated assertion messages)
+                    # -s: disable pytest capture so stdout/stderr stream live to the log file
+                    exit_code = pytest.main([self.name, "-rA", "-s"])
+                except Exception:
+                    exit_code = PyTestFlyExitCode.INTERNAL_ERROR
+                    try:
+                        live_file.write(f"\n\npytest.main raised an exception:\n{traceback.format_exc()}")
+                    except (ValueError, OSError):
+                        pass  # live_file may be closed if the test redirected/closed stderr
 
-            coverage.stop()
-            coverage.save()
-            coverage_file_path.unlink(missing_ok=True)
-            shutil.move(coverage_temp_file_path, coverage_file_path)
+                coverage.stop()
+                coverage.save()
+                coverage_file_path.unlink(missing_ok=True)
+                shutil.move(coverage_temp_file_path, coverage_file_path)
 
-        output: str = buf.getvalue()
+        output: str = live_path.read_text(encoding="utf-8", errors="replace")
 
         # stop the process monitor
         self._process_monitor_process.request_stop()

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -108,7 +108,7 @@ def test_status_window_with_data(app):
 
 def test_table_tab_empty(app):
     """TableTab should have zero rows for empty data."""
-    table = TableTab()
+    table = TableTab(get_temp_dir("table_tab"))
     tick = _make_tick_data_empty()
     table.update_tick(tick)
 
@@ -117,7 +117,7 @@ def test_table_tab_empty(app):
 
 def test_table_tab_with_data(app):
     """TableTab should show one row per test with correct state text."""
-    table = TableTab()
+    table = TableTab(get_temp_dir("table_tab"))
     tick = _make_tick_data_with_tests()
     table.update_tick(tick)
 
@@ -139,7 +139,7 @@ def test_table_tab_with_data(app):
 
 def test_table_tab_per_test_coverage(app):
     """TableTab should display per-test coverage when per_test_coverage is populated."""
-    table = TableTab()
+    table = TableTab(get_temp_dir("table_tab"))
     tick = _make_tick_data_with_tests()
     tick.per_test_coverage = {"tests/test_a.py": 0.123, "tests/test_b.py": 0.456}
     table.update_tick(tick)
@@ -169,7 +169,7 @@ def test_per_test_coverage_not_greater_than_combined(app):
         assert pct <= combined_pct, f"{test_name} coverage {pct:.1%} exceeds combined {combined_pct:.1%}"
 
     # Verify the table displays them correctly
-    table = TableTab()
+    table = TableTab(get_temp_dir("table_tab"))
     table.update_tick(tick)
     for row in range(table.table_widget.rowCount()):
         name_item = table.table_widget.item(row, 0)
@@ -183,7 +183,7 @@ def test_per_test_coverage_not_greater_than_combined(app):
 
 def test_table_tab_updates_on_second_tick(app):
     """TableTab should reflect new state when update_tick is called again."""
-    table = TableTab()
+    table = TableTab(get_temp_dir("table_tab"))
     guid = "test-guid-update"
     now = time.time()
 
@@ -212,7 +212,7 @@ def test_table_tab_last_pass_columns(app):
     """TableTab should display last pass start time and duration from last_pass_data."""
     from pytest_fly.gui.table_tab.table_tab import Columns
 
-    table = TableTab()
+    table = TableTab(get_temp_dir("table_tab"))
     tick = _make_tick_data_with_tests()
     now = time.time()
     tick.last_pass_data = {
@@ -250,7 +250,7 @@ def test_table_tab_double_click_name_sorts(app):
     """
     from pytest_fly.gui.table_tab.table_tab import Columns
 
-    table = TableTab()
+    table = TableTab(get_temp_dir("table_tab"))
     guid = "test-guid-sort"
     now = time.time()
 
@@ -792,7 +792,7 @@ def test_full_pipeline(app):
     assert "Pass: 1" in status_text
 
     # TableTab
-    table = TableTab()
+    table = TableTab(get_temp_dir("table_tab"))
     table.update_tick(tick)
     assert table.table_widget.rowCount() == 1
     assert table.table_widget.item(0, 0).text() == "tests/test_no_operation.py"


### PR DESCRIPTION
## Summary
- Adds a **Live Output** panel in the Run tab (beside Failed Tests) with a combo to pick which running test to watch and a Follow-tail toggle.
- Extends the Table tab: State-cell tooltip and right-click **Copy Pytest Output** now read the same live log while a test is still running.
- Each pytest process streams stdout/stderr to a line-buffered log under ``data_dir/live_output/`` while running; the file is read back into ``PytestProcessInfo.output`` on completion, preserving the existing DB contract. Pytest is now invoked with ``-s`` so output streams rather than being batched.

## Test plan
- [ ] Run a test that prints on a timer (``for i in range(20): print(i); time.sleep(0.5)``) and confirm output increments live in the Run-tab panel within one refresh tick.
- [ ] Hover a running row's State cell in the Table tab; tooltip shows the current live tail.
- [ ] On a completed test, right-click → **Copy Pytest Output** still returns the full untruncated output.
- [ ] On a running test, right-click → **Copy Pytest Output** returns the current live output.
- [ ] Run two modules in parallel printing distinct markers; switching the combo shows the correct per-test stream.
- [ ] Drag both splitters, restart the app, confirm both positions restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)