### PR TITLE
Add Status-window completion indicators; bump to 0.3.42

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.41"
+version = "0.3.42"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -2,9 +2,9 @@
 
 import time
 
-from PySide6.QtWidgets import QGroupBox, QSizePolicy, QVBoxLayout
+from PySide6.QtWidgets import QGroupBox, QLabel, QProgressBar, QSizePolicy, QVBoxLayout
 
-from ...gui.gui_util import PlainTextWidget, count_test_states, format_runtime
+from ...gui.gui_util import PlainTextWidget, count_test_states, format_runtime, get_font
 from ...interfaces import PytestRunnerState
 from ...tick_data import TickData
 
@@ -20,6 +20,22 @@ class StatusWindow(QGroupBox):
         self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.MinimumExpanding)
         self.status_widget = PlainTextWidget(self, "Loading...")
         layout.addWidget(self.status_widget)
+
+        self.progress_bar = QProgressBar(self)
+        self.progress_bar.setRange(0, 100)
+        self.progress_bar.setValue(0)
+        self.progress_bar.setFormat("%p%")
+        self.progress_bar.setTextVisible(True)
+        layout.addWidget(self.progress_bar)
+
+        label_font = get_font()
+        self.complete_label = QLabel("Complete: (calculating...)", self)
+        self.complete_label.setFont(label_font)
+        layout.addWidget(self.complete_label)
+
+        self.pass_rate_label = QLabel("Pass rate: (calculating...)", self)
+        self.pass_rate_label.setFont(label_font)
+        layout.addWidget(self.pass_rate_label)
 
     def update_tick(self, tick: TickData):
         """
@@ -48,14 +64,24 @@ class StatusWindow(QGroupBox):
             current_fail_count = counts[PytestRunnerState.FAIL]
             total_completed = current_pass_count + current_fail_count
             complete_fraction = total_completed / total_tests
-            lines.append(f"Complete: {total_completed}/{total_tests} ({complete_fraction:.2%})")
-            prefix = "Pass rate: "
+            is_complete = counts[PytestRunnerState.QUEUED] == 0 and counts[PytestRunnerState.RUNNING] == 0
+
+            self.progress_bar.setValue(int(round(complete_fraction * 100)))
+
+            self.complete_label.setText(f"Complete: {total_completed}/{total_tests} ({complete_fraction:.2%})")
+            self.complete_label.setStyleSheet("font-weight: bold;" if is_complete else "font-weight: normal;")
+
             if total_completed > 0:
                 pass_rate = current_pass_count / total_completed
-                lines.append(f"{prefix}{current_pass_count}/{total_completed} ({pass_rate:.2%})")
+                self.pass_rate_label.setText(f"Pass rate: {current_pass_count}/{total_completed} ({pass_rate:.2%})")
             else:
-                lines.append(f"{prefix}(calculating...)")
-            lines.append("")  # space
+                self.pass_rate_label.setText("Pass rate: (calculating...)")
+            if is_complete and current_pass_count == total_tests:
+                self.pass_rate_label.setStyleSheet("color: green;")
+            elif is_complete:
+                self.pass_rate_label.setStyleSheet("color: red;")
+            else:
+                self.pass_rate_label.setStyleSheet("")
 
             for state in [PytestRunnerState.PASS, PytestRunnerState.FAIL, PytestRunnerState.QUEUED, PytestRunnerState.RUNNING, PytestRunnerState.TERMINATED, PytestRunnerState.STOPPED]:
                 count = counts[state]
@@ -102,6 +128,12 @@ class StatusWindow(QGroupBox):
                     put_line += "  [uncommitted changes]"
                 lines.extend([put_line, ""])
             lines.append("Calculating...")
+
+            self.progress_bar.setValue(0)
+            self.complete_label.setText("Complete: (calculating...)")
+            self.complete_label.setStyleSheet("font-weight: normal;")
+            self.pass_rate_label.setText("Pass rate: (calculating...)")
+            self.pass_rate_label.setStyleSheet("")
 
         self.status_widget.set_text("\n".join(lines))
 

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -93,8 +93,9 @@ def test_status_window_with_data(app):
     text = window.status_widget.toPlainText()
     assert "3 tests" in text
     # 1 pass out of 2 completed (test_a passed, test_b failed, test_c queued)
-    assert "Pass rate:" in text
-    assert "1/2" in text
+    pass_rate_text = window.pass_rate_label.text()
+    assert "Pass rate:" in pass_rate_text
+    assert "1/2" in pass_rate_text
     # State counts should be present
     assert "Pass: 1" in text
     assert "Fail: 1" in text


### PR DESCRIPTION
## Summary
- Add a `QProgressBar` to the Run tab's Status widget showing % complete
- Bold the "Complete: X/Y" line once the run finishes (no more QUEUED or RUNNING)
- Color the "Pass rate" line green on 100% pass, red on any fails, default while running
- Bump version to 0.3.42

## Test plan
- [x] `ruff check` / `ruff format --check` pass on edited files
- [x] Headless smoke test driving `update_tick` through mid-run / all-pass / mixed-fail / empty scenarios produces the expected progress value, text, and stylesheet
- [x] Full `pytest tests/` suite passes (test_status_window_with_data updated to read the new `pass_rate_label`)
- [ ] Manual eye-check: launch `python -m pytest_fly`, run the test suite, confirm bold/green/red transitions render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)