### PR TITLE
Fix runner hangs and typechecked decorator usage; bump to 0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.1"
+version = "0.4.2"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/db/db.py
+++ b/src/pytest_fly/db/db.py
@@ -35,7 +35,7 @@ class PytestProcessInfoDB(MSQLite):
     # schema/pragma work only needs to run once.
     _initialized_paths: set[Path] = set()
 
-    @typechecked
+    @typechecked()
     def __init__(self, db_dir: Path):
         table_name = "pytest_process_info"
 
@@ -102,7 +102,7 @@ class PytestProcessInfoDB(MSQLite):
 
         super().__init__(db_path, table_name, self._schema, indexes=["run_guid", "exit_code"])
 
-    @typechecked
+    @typechecked()
     def write(self, pytest_process_info: PytestProcessInfo) -> None:
         """
         Write the pytest process info to the database.

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -246,7 +246,7 @@ def window_text_color(widget: QWidget) -> QColor:
 _TOOLTIP_WIDTH_LIMIT = 120
 
 
-@typechecked
+@typechecked()
 def tool_tip_limiter(text: str | None, line_limit: int | None = None, width_limit: int = _TOOLTIP_WIDTH_LIMIT) -> str:
     """
     Prepare tooltip text from pytest output: keep the last *line_limit* lines

--- a/src/pytest_fly/gui/run_tab/live_output_window.py
+++ b/src/pytest_fly/gui/run_tab/live_output_window.py
@@ -17,7 +17,7 @@ _MAX_LINE_BLOCKS = 5000  # QPlainTextEdit max line count — bounds memory on ve
 class LiveOutputWindow(QGroupBox):
     """Displays live pytest output for a selectable running test."""
 
-    @typechecked
+    @typechecked()
     def __init__(self, parent, data_dir: Path):
         super().__init__(parent)
         self.setTitle("Live Output")

--- a/src/pytest_fly/gui/run_tab/run_tab.py
+++ b/src/pytest_fly/gui/run_tab/run_tab.py
@@ -21,7 +21,7 @@ log = get_logger()
 class RunTab(QWidget):
     """Primary tab combining the control panel (Run/Stop) and the status summary."""
 
-    @typechecked
+    @typechecked()
     def __init__(self, parent, data_dir: Path):
         super().__init__(parent)
 

--- a/src/pytest_fly/gui/run_tab/view_coverage.py
+++ b/src/pytest_fly/gui/run_tab/view_coverage.py
@@ -15,7 +15,7 @@ log = get_logger(application_name)
 class ViewCoverage:
     """Opens the most recent HTML coverage report in the user's default browser."""
 
-    @typechecked
+    @typechecked()
     def __init__(self, coverage_parent_directory: Path):
         self.coverage_parent_directory = coverage_parent_directory
 

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -80,7 +80,7 @@ class TableTab(QGroupBox):
 
     force_stop_test_requested = Signal(str)  # emits the test node_id
 
-    @typechecked
+    @typechecked()
     def __init__(self, data_dir: Path):
         super().__init__()
 

--- a/src/pytest_fly/guid.py
+++ b/src/pytest_fly/guid.py
@@ -7,7 +7,7 @@ from typeguard import typechecked
 from uuid6 import uuid7
 
 
-@typechecked
+@typechecked()
 def generate_uuid() -> str:
     """
     Generate a UUIDv7 (time-ordered, timestamp-encoded).
@@ -16,7 +16,7 @@ def generate_uuid() -> str:
     return u
 
 
-@typechecked
+@typechecked()
 def decode_uuid_timestamp(uuid_string: str) -> datetime:
     """
     Extract the UTC timestamp encoded in a UUIDv7.

--- a/src/pytest_fly/interfaces.py
+++ b/src/pytest_fly/interfaces.py
@@ -8,6 +8,7 @@ Defines the fundamental types used by the runner, database, and GUI layers:
 
 from dataclasses import dataclass
 from enum import IntEnum, StrEnum
+from functools import cache
 
 from pytest import ExitCode
 
@@ -94,6 +95,16 @@ class PyTestFlyExitCode(IntEnum):
     NONE = 100  # not yet set
     TERMINATED = 101  # test run was forcefully terminated
     STOPPED = 102  # test was queued but never ran (soft stop)
+
+
+@cache
+def int_exit_code_to_pytest_fly_exit_code(int_exit_code: int) -> PyTestFlyExitCode:
+    found = None
+    for exit_code in PyTestFlyExitCode:
+        if exit_code.value == int_exit_code:
+            found = exit_code
+    assert found is not None
+    return found
 
 
 @dataclass(frozen=True)

--- a/src/pytest_fly/pytest_runner/process_monitor.py
+++ b/src/pytest_fly/pytest_runner/process_monitor.py
@@ -26,6 +26,7 @@ class PytestProcessMonitorInfo:
     time_stamp: float  # time stamp of the info update
 
 
+@typechecked()
 def normalize_cpu_percent(cpu_percent: float, cores: int) -> float:
     """Normalize psutil's per-process CPU percent (0-100 * cores) to a single-core-equivalent 0-100 scale.
 
@@ -86,6 +87,10 @@ class ProcessMonitor(Process):
             put_process_monitor_data()
             self._stop_event.wait(self._update_rate)
         put_process_monitor_data()
+        # Prevent the multiprocessing Queue feeder thread from blocking process exit.
+        # Without this, if the consumer (PytestProcess) is waiting in join() rather than
+        # draining the queue, the pipe buffer fills and this process hangs indefinitely.
+        self.process_monitor_queue.cancel_join_thread()
 
     def request_stop(self):
         """Signal the monitor loop to exit after the current sample."""

--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -4,6 +4,7 @@ and a :class:`ProcessMonitor` that samples CPU/memory usage.
 """
 
 import contextlib
+import logging
 import shutil
 import time
 import traceback
@@ -18,7 +19,7 @@ from typeguard import typechecked
 from ..__version__ import application_name
 from ..db import PytestProcessInfoDB
 from ..file_util import sanitize_test_name
-from ..interfaces import PyTestFlyExitCode, PytestProcessInfo
+from ..interfaces import PyTestFlyExitCode, PytestProcessInfo, int_exit_code_to_pytest_fly_exit_code
 from ..logger import configure_child_logger, get_logger
 from .live_output import live_output_path
 from .process_monitor import ProcessMonitor
@@ -96,7 +97,8 @@ class PytestProcess(Process):
                 try:
                     # -rA: show full short test summary (all outcomes, untruncated assertion messages)
                     # -s: disable pytest capture so stdout/stderr stream live to the log file
-                    exit_code = pytest.main([self.name, "-rA", "-s"])
+                    pytest_exit_code = pytest.main([self.name, "-rA", "-s"])
+                    exit_code = int_exit_code_to_pytest_fly_exit_code(pytest_exit_code)
                 except Exception:
                     exit_code = PyTestFlyExitCode.INTERNAL_ERROR
                     try:
@@ -111,11 +113,21 @@ class PytestProcess(Process):
 
         output: str = live_path.read_text(encoding="utf-8", errors="replace")
 
+        # Tests may have registered StreamHandlers pointing to live_file (now closed).
+        # Remove them so subsequent log calls don't raise ValueError.
+        for _lgr in [logging.root, *logging.Logger.manager.loggerDict.values()]:
+            if isinstance(_lgr, logging.Logger):
+                for _handler in list(_lgr.handlers):
+                    if hasattr(_handler, "stream") and getattr(_handler.stream, "closed", False):
+                        _lgr.removeHandler(_handler)
+
         # stop the process monitor
         self._process_monitor_process.request_stop()
         self._process_monitor_process.join(100.0)  # plenty of time for the monitor to stop
         if self._process_monitor_process.is_alive():
             log.warning(f"{self._process_monitor_process} is alive")
+            self._process_monitor_process.kill()
+            self._process_monitor_process.join(5.0)
 
         # drain the process monitor queue to compute peak CPU and memory usage
         cpu_samples = []

--- a/src/pytest_fly/pytest_runner/test_list.py
+++ b/src/pytest_fly/pytest_runner/test_list.py
@@ -31,7 +31,7 @@ class GetTests(Process):
         self._scheduled_tests_queue = Queue()
         super().__init__()
 
-    @typechecked
+    @typechecked()
     def run(self):
         configure_child_logger("get_tests.log")
         log.info(f"{self.test_dir=}")


### PR DESCRIPTION
## Summary
- Prevent `ProcessMonitor` from hanging at exit by calling `cancel_join_thread()` on its queue and force-killing if it doesn't exit; add exit-code conversion helper `int_exit_code_to_pytest_fly_exit_code` so pytest's int return is mapped to `PyTestFlyExitCode`.
- Clean up log handlers whose streams were closed during the test run, so subsequent log calls don't raise `ValueError`.
- Fix `@typechecked` -> `@typechecked()` (typeguard requires the call form) across db, gui, runner modules.
- Bump version 0.4.1 -> 0.4.2.

## Test plan
- [ ] `python -m pytest_fly` launches and runs a suite to completion without hanging on monitor exit
- [ ] `pytest tests/`
- [ ] `ruff check src tests`