### PR TITLE
Replace balsa with stdlib logging; per-process child log files; bump to 0.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Tests are parallelised **at the module level**. All functions inside a module ru
 |---|---|
 | GUI | PySide6 (Qt6) |
 | DB | msqlite (SQLite3) |
-| Logging | balsa |
+| Logging | stdlib logging |
 | Preferences | pref |
 | File watching | watchdog |
 | Resource monitoring | psutil |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.44"
+version = "0.4.0"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.3.43"
+version = "0.3.44"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [
@@ -35,7 +35,6 @@ dependencies = [
     "pref",
     "attrs",
     "typeguard",
-    "balsa",
     "psutil",
     "py-cpuinfo",
     "humanize",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ PySide6
 pref
 attrs
 typeguard
-balsa
 psutil
 py-cpuinfo
 humanize

--- a/src/pytest_fly/logger.py
+++ b/src/pytest_fly/logger.py
@@ -1,31 +1,89 @@
-from logging import Logger
+"""Application logging — stdlib-only.
 
-from balsa import get_logger as balsa_get_logger
+The parent GUI process calls :func:`init_parent_logger` once at startup.
+Every :class:`multiprocessing.Process` subclass that logs from its ``run()``
+method calls :func:`configure_child_logger` as the first line of that method:
+spawn children inherit no handlers, and ``sys.stderr`` in a Windows spawn
+child is not reliable (pytest's capture plumbing can leave it closed), so
+each child writes its records directly to its own file in the shared log
+directory.
+"""
 
-from pytest_fly.__version__ import application_name
+import logging
+import sys
+from logging import FileHandler, Formatter, Logger, StreamHandler
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
-_log_directory: str | None = None
+from platformdirs import user_log_dir
+
+from pytest_fly.__version__ import application_name, author
+
+_LOG_FORMAT = "%(asctime)s %(process)d %(name)s %(levelname)s %(message)s"
+_MAX_BYTES = 10 * 1024 * 1024
+_BACKUP_COUNT = 5
+
+_log_directory: Path | None = None
 
 
-def set_log_directory(directory: str | None) -> None:
-    """Store the Balsa log directory path (called once during startup)."""
+def _resolve_log_directory() -> Path:
+    """Deterministic log directory, shared by parent and spawn children."""
+    log_dir = Path(user_log_dir(application_name, author))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir
+
+
+def init_parent_logger(verbose: bool) -> Path:
+    """Configure the parent process's root logger.
+
+    File handler rotates at 10 MB with 5 backups; stderr mirrors the file
+    level so console output matches what lands on disk.
+    """
     global _log_directory
-    _log_directory = directory
+    log_dir = _resolve_log_directory()
+    level = logging.DEBUG if verbose else logging.INFO
+    formatter = Formatter(_LOG_FORMAT)
+
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    root.setLevel(level)
+
+    file_handler = RotatingFileHandler(log_dir / f"{application_name}.log", maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    root.addHandler(file_handler)
+
+    stderr_handler = StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(formatter)
+    root.addHandler(stderr_handler)
+
+    _log_directory = log_dir
+    return log_dir
 
 
-def get_log_directory() -> str | None:
-    """Return the Balsa log directory path set during application startup."""
+def configure_child_logger(log_file_name: str) -> None:
+    """Install a per-child :class:`FileHandler` on the root logger.
+
+    Spawn children inherit no handlers; without this the stdlib falls back
+    to ``logging.lastResort`` → a potentially-closed ``sys.stderr`` and
+    raises ``ValueError`` on the first record. Each child writes DEBUG+ to
+    its own file so nothing is dropped.
+    """
+    log_dir = _resolve_log_directory()
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    root.setLevel(logging.DEBUG)
+    file_handler = FileHandler(log_dir / log_file_name, mode="a", encoding="utf-8")
+    file_handler.setFormatter(Formatter(_LOG_FORMAT))
+    root.addHandler(file_handler)
+
+
+def get_log_directory() -> Path | None:
+    """Return the log directory set by :func:`init_parent_logger`, or ``None`` if it has not run yet."""
     return _log_directory
 
 
 def get_logger(name: str = application_name) -> Logger:
-    """
-    Return the application logger.
-
-    Wraps :func:`balsa.get_logger` so that every module in the project imports
-    the logger from one place, making it easy to swap implementations later.
-
-    :param name: Logger name (defaults to the application name).
-    :return: A standard-library :class:`~logging.Logger` instance.
-    """
-    return balsa_get_logger(name)
+    """Return a stdlib logger by name."""
+    return logging.getLogger(name)

--- a/src/pytest_fly/main.py
+++ b/src/pytest_fly/main.py
@@ -1,11 +1,9 @@
 """Application bootstrap — configures logging and launches the Qt GUI."""
 
-from balsa import Balsa
-
-from .__version__ import application_name, author
+from .__version__ import application_name
 from .gui import fly_main
 from .gui.about_tab.project_info import get_project_info
-from .logger import get_logger, set_log_directory
+from .logger import get_logger, init_parent_logger
 from .paths import get_default_data_dir
 from .preferences import get_pref
 from .put_version import detect_put_version
@@ -13,19 +11,9 @@ from .put_version import detect_put_version
 log = get_logger(application_name)
 
 
-class FlyLogger(Balsa):
-    """Application-level Balsa logger configured from user preferences."""
-
-    def __init__(self):
-        pref = get_pref()
-        super().__init__(name=application_name, author=author, verbose=pref.verbose, gui=False)
-
-
 def app_main():
     """Initialize logging and launch the GUI."""
-    fly_logger = FlyLogger()
-    fly_logger.init_logger()
-    set_log_directory(fly_logger.log_directory)
+    init_parent_logger(verbose=get_pref().verbose)
 
     project_info = get_project_info()
     log.info(f"{project_info.application_name} version {project_info.version}")
@@ -33,6 +21,4 @@ def app_main():
     put_info = detect_put_version()
     log.info(f"program under test: {put_info.short_label()} (source={put_info.source}, project_root={put_info.project_root})")
 
-    data_dir = get_default_data_dir()
-
-    fly_main(data_dir)
+    fly_main(get_default_data_dir())

--- a/src/pytest_fly/pytest_runner/process_monitor.py
+++ b/src/pytest_fly/pytest_runner/process_monitor.py
@@ -11,6 +11,8 @@ from psutil import NoSuchProcess
 from psutil import Process as PsutilProcess
 from typeguard import typechecked
 
+from ..logger import configure_child_logger
+
 
 @dataclass(frozen=True)
 class PytestProcessMonitorInfo:
@@ -59,6 +61,7 @@ class ProcessMonitor(Process):
 
     def run(self):
         """Sample CPU and memory at ``_update_rate`` intervals until stop is requested."""
+        configure_child_logger(f"process_monitor-{self._pid}.log")
 
         psutil_process = PsutilProcess(self._pid)
         psutil_process.cpu_percent()  # initialize psutil's CPU usage (ignore the first 0.0)

--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -19,7 +19,7 @@ from ..__version__ import application_name
 from ..db import PytestProcessInfoDB
 from ..file_util import sanitize_test_name
 from ..interfaces import PyTestFlyExitCode, PytestProcessInfo
-from ..logger import get_logger
+from ..logger import configure_child_logger, get_logger
 from .live_output import live_output_path
 from .process_monitor import ProcessMonitor
 
@@ -53,6 +53,8 @@ class PytestProcess(Process):
         self._process_monitor_process = None
 
     def run(self) -> None:
+
+        configure_child_logger(f"{sanitize_test_name(self.name)}.log")
 
         # start the process monitor to monitor things like CPU and memory usage
         self._process_monitor_process = ProcessMonitor(self.run_guid, self.name, self.pid, self.update_rate)

--- a/src/pytest_fly/pytest_runner/system_monitor.py
+++ b/src/pytest_fly/pytest_runner/system_monitor.py
@@ -14,6 +14,8 @@ from multiprocessing import Event, Process, Queue
 import psutil
 from typeguard import typechecked
 
+from ..logger import configure_child_logger
+
 
 @dataclass(frozen=True)
 class SystemMonitorSample:
@@ -50,6 +52,7 @@ class SystemMonitor(Process):
 
     def run(self):
         """Sample resources at ``_update_rate`` intervals until stop is requested."""
+        configure_child_logger("system_monitor.log")
         psutil.cpu_percent(interval=None)  # prime psutil's CPU counter; ignore the first 0.0
 
         prev_disk = psutil.disk_io_counters()

--- a/src/pytest_fly/pytest_runner/test_list.py
+++ b/src/pytest_fly/pytest_runner/test_list.py
@@ -14,7 +14,7 @@ import pytest
 from typeguard import typechecked
 
 from ..interfaces import ScheduledTest
-from ..logger import get_logger
+from ..logger import configure_child_logger, get_logger
 
 log = get_logger()
 
@@ -33,6 +33,7 @@ class GetTests(Process):
 
     @typechecked
     def run(self):
+        configure_child_logger("get_tests.log")
         log.info(f"{self.test_dir=}")
 
         # Collection only needs core pytest.  Third-party plugins installed in the venv


### PR DESCRIPTION
## Summary
- Removes the `balsa` dependency; `src/pytest_fly/logger.py` now owns the whole logging pipeline with the stdlib.
- Fixes `ValueError: I/O operation on closed file` crash in spawn children (e.g. `pytest_process.py:116`): `balsa.init_logger()` only ran in the parent, so children fell back to `logging.lastResort -> sys.stderr`, which pytest left closed on Windows.
- Each spawn child (`PytestProcess`, `GetTests`, `ProcessMonitor`, `SystemMonitor`) now calls `configure_child_logger(<name>.log)` as the first line of `run()` and writes directly to its own file in the shared log directory -- nothing is dropped.
- Parent gets a 10MB / 5-backup `RotatingFileHandler` + stderr, both at DEBUG if `pref.verbose` else INFO.
- Log directory is resolved deterministically in every process via `platformdirs.user_log_dir(application_name, author)` -- no IPC needed.
- Bumps version to 0.3.44.

## Test plan
- [x] `python -m ruff check src tests` and `ruff format --check` clean.
- [x] `python -m ty check src` -- 29 diagnostics, all pre-existing (was 33 on master; the 4 removed were balsa-related).
- [x] Targeted suites: `test_file_util`, `test_paths`, `test_interfaces`, `test_platform`, `test_uuid`, `test_preferences_ordering_aspects`, `test_process_monitor`, `test_system_monitor`, `test_test_list`, `test_pytest_process` -- all green.
- [x] Import smoke test: every changed module imports without error.
- [x] Runtime smoke test: `init_parent_logger(verbose=False)` -> creates `%LOCALAPPDATA%\abel\pytest-fly\Logs\pytest-fly.log` with RotatingFileHandler + StreamHandler; `configure_child_logger("smoke_child.log")` swaps to a single FileHandler at DEBUG; records confirmed on disk.
- [x] Directory after tests shows expected per-child files (`tests_test_3_sec_operation.py.log`, `get_tests.log`, `process_monitor-*.log`, `system_monitor.log`).
- [ ] Manual: launch `python -m pytest_fly` against a real target project, run a suite, confirm no `ValueError: I/O operation on closed file` in the console and About tab still shows the log directory path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)