### PR TITLE
Terminate child processes when stopping a test

### DIFF
--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -12,6 +12,7 @@ from multiprocessing import Process
 from pathlib import Path
 from queue import Empty
 
+import psutil
 import pytest
 from coverage import Coverage
 from typeguard import typechecked
@@ -25,6 +26,82 @@ from .live_output import live_output_path
 from .process_monitor import ProcessMonitor
 
 log = get_logger(application_name)
+
+
+@typechecked()
+def terminate_process_tree(pid: int | None, terminate_timeout: float = 3.0, kill_timeout: float = 2.0) -> None:
+    """
+    Terminate a process and all of its descendants.
+
+    Tests under test may spawn their own subprocesses (subprocess.Popen, multiprocessing,
+    helper services). When we kill only the direct pytest subprocess those descendants
+    are orphaned. This helper walks the process tree via psutil and kills everything.
+
+    Algorithm: SIGTERM children-first then parent (so the parent can't keep spawning
+    new children between enumeration and signal); wait; re-scan for grandchildren that
+    appeared in the gap; SIGKILL survivors.
+
+    Cross-platform via psutil — on Windows ``terminate()`` and ``kill()`` both map to
+    ``TerminateProcess``; on POSIX they map to SIGTERM and SIGKILL.
+
+    :param pid: PID of the parent process to terminate. ``None`` is a no-op.
+    :param terminate_timeout: Seconds to wait after SIGTERM before escalating to SIGKILL.
+    :param kill_timeout: Seconds to wait after SIGKILL for the OS to reap the processes.
+    """
+    if pid is None:
+        return
+
+    try:
+        parent = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return
+
+    log.info(f"terminating process tree for pid={pid}")
+
+    try:
+        descendants = parent.children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        descendants = []
+
+    # SIGTERM children first, then parent
+    for proc in descendants + [parent]:
+        try:
+            proc.terminate()
+            log.debug(f"terminated pid={proc.pid} name={proc.name()}")
+        except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
+            log.debug(f"could not terminate pid={proc.pid}: {e}")
+
+    _, alive = psutil.wait_procs(descendants + [parent], timeout=terminate_timeout)
+
+    # Re-scan for grandchildren that appeared between snapshot and SIGTERM
+    try:
+        if parent.is_running():
+            new_descendants = parent.children(recursive=True)
+            seen_pids = {p.pid for p in alive}
+            for proc in new_descendants:
+                if proc.pid not in seen_pids:
+                    alive.append(proc)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        pass
+
+    if not alive:
+        return
+
+    # SIGKILL survivors, children-first
+    survivors_children_first = [p for p in alive if p.pid != pid] + [p for p in alive if p.pid == pid]
+    for proc in survivors_children_first:
+        try:
+            proc.kill()
+            log.debug(f"killed pid={proc.pid}")
+        except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
+            log.debug(f"could not kill pid={proc.pid}: {e}")
+
+    _, still_alive = psutil.wait_procs(survivors_children_first, timeout=kill_timeout)
+    for proc in still_alive:
+        try:
+            log.warning(f"process did not die after kill: pid={proc.pid} name={proc.name()}")
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            log.warning(f"process did not die after kill: pid={proc.pid}")
 
 
 class PytestProcess(Process):

--- a/src/pytest_fly/pytest_runner/pytest_runner.py
+++ b/src/pytest_fly/pytest_runner/pytest_runner.py
@@ -21,7 +21,7 @@ from ..db import PytestProcessInfoDB
 from ..interfaces import PyTestFlyExitCode, PytestRunnerState, ScheduledTest
 from ..logger import get_logger
 from .const import TIMEOUT
-from .pytest_process import PytestProcess, PytestProcessInfo
+from .pytest_process import PytestProcess, PytestProcessInfo, terminate_process_tree
 
 log = get_logger()
 
@@ -306,57 +306,35 @@ class _TestRunner(Thread):
 
     def _terminate_process(self, proc: PytestProcess, proc_name: str, test: str) -> None:
         """
-        Attempt a graceful termination of *proc*.  If the process exits within
-        a short grace period the result is recorded as ``TERMINATED`` in the DB.
-        Otherwise :meth:`_force_kill_process` is called.
+        Terminate *proc* and all of its descendants.  ``terminate_process_tree``
+        handles SIGTERM-then-SIGKILL escalation internally and waits for the
+        processes to exit, so this method records the ``TERMINATED`` status to
+        the DB unconditionally.
 
         :param proc: The running :class:`PytestProcess`.
         :param proc_name: Human-readable name for log messages.
         :param test: Test node-ID (used when writing the DB record).
         """
-        try:
-            proc.terminate()
-            log.info(f'attempted terminate for process "{proc_name}" ({self.run_guid=})')
-        except (OSError, RuntimeError, PermissionError) as e:
-            log.info(f'error calling terminate on "{proc_name}",{self.run_guid=},{e}')
+        terminate_process_tree(proc.pid, terminate_timeout=max(self.update_rate, 2.0))
+        proc.join(0.5)  # reap the multiprocessing.Process wrapper
 
-        proc.join(max(self.update_rate, 2.0))
-
-        if not proc.is_alive():
-            log.info(f'process for test "{proc_name}" terminated ({self.run_guid=})')
-            with PytestProcessInfoDB(self.data_dir) as db:
-                info = PytestProcessInfo(
-                    self.run_guid,
-                    test,
-                    None,
-                    PyTestFlyExitCode.TERMINATED,
-                    None,
-                    time_stamp=time.time(),
-                    put_version=self.put_version,
-                    put_fingerprint=self.put_fingerprint,
-                )
-                db.write(info)
+        if proc.is_alive():
+            log.warning(f'process for test "{proc_name}" still alive after tree kill ({self.run_guid=})')
         else:
-            self._force_kill_process(proc, proc_name)
+            log.info(f'process tree for test "{proc_name}" terminated ({self.run_guid=})')
 
-    def _force_kill_process(self, proc: PytestProcess, proc_name: str) -> None:
-        """
-        Forcefully kill *proc* after a graceful terminate failed.
-
-        A safety check ensures the ``self.process`` reference has not been
-        replaced by a newer process before issuing the kill.
-
-        :param proc: The process to kill.
-        :param proc_name: Human-readable name for log messages.
-        """
-        if self.process is not proc:
-            log.info(f'process object changed while waiting; skipping kill for "{proc_name}" ({self.run_guid=})')
-            return
-        try:
-            proc.kill()
-            log.info(f'process for test "{proc_name}" killed ({self.run_guid=})')
-        except (OSError, RuntimeError, PermissionError) as e:
-            log.warning(f'error calling kill on "{proc_name}",{self.run_guid=},{e}')
+        with PytestProcessInfoDB(self.data_dir) as db:
+            info = PytestProcessInfo(
+                self.run_guid,
+                test,
+                None,
+                PyTestFlyExitCode.TERMINATED,
+                None,
+                time_stamp=time.time(),
+                put_version=self.put_version,
+                put_fingerprint=self.put_fingerprint,
+            )
+            db.write(info)
 
     def _handle_stop_request(self, test: str) -> None:
         """

--- a/tests/test_pytest_process.py
+++ b/tests/test_pytest_process.py
@@ -1,10 +1,15 @@
+import subprocess
+import sys
+import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
+import psutil
 
 from pytest_fly.db import PytestProcessInfoDB
 from pytest_fly.guid import generate_uuid
 from pytest_fly.interfaces import PyTestFlyExitCode
-from pytest_fly.pytest_runner.pytest_process import PytestProcess
+from pytest_fly.pytest_runner.pytest_process import PytestProcess, terminate_process_tree
 
 
 def test_pytest_process():
@@ -23,3 +28,71 @@ def test_pytest_process():
         execution_time = results[-1].time_stamp - results[0].time_stamp
         print(f"{execution_time=}")
         assert execution_time >= 0.0  # 1.4768257141113281 has been observed
+
+
+def _wait_pid_gone(pid: int, timeout: float = 5.0) -> bool:
+    """Poll until *pid* no longer exists (Windows handle cleanup is async)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not psutil.pid_exists(pid):
+            return True
+        time.sleep(0.1)
+    return not psutil.pid_exists(pid)
+
+
+def test_terminate_process_tree_none_pid():
+    # no-op, must not raise
+    terminate_process_tree(None)
+
+
+def test_terminate_process_tree_already_dead():
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait(timeout=10.0)
+    # the pid is now reaped/gone - helper must handle gracefully
+    terminate_process_tree(proc.pid)
+
+
+def test_terminate_process_tree_no_children():
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        terminate_process_tree(proc.pid)
+        assert _wait_pid_gone(proc.pid)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)
+
+
+def test_terminate_process_tree_kills_children():
+    # Parent spawns a long-sleeping child and prints the child PID, then sleeps itself.
+    code = f"import subprocess, sys, time;c = subprocess.Popen([{sys.executable!r}, '-c', 'import time; time.sleep(60)']);print(c.pid, flush=True);time.sleep(60)"
+    parent = subprocess.Popen([sys.executable, "-c", code], stdout=subprocess.PIPE, text=True)
+    try:
+        # read the child pid line that the parent printed
+        line = parent.stdout.readline().strip()
+        child_pid = int(line)
+        # sanity: both must be alive before we kill the tree
+        assert psutil.pid_exists(parent.pid)
+        assert psutil.pid_exists(child_pid)
+
+        terminate_process_tree(parent.pid)
+
+        assert _wait_pid_gone(parent.pid), f"parent pid {parent.pid} still alive"
+        assert _wait_pid_gone(child_pid), f"child pid {child_pid} still alive"
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait(timeout=5.0)
+
+
+def test_terminate_process_tree_idempotent():
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        terminate_process_tree(proc.pid)
+        assert _wait_pid_gone(proc.pid)
+        # second call after the process is gone must be a graceful no-op
+        terminate_process_tree(proc.pid)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)

--- a/tests/test_pytest_runner/test_pytest_runner_stop_kills_children.py
+++ b/tests/test_pytest_runner/test_pytest_runner_stop_kills_children.py
@@ -1,0 +1,52 @@
+import os
+import time
+from pathlib import Path
+
+import psutil
+
+from pytest_fly.guid import generate_uuid
+from pytest_fly.interfaces import ScheduledTest
+from pytest_fly.pytest_runner import PytestRunner
+
+from ..paths import get_temp_dir
+
+
+def _wait_pid_gone(pid: int, timeout: float = 10.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not psutil.pid_exists(pid):
+            return True
+        time.sleep(0.1)
+    return not psutil.pid_exists(pid)
+
+
+def test_pytest_runner_stop_kills_children(app, tmp_path):
+
+    test_name = "test_pytest_runner_stop_kills_children"
+    data_dir = get_temp_dir(test_name)
+    run_guid = generate_uuid()
+
+    pid_file = Path(tmp_path, "child.pid")
+    os.environ["PYTEST_FLY_SPAWN_CHILD_TEST"] = "1"
+    os.environ["PYTEST_FLY_CHILD_PID_FILE"] = str(pid_file)
+    try:
+        scheduled_tests = [ScheduledTest(node_id="tests/test_spawns_child.py", singleton=False, duration=None, coverage=None)]
+
+        runner = PytestRunner(run_guid, scheduled_tests, number_of_processes=1, data_dir=data_dir, update_rate=1.0)
+        runner.start()
+
+        # wait until the test has spawned its child and recorded the PID
+        deadline = time.time() + 30.0
+        while time.time() < deadline and not pid_file.exists():
+            time.sleep(0.2)
+        assert pid_file.exists(), "test_spawns_child never wrote its child pid"
+        child_pid = int(pid_file.read_text().strip())
+        assert psutil.pid_exists(child_pid), f"child pid {child_pid} was not running before stop"
+
+        runner.stop()
+        runner.join(15.0)
+
+        assert _wait_pid_gone(child_pid), f"orphaned child pid {child_pid} still alive after runner.stop()"
+    finally:
+        os.environ.pop("PYTEST_FLY_SPAWN_CHILD_TEST", None)
+        os.environ.pop("PYTEST_FLY_CHILD_PID_FILE", None)

--- a/tests/test_spawns_child.py
+++ b/tests/test_spawns_child.py
@@ -1,0 +1,23 @@
+"""
+Test fixture used by test_pytest_runner_stop_kills_children — spawns a long-sleeping
+child process and writes its PID to a known file, then sleeps so the runner can stop it.
+This file is intentionally excluded from normal test runs (it would just sleep);
+its callers run it directly via pytest_fly.
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+
+@pytest.mark.skipif(os.environ.get("PYTEST_FLY_SPAWN_CHILD_TEST") != "1", reason="invoked only by the runner stop test")
+def test_spawns_child():
+    pid_file = os.environ["PYTEST_FLY_CHILD_PID_FILE"]
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+    with open(pid_file, "w") as f:
+        f.write(str(child.pid))
+    time.sleep(120)
+    assert True


### PR DESCRIPTION
## Summary
- Walks the pytest subprocess's process tree with psutil and kills all descendants when a test is stopped (Stop button, Force Stop, window close, runner replacement). Previously only the immediate pytest subprocess was terminated, leaving child processes spawned by the test under test (`subprocess.Popen`, `multiprocessing` workers, helper services) orphaned.
- New module-level helper `terminate_process_tree(pid, terminate_timeout=3.0, kill_timeout=2.0)` in `pytest_process.py`: SIGTERM children-first then parent, wait, re-scan for grandchildren spawned in the gap, SIGKILL survivors. Cross-platform via psutil — no `os.kill` / `signal` / `sys.platform` branches needed.
- `_TestRunner._terminate_process` now calls the helper. The redundant `_force_kill_process` fallback is deleted (the helper escalates to SIGKILL internally).

## Known non-regression
When force-killing a pytest subprocess today, the `process_monitor_queue.get_nowait()` drain loop in `PytestProcess.run` never runs, so peak CPU/memory data for force-stopped tests has always been lost. This change does not change that behavior.

## Test plan
- [x] `python -m ruff check src tests` — clean
- [x] `python -m ruff format --check src tests` — clean
- [x] `python -m ty check src` — 28 diagnostics, identical to master (no new errors)
- [x] `pytest tests/test_pytest_process.py -v` — 6/6 pass, including 5 new unit tests for `terminate_process_tree` (None pid, already-dead, no-children, kills-children, idempotent)
- [x] `pytest tests/test_pytest_runner/ -v` — 10/10 pass, including the new `test_pytest_runner_stop_kills_children` integration test that schedules a test which spawns a 60s sleeping child and asserts the orphaned PID is gone after `runner.stop()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)