### PR TITLE
Reduce per-tick GUI work to fix UI lag; bump to 0.3.43

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.42"
+version = "0.3.43"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/db/db.py
+++ b/src/pytest_fly/db/db.py
@@ -30,6 +30,11 @@ class PytestProcessInfoDB(MSQLite):
     loss is acceptable.
     """
 
+    # Paths whose schema and journal-mode have already been validated this
+    # process.  The GUI reopens this class on every refresh tick and the
+    # schema/pragma work only needs to run once.
+    _initialized_paths: set[Path] = set()
+
     @typechecked
     def __init__(self, db_dir: Path):
         table_name = "pytest_process_info"
@@ -62,26 +67,40 @@ class PytestProcessInfoDB(MSQLite):
 
         db_path = Path(db_dir, f"{application_name}.db")
 
-        # Schema migration: if the table exists with a different set of columns, drop it so
-        # MSQLite recreates it with the current schema.  Test results are ephemeral, so data loss is acceptable.
-        # Note: sqlite3 context manager only handles transactions, not closing — call close() explicitly
-        # to release the Windows file lock before MSQLite opens its own connection below.
-        if db_path.exists():
-            _conn = sqlite3.connect(db_path)
-            try:
-                existing_columns = {row[1] for row in _conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
-            finally:
-                _conn.close()
-            if existing_columns and existing_columns != set(self._columns):
-                log.info(f"Schema change detected for {table_name!r} – dropping table to recreate with new schema")
+        if db_path not in PytestProcessInfoDB._initialized_paths:
+            # Schema migration: if the table exists with a different set of columns, drop it so
+            # MSQLite recreates it with the current schema.  Test results are ephemeral, so data loss is acceptable.
+            # Note: sqlite3 context manager only handles transactions, not closing — call close() explicitly
+            # to release the Windows file lock before MSQLite opens its own connection below.
+            if db_path.exists():
                 _conn = sqlite3.connect(db_path)
                 try:
-                    _conn.execute(f"DROP TABLE IF EXISTS {table_name}")
-                    _conn.commit()
+                    existing_columns = {row[1] for row in _conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
                 finally:
                     _conn.close()
+                if existing_columns and existing_columns != set(self._columns):
+                    log.info(f"Schema change detected for {table_name!r} – dropping table to recreate with new schema")
+                    _conn = sqlite3.connect(db_path)
+                    try:
+                        _conn.execute(f"DROP TABLE IF EXISTS {table_name}")
+                        _conn.commit()
+                    finally:
+                        _conn.close()
 
-        super().__init__(db_path, table_name, self._schema, indexes=["run_guid"])
+            # WAL lets GUI readers proceed concurrently with test-process writers instead of
+            # serializing through BEGIN EXCLUSIVE — the main source of GUI-read stalls while a run
+            # is in progress.  WAL mode is a persistent per-file property, but re-issuing the pragma
+            # on a WAL database is a no-op, so the one-shot guard is sufficient.
+            _conn = sqlite3.connect(db_path)
+            try:
+                _conn.execute("PRAGMA journal_mode=WAL")
+                _conn.commit()
+            finally:
+                _conn.close()
+
+            PytestProcessInfoDB._initialized_paths.add(db_path)
+
+        super().__init__(db_path, table_name, self._schema, indexes=["run_guid", "exit_code"])
 
     @typechecked
     def write(self, pytest_process_info: PytestProcessInfo) -> None:

--- a/src/pytest_fly/gui/graph_tab/graph_tab.py
+++ b/src/pytest_fly/gui/graph_tab/graph_tab.py
@@ -15,6 +15,7 @@ class GraphTab(QGroupBox):
         super().__init__()
         self.setTitle("Progress")
         self.progress_bars: dict[str, PytestProgressBar] = {}
+        self._layout_order: list[str] = []
 
         outer_layout = QVBoxLayout()
         outer_layout.setContentsMargins(0, 0, 0, 0)
@@ -65,8 +66,13 @@ class GraphTab(QGroupBox):
                 progress_bar = PytestProgressBar(infos, effective_min, tick.max_time_stamp, run_state, is_singleton)
                 self.progress_bars[test_name] = progress_bar
 
-        # Ensure layout order matches tick.infos_by_name order (same as table tab)
-        while self._bar_layout.count():
-            self._bar_layout.takeAt(0)
-        for test_name in tick.infos_by_name:
-            self._bar_layout.addWidget(self.progress_bars[test_name])
+        # Ensure layout order matches tick.infos_by_name order (same as table tab).
+        # In steady state the order doesn't change — skip the takeAt/addWidget churn
+        # (and associated layout invalidation) when the order is already correct.
+        desired_order = list(tick.infos_by_name)
+        if desired_order != self._layout_order:
+            while self._bar_layout.count():
+                self._bar_layout.takeAt(0)
+            for test_name in desired_order:
+                self._bar_layout.addWidget(self.progress_bars[test_name])
+            self._layout_order = desired_order

--- a/src/pytest_fly/gui/graph_tab/time_axis.py
+++ b/src/pytest_fly/gui/graph_tab/time_axis.py
@@ -10,6 +10,7 @@ Provides:
 """
 
 from dataclasses import dataclass
+from functools import lru_cache
 
 from PySide6.QtGui import QPainter, QPen
 from PySide6.QtWidgets import QWidget
@@ -81,18 +82,8 @@ def format_elapsed_label(elapsed_seconds: float) -> str:
     return f"{hours}h{minutes}m"
 
 
-def compute_grid_ticks(min_ts: float | None, max_ts: float | None, width_pixels: int) -> list[tuple[float, str]]:
-    """
-    Compute X-pixel positions and labels for time-axis grid lines.
-
-    :param min_ts: Earliest timestamp (epoch seconds), or ``None``.
-    :param max_ts: Latest timestamp (epoch seconds), or ``None``.
-    :param width_pixels: Widget width in pixels.
-    :return: List of ``(x_pixel, label_text)`` tuples.
-    """
-    if min_ts is None or max_ts is None or width_pixels <= 0:
-        return []
-
+@lru_cache(maxsize=8)
+def _compute_grid_ticks_cached(min_ts: float, max_ts: float, width_pixels: int) -> tuple[tuple[float, str], ...]:
     mapping = TimeAxisMapping(min_ts=min_ts, max_ts=max_ts, width_pixels=width_pixels)
     interval = _choose_interval(mapping.time_window)
 
@@ -102,7 +93,25 @@ def compute_grid_ticks(min_ts: float | None, max_ts: float | None, width_pixels:
         ticks.append((mapping.elapsed_to_x(elapsed), format_elapsed_label(elapsed)))
         elapsed += interval
 
-    return ticks
+    return tuple(ticks)
+
+
+def compute_grid_ticks(min_ts: float | None, max_ts: float | None, width_pixels: int) -> list[tuple[float, str]]:
+    """
+    Compute X-pixel positions and labels for time-axis grid lines.
+
+    Cached across calls with identical inputs — every progress bar in a single
+    paint pass calls this with the same (min_ts, max_ts, width) tuple, and the
+    time-axis header adds a fourth with only a different width.
+
+    :param min_ts: Earliest timestamp (epoch seconds), or ``None``.
+    :param max_ts: Latest timestamp (epoch seconds), or ``None``.
+    :param width_pixels: Widget width in pixels.
+    :return: List of ``(x_pixel, label_text)`` tuples.
+    """
+    if min_ts is None or max_ts is None or width_pixels <= 0:
+        return []
+    return list(_compute_grid_ticks_cached(min_ts, max_ts, width_pixels))
 
 
 class TimeAxisWidget(QWidget):

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -23,7 +23,7 @@ from typeguard import typechecked
 
 from ..__version__ import application_name
 from ..db import PytestProcessInfoDB
-from ..interfaces import PutVersionInfo, PytestRunnerState
+from ..interfaces import PutVersionInfo, PyTestFlyExitCode, PytestRunnerState
 from ..logger import get_logger
 from ..preferences import get_pref
 from ..pytest_runner.pytest_runner import PytestRunState
@@ -155,6 +155,12 @@ class FlyAppMainWindow(QMainWindow):
 
         self._coverage_tracker = CoverageTracker(self.data_dir)
 
+        # query_last_pass scans the full DB history — cache its result and only
+        # re-query when the set of passing tests in the current run has grown.
+        self._last_pass_cache: dict[str, tuple[float, float]] = {}
+        self._last_pass_cache_run_guid: str | None = None
+        self._last_pass_cache_pass_count: int = -1
+
         self.table_tab.force_stop_test_requested.connect(self._force_stop_single_test)
 
         self.setCentralWidget(self.tab_widget)
@@ -229,11 +235,19 @@ class FlyAppMainWindow(QMainWindow):
         timer = PhaseTimer()
         tick_start = time.perf_counter()
 
+        run_guid = self.run_tab.control_window.run_guid
         with PytestProcessInfoDB(self.data_dir) as db:
             with timer.time("db_query"):
-                process_infos = db.query(self.run_tab.control_window.run_guid)
+                process_infos = db.query(run_guid)
             with timer.time("db_last_pass"):
-                last_pass_data = db.query_last_pass()
+                # query_last_pass scans the full DB — only re-run when the set of
+                # passing tests for the current run has grown, or on run change.
+                pass_count = sum(1 for info in process_infos if info.exit_code == PyTestFlyExitCode.OK)
+                if run_guid != self._last_pass_cache_run_guid or pass_count != self._last_pass_cache_pass_count:
+                    self._last_pass_cache = db.query_last_pass()
+                    self._last_pass_cache_run_guid = run_guid
+                    self._last_pass_cache_pass_count = pass_count
+                last_pass_data = self._last_pass_cache
 
         control = self.run_tab.control_window
         with timer.time("build"):

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -62,10 +62,14 @@ class PlainTextWidget(QPlainTextEdit):
         self.setReadOnly(True)
         self.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
         self.setSizePolicy(QSizePolicy.Policy.MinimumExpanding, QSizePolicy.Policy.MinimumExpanding)
+        self._last_text: str | None = None
         self.set_text(initial_text)
 
     def set_text(self, text: str):
         """Replace the displayed text and resize to fit content without wrapping."""
+        if text == self._last_text:
+            return
+        self._last_text = text
         self.setPlainText(text)
         # Calculate the width needed to display the longest line
         doc = self.document()

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -87,8 +87,13 @@ class ControlWindow(QGroupBox):
         max_width += 30
         self.setFixedWidth(max_width)
 
-    def update(self):
-        """Enable/disable run, stop, and force stop buttons based on the runner state."""
+    def refresh_button_state(self):
+        """Enable/disable run, stop, and force stop buttons based on the runner state.
+
+        Named to avoid shadowing :meth:`QWidget.update`, which Qt internals may
+        call to schedule a repaint — when that was overridden, a repaint request
+        would silently mutate button state instead.
+        """
         if self.pytest_runner is None or not self.pytest_runner.is_running():
             self.run_button.setEnabled(True)
             self.stop_button.setEnabled(False)

--- a/src/pytest_fly/gui/run_tab/run_tab.py
+++ b/src/pytest_fly/gui/run_tab/run_tab.py
@@ -75,7 +75,7 @@ class RunTab(QWidget):
         self.failed_tests_window.update_tick(tick)
         self.live_output_window.update_tick(tick)
         self.system_metrics_window.update_tick()
-        self.control_window.update()
+        self.control_window.refresh_button_state()
 
     def _restore_splitter_state(self) -> None:
         """Restore the saved splitter divider position, if any."""

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -231,9 +231,18 @@ class TableTab(QGroupBox):
                     self._row_by_name[name] = row
 
     @staticmethod
-    def _set_text_if_changed(item: QTableWidgetItem, text: str) -> None:
+    def _set_text_if_changed(item: QTableWidgetItem, text: str) -> bool:
         if item.text() != text:
             item.setText(text)
+            return True
+        return False
+
+    @staticmethod
+    def _set_sort_key_if_changed(item: QTableWidgetItem, value) -> bool:
+        if item.data(_SORT_KEY_ROLE) != value:
+            item.setData(_SORT_KEY_ROLE, value)
+            return True
+        return False
 
     @staticmethod
     def _set_tooltip_if_changed(item: QTableWidgetItem, tooltip: str) -> None:
@@ -266,6 +275,8 @@ class TableTab(QGroupBox):
         utilization_low_threshold = pref.utilization_low_threshold
         tooltip_line_limit = pref.tooltip_line_limit
         new_rows_added = False
+        sort_column = self._sort_column
+        sort_dirty = False
 
         self.table_widget.setUpdatesEnabled(False)
         try:
@@ -286,13 +297,15 @@ class TableTab(QGroupBox):
                 if test_name in tick.singleton_names:
                     display_name = f"{display_name} (singleton)"
                 name_item = self._get_or_create_item(row_number, Columns.NAME.value)
-                self._set_text_if_changed(name_item, display_name)
+                if self._set_text_if_changed(name_item, display_name) and sort_column == Columns.NAME.value:
+                    sort_dirty = True
                 if name_item.data(Qt.ItemDataRole.UserRole) != test_name:
                     name_item.setData(Qt.ItemDataRole.UserRole, test_name)
 
                 # STATE
                 state_item = self._get_or_create_item(row_number, Columns.STATE.value)
-                self._set_text_if_changed(state_item, pytest_run_state.get_string())
+                if self._set_text_if_changed(state_item, pytest_run_state.get_string()) and sort_column == Columns.STATE.value:
+                    sort_dirty = True
                 state_item.setForeground(pytest_run_state.get_qt_table_color())
                 if pytest_run_state.get_state() == PytestRunnerState.RUNNING:
                     live_text = read_live_output(self._data_dir, test_name)
@@ -332,7 +345,9 @@ class TableTab(QGroupBox):
 
                 cpu_item = self._get_or_create_item(row_number, Columns.CPU.value)
                 self._set_text_if_changed(cpu_item, cpu_text)
-                cpu_item.setData(_SORT_KEY_ROLE, cpu_normalized if cpu_normalized is not None else float("-inf"))
+                cpu_key = cpu_normalized if cpu_normalized is not None else float("-inf")
+                if self._set_sort_key_if_changed(cpu_item, cpu_key) and sort_column == Columns.CPU.value:
+                    sort_dirty = True
                 if cpu_normalized is not None:
                     set_utilization_color(cpu_item, cpu_normalized / 100.0, utilization_high_threshold, utilization_low_threshold)
                 else:
@@ -341,18 +356,24 @@ class TableTab(QGroupBox):
                 memory_item = self._get_or_create_item(row_number, Columns.MEMORY.value)
                 self._set_text_if_changed(memory_item, memory_text)
                 memory_value = final_info.memory_percent if (final_info is not None and final_info.memory_percent is not None) else None
-                memory_item.setData(_SORT_KEY_ROLE, memory_value if memory_value is not None else float("-inf"))
+                memory_key = memory_value if memory_value is not None else float("-inf")
+                if self._set_sort_key_if_changed(memory_item, memory_key) and sort_column == Columns.MEMORY.value:
+                    sort_dirty = True
 
                 runtime_item = self._get_or_create_item(row_number, Columns.RUNTIME.value)
                 self._set_text_if_changed(runtime_item, runtime_text)
-                runtime_item.setData(_SORT_KEY_ROLE, elapsed_seconds if elapsed_seconds is not None else float("-inf"))
+                runtime_key = elapsed_seconds if elapsed_seconds is not None else float("-inf")
+                if self._set_sort_key_if_changed(runtime_item, runtime_key) and sort_column == Columns.RUNTIME.value:
+                    sort_dirty = True
 
                 # Per-test coverage
                 coverage_pct = tick.per_test_coverage.get(test_name)
                 coverage_text = f"{coverage_pct:.1%}" if coverage_pct is not None else ""
                 coverage_item = self._get_or_create_item(row_number, Columns.COVERAGE.value)
                 self._set_text_if_changed(coverage_item, coverage_text)
-                coverage_item.setData(_SORT_KEY_ROLE, coverage_pct if coverage_pct is not None else float("-inf"))
+                coverage_key = coverage_pct if coverage_pct is not None else float("-inf")
+                if self._set_sort_key_if_changed(coverage_item, coverage_key) and sort_column == Columns.COVERAGE.value:
+                    sort_dirty = True
 
                 # Last pass data (persists across runs)
                 last_pass = tick.last_pass_data.get(test_name)
@@ -367,17 +388,21 @@ class TableTab(QGroupBox):
                     last_pass_duration_text = ""
                 last_pass_start_item = self._get_or_create_item(row_number, Columns.LAST_PASS_START.value)
                 self._set_text_if_changed(last_pass_start_item, last_pass_start_text)
-                last_pass_start_item.setData(_SORT_KEY_ROLE, last_pass_start_ts if last_pass_start_ts is not None else float("-inf"))
+                last_pass_start_key = last_pass_start_ts if last_pass_start_ts is not None else float("-inf")
+                if self._set_sort_key_if_changed(last_pass_start_item, last_pass_start_key) and sort_column == Columns.LAST_PASS_START.value:
+                    sort_dirty = True
                 last_pass_duration_item = self._get_or_create_item(row_number, Columns.LAST_PASS_DURATION.value)
                 self._set_text_if_changed(last_pass_duration_item, last_pass_duration_text)
-                last_pass_duration_item.setData(_SORT_KEY_ROLE, last_pass_duration if last_pass_duration is not None else float("-inf"))
+                last_pass_duration_key = last_pass_duration if last_pass_duration is not None else float("-inf")
+                if self._set_sort_key_if_changed(last_pass_duration_item, last_pass_duration_key) and sort_column == Columns.LAST_PASS_DURATION.value:
+                    sort_dirty = True
 
             if new_rows_added:
                 self.table_widget.resizeColumnsToContents()
 
-            if self._sort_column is not None:
-                self.table_widget.sortItems(self._sort_column, self._sort_order)
-                self.table_widget.horizontalHeader().setSortIndicator(self._sort_column, self._sort_order)
+            if sort_column is not None and (new_rows_added or sort_dirty):
+                self.table_widget.sortItems(sort_column, self._sort_order)
+                self.table_widget.horizontalHeader().setSortIndicator(sort_column, self._sort_order)
                 self._rebuild_row_by_name()
         finally:
             self.table_widget.setUpdatesEnabled(True)

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -105,7 +105,9 @@ def get_pref() -> FlyPreferences:
     stays consistent with persistent storage.
 
     The cache is keyed on the resolved storage path, so tests that redirect
-    pref storage to a tmp dir transparently get a fresh instance.
+    pref storage to a tmp dir transparently get a fresh instance.  Tests can
+    also call :func:`reset_pref_cache` explicitly if the path-key heuristic
+    isn't enough (e.g., when bypassing the appdirs monkeypatch path).
     """
     global _cached_pref, _cached_pref_path
     current_path = _resolve_pref_path()
@@ -113,6 +115,13 @@ def get_pref() -> FlyPreferences:
         _cached_pref = FlyPreferences(application_name, author, file_name=preferences_file_name)
         _cached_pref_path = current_path
     return _cached_pref
+
+
+def reset_pref_cache() -> None:
+    """Drop the cached :class:`FlyPreferences` instance.  Intended for tests."""
+    global _cached_pref, _cached_pref_path
+    _cached_pref = None
+    _cached_pref_path = None
 
 
 def get_ordering_aspects_set() -> PrefOrderedSet:

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -77,9 +77,23 @@ class FlyPreferences(Pref):
     perf_logging: bool = attrib(default=False)  # log per-tick phase timings (db query, build_tick_data, each tab update) to diagnose UI lag
 
 
+_cached_pref: FlyPreferences | None = None
+
+
 def get_pref() -> FlyPreferences:
-    """Return a :class:`FlyPreferences` instance (reads from / auto-saves to disk)."""
-    return FlyPreferences(application_name, author, file_name=preferences_file_name)
+    """Return a :class:`FlyPreferences` instance (reads from / auto-saves to disk).
+
+    The instance is cached process-wide after first construction.  Constructing
+    ``FlyPreferences`` reopens the backing ``SqliteDict`` and issues one SELECT
+    per attribute, so calling ``get_pref()`` on every tick — including from
+    each progress bar — was a measurable contributor to UI latency.  Writes
+    go through ``FlyPreferences.__setattr__`` directly to disk, so the cached
+    instance stays consistent with persistent storage.
+    """
+    global _cached_pref
+    if _cached_pref is None:
+        _cached_pref = FlyPreferences(application_name, author, file_name=preferences_file_name)
+    return _cached_pref
 
 
 def get_ordering_aspects_set() -> PrefOrderedSet:

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -7,9 +7,11 @@ them without circular imports.
 """
 
 from enum import IntEnum
+from pathlib import Path
 
 from attr import attrib, attrs
 from pref import Pref, PrefOrderedSet
+from pref.pref import appdirs as _pref_appdirs
 
 from .__version__ import application_name, author
 from .interfaces import OrderingAspect, RunMode
@@ -78,21 +80,38 @@ class FlyPreferences(Pref):
 
 
 _cached_pref: FlyPreferences | None = None
+_cached_pref_path: Path | None = None
+
+
+def _resolve_pref_path() -> Path:
+    """Resolve the SQLite path that ``FlyPreferences`` would open right now.
+
+    Mirrors ``Pref.get_sqlite_path`` and uses pref's own ``appdirs`` import so
+    test fixtures that monkeypatch ``pref.pref.appdirs.user_config_dir`` are
+    honored — this is what lets the cache invalidate across tests with isolated
+    storage dirs.
+    """
+    return Path(_pref_appdirs.user_config_dir(application_name, author), preferences_file_name)
 
 
 def get_pref() -> FlyPreferences:
     """Return a :class:`FlyPreferences` instance (reads from / auto-saves to disk).
 
-    The instance is cached process-wide after first construction.  Constructing
-    ``FlyPreferences`` reopens the backing ``SqliteDict`` and issues one SELECT
-    per attribute, so calling ``get_pref()`` on every tick — including from
-    each progress bar — was a measurable contributor to UI latency.  Writes
-    go through ``FlyPreferences.__setattr__`` directly to disk, so the cached
-    instance stays consistent with persistent storage.
+    The instance is cached process-wide.  Constructing ``FlyPreferences``
+    reopens the backing ``SqliteDict`` and issues one SELECT per attribute,
+    so calling ``get_pref()`` on every tick — including from each progress
+    bar — was a measurable contributor to UI latency.  Writes go through
+    ``FlyPreferences.__setattr__`` directly to disk, so the cached instance
+    stays consistent with persistent storage.
+
+    The cache is keyed on the resolved storage path, so tests that redirect
+    pref storage to a tmp dir transparently get a fresh instance.
     """
-    global _cached_pref
-    if _cached_pref is None:
+    global _cached_pref, _cached_pref_path
+    current_path = _resolve_pref_path()
+    if _cached_pref is None or _cached_pref_path != current_path:
         _cached_pref = FlyPreferences(application_name, author, file_name=preferences_file_name)
+        _cached_pref_path = current_path
     return _cached_pref
 
 

--- a/src/pytest_fly/pytest_runner/live_output.py
+++ b/src/pytest_fly/pytest_runner/live_output.py
@@ -15,6 +15,12 @@ from ..file_util import sanitize_test_name
 _LIVE_OUTPUT_SUBDIR = "live_output"
 _TRUNCATION_MARKER = "...[truncated]...\n"
 
+# Cache decoded live-output text keyed by path, invalidated by (size, mtime_ns).
+# GUI ticks call read_live_output once per running test per tick just to keep
+# table tooltips current; this avoids the re-read + UTF-8 decode when the file
+# on disk has not changed.
+_read_cache: dict[Path, tuple[int, int, str]] = {}
+
 
 def live_output_dir(data_dir: Path) -> Path:
     """Return the directory that holds per-test live-output log files."""
@@ -37,9 +43,15 @@ def read_live_output(data_dir: Path, test_name: str, max_bytes: int = 65536) -> 
     """
     path = live_output_path(data_dir, test_name)
     try:
-        file_size = path.stat().st_size
+        stat_result = path.stat()
     except FileNotFoundError:
+        _read_cache.pop(path, None)
         return None
+    file_size = stat_result.st_size
+    mtime_ns = stat_result.st_mtime_ns
+    cached = _read_cache.get(path)
+    if cached is not None and cached[0] == file_size and cached[1] == mtime_ns:
+        return cached[2]
     with open(path, "rb") as fh:
         truncated = file_size > max_bytes
         if truncated:
@@ -51,12 +63,14 @@ def read_live_output(data_dir: Path, test_name: str, max_bytes: int = 65536) -> 
         if newline_index != -1:
             text = text[newline_index + 1 :]
         text = _TRUNCATION_MARKER + text
+    _read_cache[path] = (file_size, mtime_ns, text)
     return text
 
 
 def clear_live_output(data_dir: Path) -> None:
     """Remove the entire live-output directory; safe if it does not exist."""
     directory = live_output_dir(data_dir)
+    _read_cache.clear()
     if not directory.exists():
         return
     for entry in directory.iterdir():

--- a/tests/test_preferences_ordering_aspects.py
+++ b/tests/test_preferences_ordering_aspects.py
@@ -9,6 +9,7 @@ from pytest_fly.preferences import (
     get_ordering_aspects_ordered,
     get_ordering_aspects_set,
     get_pref,
+    reset_pref_cache,
     set_ordering_aspects_ordered,
 )
 
@@ -20,9 +21,13 @@ def isolated_prefs(tmp_path, monkeypatch):
     The pref library resolves its storage via ``appdirs.user_config_dir`` at
     instantiation time, so patching it on the ``pref.pref`` module is enough
     to send every pref (including :class:`PrefOrderedSet`) into tmp_path.
+    Also drops :func:`get_pref`'s in-process cache before and after the test
+    so a stale instance from prior code paths can't bleed in.
     """
+    reset_pref_cache()
     monkeypatch.setattr(pref_mod.appdirs, "user_config_dir", lambda *a, **kw: str(tmp_path))
     yield tmp_path
+    reset_pref_cache()
 
 
 def test_first_call_seeds_defaults(isolated_prefs):


### PR DESCRIPTION
## Summary

The 3-second GUI refresh tick was doing several things on the Qt main thread that scaled poorly with test count, run history, or both. None of them were individually catastrophic, but they compounded — pref re-instantiation, per-tick DB schema checks, full-history `query_last_pass`, unconditional widget rebuilds, per-row file I/O for tooltips, and a `sortItems` that ran every tick whether or not the sort column changed.

This PR applies ten small, targeted fixes — no behavior changes, only reducing per-tick GUI work.

### Fixes
- Cache `get_pref()` process-wide instead of reopening `SqliteDict` per call
- Run `PytestProcessInfoDB` schema check once per process, not per tick
- Enable WAL on the DB so GUI reads stop contending with writers (`BEGIN EXCLUSIVE`)
- Cache `query_last_pass()`; only re-query on `run_guid` change or new PASS; add `exit_code` to the `msqlite` index list
- Short-circuit `PlainTextWidget.set_text` when the text is unchanged
- Cache `read_live_output()` by `(size, mtime_ns)`; invalidate on `clear_live_output`
- Rename `ControlWindow.update` → `refresh_button_state` to stop shadowing `QWidget.update` (Qt internals call `.update()` to schedule a repaint)
- Skip `GraphTab` layout reorder (`takeAt`/`addWidget`) when the order is already correct
- Memoize `compute_grid_ticks` (`lru_cache`) so all bars in one paint pass share the computation
- Track a sort-dirty flag in `TableTab`; only call `sortItems` when a value in the active sort column actually changed

The plan also identified three larger fixes (move coverage aggregation off the GUI thread, split DB query so `output` is lazy, run `db.query` + `build_tick_data` on a worker thread). Those are gated on `perf_logging` measurement confirming the corresponding phases are still measurable contributors after this PR.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `ty check src` — 33 diagnostics (was 34 on master; one pre-existing error went away as a side effect)
- [x] Targeted pytest run: `test_pytest_process_info_db`, `test_preferences_ordering_aspects`, `test_time_axis`, `test_gui_widgets`, `test_gui_display`, `test_coverage_tracker`, `test_interfaces`, `test_ordering_aspects`, `test_pytest_runner_simple`, `test_pytest_runner_resume`, `test_pytest_runner_multiprocess`, `test_pytest_process`, `test_put_version`, `test_uuid`, `test_file_util`, `test_paths`, `test_platform`, `test_platform_os` — all pass
- [ ] Run the app under RESTART and RESUME with `perf_logging=true` and confirm `db_query`, `db_last_pass`, `table`, `graph` phase timings drop vs. the prior baseline
- [ ] Confirm `MSQLite` `retry_count` stays at 0 on GUI reads under load (effect of the WAL switch)
- [ ] Confirm tooltips still reflect live output when a running-test row is hovered, and the progress-bar graph still renders in the same order as the table tab
- [ ] Confirm Configuration-tab changes still persist (cache invalidation for `get_pref()` works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)