### PR TITLE
Live Output separator + stop child logs leaking to CWD (0.4.8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.7"
+version = "0.4.8"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/file_util.py
+++ b/src/pytest_fly/file_util.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 def sanitize_test_name(name: str) -> str:
     """Convert a test node_id into a safe filesystem filename."""
-    return name.replace("/", "_").replace("\\", "_")
+    # ``:`` must go too — a leftover drive prefix like ``C:`` makes pathlib's ``/``
+    # treat the result as drive-relative and silently drop the parent directory.
+    return name.replace("/", "_").replace("\\", "_").replace(":", "_")
 
 
 def find_most_recent_file(directory: Path, pattern: str) -> Path | None:

--- a/src/pytest_fly/gui/run_tab/live_output_window.py
+++ b/src/pytest_fly/gui/run_tab/live_output_window.py
@@ -49,6 +49,9 @@ class LiveOutputWindow(QGroupBox):
         status_row = QHBoxLayout()
         self._elapsed_label = QLabel("")
         status_row.addWidget(self._elapsed_label)
+        self._status_separator = QLabel("|")
+        self._status_separator.setEnabled(False)
+        status_row.addWidget(self._status_separator)
         self._last_pass_label = QLabel("")
         status_row.addWidget(self._last_pass_label)
         status_row.addStretch()
@@ -83,6 +86,7 @@ class LiveOutputWindow(QGroupBox):
                 self._last_text = ""
             self._elapsed_label.setText("")
             self._last_pass_label.setText("")
+            self._status_separator.setVisible(False)
             self._progress_bar.setEnabled(False)
             self._progress_bar.setValue(0)
             self._progress_bar.setFormat("")
@@ -134,6 +138,8 @@ class LiveOutputWindow(QGroupBox):
 
         last_pass = tick.last_pass_data.get(self._selected_name)
         last_pass_duration = last_pass[1] if last_pass is not None else None
+
+        self._status_separator.setVisible(True)
 
         if elapsed is None:
             self._elapsed_label.setText("Elapsed: (starting)")


### PR DESCRIPTION
## Summary
- Live Output: insert a `|` separator between **Elapsed** and **Last successful run** labels (hidden when no test is selected).
- `sanitize_test_name`: also strip `:` so a Windows drive prefix can't survive into a filename — pathlib's `/` operator treats a right-hand side starting with a drive letter as drive-relative and silently drops the parent directory, which was sending per-test child logs / coverage / live-output files into the launching shell's CWD (e.g. `C:\Users\JamesAbel\projects\_Users_*.py.log`).
- Bump version to 0.4.8.

## Test plan
- [ ] Launch the app, start a run, confirm the `|` shows between Elapsed and Last successful run, and disappears when no test is selected.
- [ ] Confirm no new `_Users_*.py.log` (or `.coverage`) files appear in the parent of the project directory after a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)