### PR TITLE
Fix coverage-dir deletion racing with in-flight test runs

### DIFF
--- a/src/pytest_fly/gui/coverage_tracker.py
+++ b/src/pytest_fly/gui/coverage_tracker.py
@@ -6,16 +6,14 @@ separate from the GUI window lifecycle.  The main window creates one
 instance and calls :meth:`CoverageTracker.update` on each refresh tick.
 """
 
-import shutil
 import time
 from pathlib import Path
 
 from coverage import Coverage
 
 from ..file_util import sanitize_test_name
-from ..interfaces import PytestRunnerState, RunMode
+from ..interfaces import PytestRunnerState
 from ..logger import get_logger
-from ..preferences import get_pref
 from ..pytest_runner.coverage import calculate_coverage
 from ..tick_data import TickData
 
@@ -38,7 +36,12 @@ class CoverageTracker:
         self._last_run_guid: str | None = None
 
     def handle_new_run(self, current_guid: str | None) -> None:
-        """Reset coverage state when a new run starts and clear old coverage files.
+        """Reset in-memory coverage state when a new run starts.
+
+        File-system cleanup of stale coverage data is done synchronously by
+        ``ControlWindow.run`` *before* the new ``PytestRunner`` is started — doing
+        it here on a periodic tick can race with PytestProcess coverage writes
+        that are still in flight, deleting the directory mid-``coverage.save()``.
 
         :param current_guid: The GUID of the current run.
         """
@@ -49,13 +52,6 @@ class CoverageTracker:
             self._per_test_coverage = {}
             self._covered_lines = 0
             self._total_lines = 0
-
-            # In RESTART mode, clear old coverage files so the graph starts from zero
-            pref = get_pref()
-            if pref.run_mode != RunMode.RESUME:
-                coverage_dir = Path(self._data_dir, "coverage")
-                if coverage_dir.exists():
-                    shutil.rmtree(coverage_dir, ignore_errors=True)
 
     def update(self, tick: TickData) -> None:
         """Recalculate combined and per-test coverage when new tests complete.

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -5,6 +5,7 @@ Houses the run-preparation logic: test discovery, RESUME filtering, and
 the user-configured ordering-aspect chain (see :mod:`pytest_runner.ordering`).
 """
 
+import shutil
 import time
 from dataclasses import replace
 from pathlib import Path
@@ -154,6 +155,15 @@ class ControlWindow(QGroupBox):
         effective_mode = pref.run_mode
         if pref.run_mode == RunMode.CHECK:
             effective_mode = self._resolve_check_mode(prior_results)
+
+        # Clear stale coverage data before any PytestProcess starts writing into
+        # coverage/. Done here (synchronously, before pytest_runner.start) rather
+        # than from a periodic GUI tick so we cannot delete the directory while
+        # a still-running PytestProcess is mid-coverage.save().
+        if effective_mode != RunMode.RESUME:
+            coverage_dir = Path(self.data_dir, "coverage")
+            if coverage_dir.exists():
+                shutil.rmtree(coverage_dir, ignore_errors=True)
 
         all_node_ids = {t.node_id for t in tests}
         tests = self._filter_for_resume(tests, prior_results, effective_mode)


### PR DESCRIPTION
## Summary

Fixes the `coverage.exceptions.DataError: unable to open database file` crash that surfaced when running long tests through the GUI (e.g. `tests/test_pytest_runner/test_pytest_runner_singleton.py`).

## Root cause

`CoverageTracker.handle_new_run` was deleting the entire `coverage/` directory from the periodic GUI tick whenever it noticed `run_guid` had changed. The first tick after the user clicks Run fires ~3s in, *after* `PytestProcess` has already called `coverage_dir.mkdir()` and started coverage tracking. The deletion removes the directory mid-test, so `coverage.save()` at the end of `pytest.main()` crashes:

```
sqlite3.OperationalError: unable to open database file
coverage.exceptions.DataError: Couldn't use data file
  '...\coverage\tests_test_pytest_runner_test_pytest_runner_singleton.py.temp':
  unable to open database file
```

## Fix

Move the file-system cleanup out of `CoverageTracker.handle_new_run` (which runs on every tick) and into `ControlWindow.run()` synchronously, between `effective_mode` resolution and `pytest_runner.start()`. Done before any `PytestProcess` can spawn, so it cannot race with coverage writes.

Also use `effective_mode` instead of `pref.run_mode` so CHECK-mode runs that resolve to RESUME correctly preserve prior coverage data (the old code always wiped on CHECK).

`CoverageTracker.handle_new_run` keeps the in-memory state reset — that's safe to do on a tick, only the file deletion was problematic.

## Test plan
- [x] `python -m ruff check src tests` — clean
- [x] `python -m ruff format --check src tests` — clean
- [x] `python -m ty check src` — 28 diagnostics (identical to master)
- [x] `pytest tests/test_coverage_tracker.py tests/test_coverage_calculation.py -v` — 18/18 pass (the existing CoverageTracker tests don't depend on file-deletion behavior, only state reset)
- [x] `pytest tests/test_pytest_runner/ tests/test_pytest_process.py -v` — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)