### PR TITLE
Tighter Progress Graph rows + configurable graph font size; bump to 0.3.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
   - **Coverage** — line chart of combined code coverage over time with covered/total line counts
   - **Configuration** — Resume-vs-Check toggle, a reorderable test-ordering aspect list, process
     count, refresh rate, utilization thresholds, tooltip line limit, system-metrics chart window,
-    target project path, and an Expert group (verbose logging, UI performance logging)
+    Progress Graph font size, target project path, and an Expert group (verbose logging, UI
+    performance logging)
   - **About** — system and project information
 - Parallel test execution at the module level with configurable process count.
 - Three run modes — **Restart** (rerun all tests), **Resume** (skip already-passed tests and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.40"
+version = "0.3.41"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -33,6 +33,7 @@ from pytest_fly.preferences import (
     chart_window_minutes_default,
     get_ordering_aspects_ordered,
     get_pref,
+    graph_font_size_default,
     refresh_rate_default,
     set_ordering_aspects_ordered,
     tooltip_line_limit_default,
@@ -226,6 +227,7 @@ log = get_logger()
 minimum_refresh_rate = 1.0
 minimum_tooltip_line_limit = 1
 minimum_chart_window_minutes = 0.5
+minimum_graph_font_size = 6
 
 
 def _add_labeled_lineedit(
@@ -325,6 +327,11 @@ class Configuration(QWidget):
         self.chart_window_minutes_lineedit = _add_labeled_lineedit(
             layout, chart_window_label, str(pref.chart_window_minutes), QDoubleValidator(), self.update_chart_window_minutes, char_width=6
         )
+
+        layout.addWidget(QLabel(""))  # space
+
+        graph_font_size_label = f"Progress Graph Font Size (points, {minimum_graph_font_size} minimum, {graph_font_size_default} default)"
+        self.graph_font_size_lineedit = _add_labeled_lineedit(layout, graph_font_size_label, str(pref.graph_font_size), QIntValidator(), self.update_graph_font_size, char_width=6)
 
         layout.addWidget(QLabel(""))  # space
 
@@ -431,6 +438,12 @@ class Configuration(QWidget):
             pref.chart_window_minutes = max(float(value), minimum_chart_window_minutes)
         except ValueError:
             pass
+
+    def update_graph_font_size(self, value: str):
+        """Persist the Progress Graph font size (clamped to *minimum_graph_font_size*)."""
+        pref = get_pref()
+        if value.isnumeric():
+            pref.graph_font_size = max(int(value), minimum_graph_font_size)
 
     def update_target_project_path(self, value: str):
         """Persist the target-project path override (empty = auto-detect)."""

--- a/src/pytest_fly/gui/graph_tab/graph_tab.py
+++ b/src/pytest_fly/gui/graph_tab/graph_tab.py
@@ -17,6 +17,8 @@ class GraphTab(QGroupBox):
         self.progress_bars: dict[str, PytestProgressBar] = {}
 
         outer_layout = QVBoxLayout()
+        outer_layout.setContentsMargins(0, 0, 0, 0)
+        outer_layout.setSpacing(0)
         self.setLayout(outer_layout)
 
         self.time_axis = TimeAxisWidget()
@@ -31,6 +33,10 @@ class GraphTab(QGroupBox):
         self._bar_container = QWidget()
         self._bar_layout = QVBoxLayout()
         self._bar_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+        # Pack bars flush — Qt's default spacing/margins push rows apart enough
+        # that only a handful fit on screen at once.
+        self._bar_layout.setSpacing(0)
+        self._bar_layout.setContentsMargins(0, 0, 0, 0)
         self._bar_container.setLayout(self._bar_layout)
         self._scroll_area.setWidget(self._bar_container)
 

--- a/src/pytest_fly/gui/graph_tab/progress_bar.py
+++ b/src/pytest_fly/gui/graph_tab/progress_bar.py
@@ -7,14 +7,15 @@ import time
 
 from PySide6.QtCore import QPointF, QRectF
 from PySide6.QtGui import QBrush, QGuiApplication, QPainter, QPen
-from PySide6.QtWidgets import QMenu, QToolTip, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QMenu, QToolTip, QWidget
 from typeguard import typechecked
 
 from ...colors import GRID_LINE_COLOR
 from ...interfaces import PytestProcessInfo, PytestRunnerState
 from ...logger import get_logger
+from ...preferences import get_pref
 from ...pytest_runner.pytest_runner import PytestRunState
-from ..gui_util import get_text_dimensions, tool_tip_limiter, window_text_color
+from ..gui_util import get_font, get_text_dimensions, tool_tip_limiter, window_text_color
 from .time_axis import TimeAxisMapping, compute_grid_ticks
 
 log = get_logger()
@@ -36,9 +37,9 @@ class PytestProgressBar(QWidget):
     ) -> None:
 
         super().__init__()
-        layout = QVBoxLayout()
-        self.setLayout(layout)
-        self.one_character_dimensions = get_text_dimensions("X")
+        self.bar_margin = 1
+        self._font_size = self._apply_graph_font()
+        self.one_character_dimensions = get_text_dimensions("X", size=self._font_size)
 
         self.status_list = status_list
         self.min_time_stamp = min_time_stamp
@@ -48,10 +49,9 @@ class PytestProgressBar(QWidget):
 
         if len(status_list) > 0:
             name = status_list[0].name
-            name_text_dimensions = get_text_dimensions(name)
+            name_text_dimensions = get_text_dimensions(name, size=self._font_size)
         else:
             name_text_dimensions = self.one_character_dimensions
-        self.bar_margin = 1
         self.bar_height = name_text_dimensions.height() + 2 * self.bar_margin
         self.setFixedHeight(self.bar_height)
         log.debug(f"{self.bar_height=},{name_text_dimensions=}")
@@ -69,11 +69,22 @@ class PytestProgressBar(QWidget):
 
         self.update_pytest_process_info(status_list, min_time_stamp, max_time_stamp, run_state, is_singleton)
 
+    def _apply_graph_font(self) -> int:
+        """Read the user's graph-font-size preference, apply it to this widget, and return the size."""
+        size = get_pref().graph_font_size
+        self.setFont(get_font(size=size))
+        return size
+
     def update_pytest_process_info(self, status_list: list[PytestProcessInfo], min_time_stamp: float, max_time_stamp: float, run_state: PytestRunState, is_singleton: bool = False):
         """
         Update the bar's data and schedule a repaint — but only if the data
         actually changed or the test is still running (its bar grows over time).
         """
+        # Re-read the graph font size so pref changes propagate on the next tick.
+        new_font_size = self._apply_graph_font()
+        font_changed = new_font_size != self._font_size
+        self._font_size = new_font_size
+
         # O(1) change detection: skip repaint if nothing changed
         new_count = len(status_list)
         new_last_ts = status_list[-1].time_stamp if status_list else None
@@ -82,6 +93,7 @@ class PytestProgressBar(QWidget):
         unchanged = (
             not is_running
             and not singleton_changed
+            and not font_changed
             and new_count == self._prev_count
             and new_last_ts == self._prev_last_ts
             and min_time_stamp == self._prev_min_ts
@@ -102,9 +114,10 @@ class PytestProgressBar(QWidget):
 
         if len(self.status_list) > 0:
             name = self.status_list[0].name
-            name_text_dimensions = get_text_dimensions(name)
+            name_text_dimensions = get_text_dimensions(name, size=self._font_size)
         else:
             name_text_dimensions = self.one_character_dimensions
+        self.one_character_dimensions = get_text_dimensions("X", size=self._font_size)
         self.bar_height = name_text_dimensions.height() + 2 * self.bar_margin
         self.setFixedHeight(self.bar_height)
 

--- a/src/pytest_fly/gui/graph_tab/time_axis.py
+++ b/src/pytest_fly/gui/graph_tab/time_axis.py
@@ -15,7 +15,8 @@ from PySide6.QtGui import QPainter, QPen
 from PySide6.QtWidgets import QWidget
 
 from ...colors import GRID_LINE_COLOR
-from ..gui_util import get_text_dimensions, window_text_color
+from ...preferences import get_pref
+from ..gui_util import get_font, get_text_dimensions, window_text_color
 
 # Candidate intervals in seconds — chosen so labels stay readable.
 # Extends up to 24h so multi-hour runs don't collapse to minute-granularity grid lines.
@@ -109,16 +110,32 @@ class TimeAxisWidget(QWidget):
 
     def __init__(self):
         super().__init__()
-        char_dims = get_text_dimensions("X")
-        self._axis_height = char_dims.height() + 8  # text + small padding
-        self.setFixedHeight(self._axis_height)
+        self._font_size = self._apply_graph_font()
+        self._apply_axis_height()
 
         self._min_ts: float | None = None
         self._max_ts: float | None = None
 
+    def _apply_graph_font(self) -> int:
+        """Read the user's graph-font-size preference, apply it to this widget, and return the size."""
+        size = get_pref().graph_font_size
+        self.setFont(get_font(size=size))
+        return size
+
+    def _apply_axis_height(self) -> None:
+        """Resize the axis to fit the current font's text height plus a small padding."""
+        char_dims = get_text_dimensions("X", size=self._font_size)
+        self._axis_height = char_dims.height() + 8
+        self.setFixedHeight(self._axis_height)
+
     def update_time_window(self, min_ts: float | None, max_ts: float | None):
         """Store the current time window and schedule a repaint."""
-        if min_ts == self._min_ts and max_ts == self._max_ts:
+        new_size = self._apply_graph_font()
+        font_changed = new_size != self._font_size
+        self._font_size = new_size
+        if font_changed:
+            self._apply_axis_height()
+        if not font_changed and min_ts == self._min_ts and max_ts == self._max_ts:
             return
         self._min_ts = min_ts
         self._max_ts = max_ts
@@ -144,7 +161,7 @@ class TimeAxisWidget(QWidget):
         # Draw labels
         painter.setPen(QPen(window_text_color(self), 1))
         for x, label in ticks:
-            label_width = get_text_dimensions(label).width()
+            label_width = get_text_dimensions(label, size=self._font_size).width()
             # Center label on tick; clamp so it doesn't overflow the left edge
             label_x = max(int(x) - label_width // 2, 0)
             label_y = h - tick_height - 2  # just above the tick mark

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -8,7 +8,7 @@ reusable widgets used across multiple tabs.
 import time
 from collections import defaultdict
 from datetime import timedelta
-from functools import cache, lru_cache
+from functools import lru_cache
 
 import humanize
 from PySide6.QtCore import QSize
@@ -20,28 +20,31 @@ from ..interfaces import PytestProcessInfo
 from ..preferences import get_pref
 
 
-@cache
-def get_font() -> QFont:
-    # monospace font
+@lru_cache(maxsize=None)
+def get_font(size: int | None = None) -> QFont:
+    """Return the shared monospace bold font, optionally at *size* points."""
     font = QFont("Monospace")
     font.setStyleHint(QFont.StyleHint.Monospace)
     font.setFixedPitch(True)
     font.setBold(True)
+    if size is not None:
+        font.setPointSize(size)
     assert font.styleHint() == QFont.StyleHint.Monospace
     assert font.fixedPitch()
     return font
 
 
 @lru_cache(maxsize=1000)
-def get_text_dimensions(text: str, pad: bool = False) -> QSize:
+def get_text_dimensions(text: str, pad: bool = False, size: int | None = None) -> QSize:
     """
     Determine the dimensions of the provided text
 
     :param text: The text to measure
     :param pad: Whether to add padding to the text
+    :param size: Optional point size; when omitted, uses the default monospace font size.
     :return: The size of the text
     """
-    font = get_font()
+    font = get_font(size)
     metrics = QFontMetrics(font)
     text_size = metrics.size(0, text)  # Get the size of the text (QSize)
     if pad:

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -26,6 +26,7 @@ utilization_low_threshold_default = 0.5
 run_with_coverage_default = True
 tooltip_line_limit_default = 40  # max lines shown in pytest-output tooltips before truncation
 chart_window_minutes_default = 5.0  # width of the system-metrics chart time window on the Run tab, in minutes
+graph_font_size_default = 10  # point size of the font used in the Progress Graph tab
 
 
 class ParallelismControl(IntEnum):
@@ -65,6 +66,8 @@ class FlyPreferences(Pref):
     tooltip_line_limit: int = attrib(default=tooltip_line_limit_default)  # max lines of pytest output shown in a tooltip before truncation
 
     chart_window_minutes: float = attrib(default=chart_window_minutes_default)  # Run-tab system-metrics chart window (minutes)
+
+    graph_font_size: int = attrib(default=graph_font_size_default)  # Progress Graph tab font size, in points
 
     run_tab_splitter_state: str = attrib(default="")  # Run-tab top-vs-failed-tests splitter (QSplitter.saveState() hex-encoded)
     run_tab_bottom_splitter_state: str = attrib(default="")  # Run-tab bottom pane: failed-tests-vs-live-output splitter (QSplitter.saveState() hex-encoded)


### PR DESCRIPTION
## Summary
- Pack the Progress Graph rows flush: `QVBoxLayout.setSpacing(0)` + zero contents margins on both the bar layout and the tab's outer layout so many more test rows fit on screen.
- Drop the vestigial empty inner `QVBoxLayout` that `PytestProgressBar.__init__` used to create but never populate.
- New user preference `graph_font_size` (default 10 pt, min 6 pt), surfaced via the Configuration tab. Extended `get_font` / `get_text_dimensions` in `gui_util` with an optional `size` param so the graph widgets can ask for a tunable-size monospace font without disturbing other tabs.
- The progress bar and time-axis widgets re-read the pref each tick, so changes propagate live (≤ refresh_rate seconds) without any signal wiring.
- README Configuration tab bullet updated to mention the new pref.
- Version bumped 0.3.40 → 0.3.41.

## Test plan
- [ ] Launch `python -m pytest_fly`; verify the Graph tab shows noticeably more rows on screen than before.
- [ ] Change **Progress Graph Font Size** in the Configuration tab (try 6, 12, 14) and confirm the Graph tab bars and time-axis labels resize within one refresh interval (≤ 3 s).
- [ ] Enter a value below the 6 pt floor (e.g. 4) and confirm the clamp holds.
- [ ] Other tabs (Run, Table, Coverage, About) retain their previous fonts unchanged.
- [ ] `ruff check src tests` and `ruff format --check src tests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)