### PR TITLE
Anchor Graph time-axis right edge to now while tests run; bump to 0.4.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.6"
+version = "0.4.7"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -78,6 +78,12 @@ def build_tick_data(
     min_ts, max_ts = compute_time_window(process_infos)
     min_ts_s, max_ts_s = compute_time_window(process_infos, require_pid=True)
 
+    # While any test is running, anchor the time-axis right edge to wall-clock now.
+    # Otherwise max_ts is frozen at the latest STARTED record's timestamp, so running-test
+    # bars (whose right edge is time.time()) overflow far past the chart and get clipped.
+    if max_ts is not None and any(rs.get_state() == PytestRunnerState.RUNNING for rs in run_states.values()):
+        max_ts = max(max_ts, time.time())
+
     return TickData(
         process_infos=process_infos,
         infos_by_name=infos_by_name,


### PR DESCRIPTION
## Summary
- `tick.max_time_stamp` was computed only from record timestamps, so once all tests had logged their STARTED records the right edge of the Graph time-axis stopped advancing. Running-test bars are drawn with `end_time = time.time()`, so they overflowed far past the frozen chart and Qt clipped them — leaving only a tiny stub at the very right of the widget.
- Fix in `build_tick_data`: while any test is in the RUNNING state, extend `max_ts` to `time.time()`. The time axis advances with wall clock, running bars reach the right edge, and completed bars stay anchored at their finish times. The Coverage chart consumes the same field, so it gets the same correction.
- Bump version to 0.4.7.

## Test plan
- [x] At t=9s into a synthetic run with three concurrent 8-12s tests, the time axis spans 0s–7s and all three running bars extend to the right edge.
- [x] At t=13s the axis spans 0s–11s with bars still reaching the right edge.
- [x] Pre-fix: bars were tiny stubs flush against the right edge regardless of how long the run had been going.

🤖 Generated with [Claude Code](https://claude.com/claude-code)