### PR TITLE
Apply prior-data ordering aspects in RESTART mode too

### DIFF
--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -20,7 +20,7 @@ from ...logger import get_logger
 from ...preferences import ParallelismControl, get_ordering_aspects_ordered, get_pref
 from ...put_version import detect_put_version
 from ...pytest_runner.coverage import compute_per_test_coverage
-from ...pytest_runner.ordering import PRIOR_DATA_ASPECTS, OrderingContext, apply_ordering_aspects
+from ...pytest_runner.ordering import OrderingContext, apply_ordering_aspects
 from ...pytest_runner.pytest_runner import PytestRunner
 from ...pytest_runner.test_list import GetTests
 from .control_pushbutton import ControlButton
@@ -176,10 +176,9 @@ class ControlWindow(QGroupBox):
         self.num_processes = processes
 
         # Apply the user's ordered list of ordering aspects (see Configuration tab).
+        # Prior-run data still informs execution *order* even in RESTART mode — RESTART only
+        # means "rerun every test," not "forget the durations/failures we know about."
         enabled_aspects: list[OrderingAspect] = get_ordering_aspects_ordered()
-        if effective_mode == RunMode.RESTART:
-            # RESTART ignores prior-run results, so aspects that depend on them do nothing.
-            enabled_aspects = [a for a in enabled_aspects if a not in PRIOR_DATA_ASPECTS]
 
         per_test_cov: dict[str, float] = {}
         if OrderingAspect.COVERAGE_EFFICIENCY in enabled_aspects:

--- a/src/pytest_fly/pytest_runner/ordering.py
+++ b/src/pytest_fly/pytest_runner/ordering.py
@@ -25,11 +25,6 @@ class OrderingContext:
     per_test_coverage: dict[str, float] = field(default_factory=dict)  # node_id -> fraction covered (0..1); unused for keying but preserved for completeness
 
 
-# Aspects that require prior-run data.  In RunMode.RESTART these are filtered
-# out by the caller before invoking :func:`apply_ordering_aspects`.
-PRIOR_DATA_ASPECTS: frozenset[OrderingAspect] = frozenset({OrderingAspect.FAILED_FIRST, OrderingAspect.LONGEST_PRIOR_FIRST, OrderingAspect.COVERAGE_EFFICIENCY})
-
-
 def _key_for(aspect: OrderingAspect, test: ScheduledTest, ctx: OrderingContext) -> float:
     """Return a sort key for *test* under *aspect*.  Lower = earlier."""
     if aspect is OrderingAspect.FAILED_FIRST:
@@ -64,8 +59,9 @@ def apply_ordering_aspects(
 
     :param tests: Tests to order.
     :param aspects: Enabled aspects in priority order (index 0 = highest priority).
-        Callers are expected to have already filtered out disabled aspects and,
-        in RESTART mode, aspects in :data:`PRIOR_DATA_ASPECTS`.
+        Callers are expected to have already filtered out disabled aspects.
+        Aspects that read prior-run data gracefully produce tie keys when no data
+        exists, so they are safe to include in RESTART mode too.
     :param ctx: Supporting data for the aspect key functions.
     :return: A new list ordered for execution.
     """

--- a/tests/test_ordering_aspects.py
+++ b/tests/test_ordering_aspects.py
@@ -2,7 +2,6 @@
 
 from pytest_fly.interfaces import OrderingAspect, ScheduledTest
 from pytest_fly.pytest_runner.ordering import (
-    PRIOR_DATA_ASPECTS,
     OrderingContext,
     apply_ordering_aspects,
 )
@@ -95,8 +94,9 @@ def test_singleton_invariant_across_aspects():
     assert result[-1].node_id == "singleton_a"
 
 
-def test_prior_data_aspects_set():
-    assert OrderingAspect.FAILED_FIRST in PRIOR_DATA_ASPECTS
-    assert OrderingAspect.LONGEST_PRIOR_FIRST in PRIOR_DATA_ASPECTS
-    assert OrderingAspect.COVERAGE_EFFICIENCY in PRIOR_DATA_ASPECTS
-    assert OrderingAspect.NEVER_RUN_FIRST not in PRIOR_DATA_ASPECTS
+def test_longest_prior_first_works_without_any_prior_data():
+    """With no prior durations at all (e.g. first ever run), the aspect is a no-op
+    rather than a crash — all tests get tie key 0 and fall back to the alphabetical baseline."""
+    tests = [_t("b"), _t("a"), _t("c")]
+    result = apply_ordering_aspects(tests, [OrderingAspect.LONGEST_PRIOR_FIRST], OrderingContext())
+    assert [t.node_id for t in result] == ["a", "b", "c"]


### PR DESCRIPTION
## Summary
- Longest-prior-first (and failed-first / coverage-efficiency) were silently stripped in RESTART mode and in CHECK-falls-back-to-RESTART. RESTART means \"rerun every test,\" not \"forget the prior durations/failures that determine order.\"
- Drops the \`PRIOR_DATA_ASPECTS\` blanket exclusion in ``ControlWindow.run`` and removes the now-unused frozenset from ``ordering.py``.
- Aspect key functions already produce tie keys when their data is missing, so first-ever runs (no DB records) gracefully fall back to the alphabetical baseline.

## Test plan
- [ ] Run a suite twice: first run warms the DB; second run with **Longest prior** enabled in RESTART mode should launch the slowest prior test first.
- [ ] Repeat with **Failed first** in RESTART mode — previously-failed tests launch first.
- [ ] First-ever run (no DB) with any prior-data aspect enabled should not crash; order falls back to alphabetical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)