### PR TITLE
Silence console logging, add Run tooltip; bump to 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.0"
+version = "0.4.1"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -49,6 +49,7 @@ class ControlWindow(QGroupBox):
         self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
         self.run_button = ControlButton(self, "Run", True)
+        self.run_button.setToolTip("Discover tests and start a new test run")
         layout.addWidget(self.run_button)
         self.run_button.clicked.connect(self.run)
 

--- a/src/pytest_fly/logger.py
+++ b/src/pytest_fly/logger.py
@@ -10,8 +10,7 @@ directory.
 """
 
 import logging
-import sys
-from logging import FileHandler, Formatter, Logger, StreamHandler
+from logging import FileHandler, Formatter, Logger
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -36,8 +35,9 @@ def _resolve_log_directory() -> Path:
 def init_parent_logger(verbose: bool) -> Path:
     """Configure the parent process's root logger.
 
-    File handler rotates at 10 MB with 5 backups; stderr mirrors the file
-    level so console output matches what lands on disk.
+    GUI app: logs go to a rotating file only (10 MB, 5 backups). No stdout
+    or stderr handler — a PySide6 app under ``pythonw``/frozen bundles has
+    no attached console, and writing there can raise on closed streams.
     """
     global _log_directory
     log_dir = _resolve_log_directory()
@@ -52,10 +52,6 @@ def init_parent_logger(verbose: bool) -> Path:
     file_handler = RotatingFileHandler(log_dir / f"{application_name}.log", maxBytes=_MAX_BYTES, backupCount=_BACKUP_COUNT, encoding="utf-8")
     file_handler.setFormatter(formatter)
     root.addHandler(file_handler)
-
-    stderr_handler = StreamHandler(sys.stderr)
-    stderr_handler.setFormatter(formatter)
-    root.addHandler(stderr_handler)
 
     _log_directory = log_dir
     return log_dir


### PR DESCRIPTION
## Summary
- Drop the `StreamHandler(sys.stderr)` from `init_parent_logger` — pytest-fly is a PySide6 GUI; under `pythonw` or a frozen bundle there is no attached console, and writing to a closed stream can raise. The rotating file handler continues to capture everything under the `platformdirs` user log dir.
- Add a tooltip to the Run button in the Run tab's Control group so all three buttons (Run / Stop / Force Stop) are self-documenting on hover.
- Bump version to 0.4.1.

## Test plan
- [ ] `python -m pytest_fly` — confirm the console stays silent (no `pytest-fly version ...` / `program under test: ...` / `closeEvent` lines printed).
- [ ] Hover each button in the Control group on the Run tab; all three show tooltips.
- [ ] Log file under the user log dir still contains the INFO records.