### PR TITLE
Fix runner kill loop that spammed warnings forever on POSIX

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.8"
+version = "0.4.9"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -29,7 +29,7 @@ log = get_logger(application_name)
 
 
 @typechecked()
-def terminate_process_tree(pid: int | None, terminate_timeout: float = 3.0, kill_timeout: float = 2.0) -> None:
+def terminate_process_tree(pid: int | None, terminate_timeout: float = 3.0, kill_timeout: float = 2.0, reap_parent: bool = True) -> None:
     """
     Terminate a process and all of its descendants.
 
@@ -47,6 +47,14 @@ def terminate_process_tree(pid: int | None, terminate_timeout: float = 3.0, kill
     :param pid: PID of the parent process to terminate. ``None`` is a no-op.
     :param terminate_timeout: Seconds to wait after SIGTERM before escalating to SIGKILL.
     :param kill_timeout: Seconds to wait after SIGKILL for the OS to reap the processes.
+    :param reap_parent: When ``True`` (default), ``psutil.wait_procs`` waits on the
+        parent too, which on POSIX reaps the zombie via ``os.waitpid``. Set to
+        ``False`` when the caller owns the parent's lifecycle and will reap it
+        itself (e.g. a ``multiprocessing.Process`` reaped via ``join()``).
+        Reaping a multiprocessing child here leaves its wrapper in a permanently
+        "alive" state — its own ``os.waitpid`` then raises ``ChildProcessError``,
+        ``_popen.poll()`` returns ``None``, and ``is_alive()`` returns ``True``
+        forever.
     """
     if pid is None:
         return
@@ -71,7 +79,8 @@ def terminate_process_tree(pid: int | None, terminate_timeout: float = 3.0, kill
         except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
             log.debug(f"could not terminate pid={proc.pid}: {e}")
 
-    _, alive = psutil.wait_procs(descendants + [parent], timeout=terminate_timeout)
+    wait_targets = descendants + [parent] if reap_parent else descendants
+    _, alive = psutil.wait_procs(wait_targets, timeout=terminate_timeout)
 
     # Re-scan for grandchildren that appeared between snapshot and SIGTERM
     try:
@@ -84,11 +93,27 @@ def terminate_process_tree(pid: int | None, terminate_timeout: float = 3.0, kill
     except (psutil.NoSuchProcess, psutil.AccessDenied):
         pass
 
+    # When not reaping the parent we still want to ensure it gets SIGKILL'd if
+    # SIGTERM didn't take; do it best-effort without waiting/reaping.
+    if not reap_parent:
+        try:
+            if parent.is_running():
+                try:
+                    parent.kill()
+                    log.debug(f"killed parent pid={parent.pid}")
+                except (psutil.NoSuchProcess, psutil.AccessDenied) as e:
+                    log.debug(f"could not kill parent pid={parent.pid}: {e}")
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
     if not alive:
         return
 
-    # SIGKILL survivors, children-first
-    survivors_children_first = [p for p in alive if p.pid != pid] + [p for p in alive if p.pid == pid]
+    # SIGKILL survivors, children-first when the parent is in scope
+    if reap_parent:
+        survivors_children_first = [p for p in alive if p.pid != pid] + [p for p in alive if p.pid == pid]
+    else:
+        survivors_children_first = list(alive)
     for proc in survivors_children_first:
         try:
             proc.kill()

--- a/src/pytest_fly/pytest_runner/pytest_runner.py
+++ b/src/pytest_fly/pytest_runner/pytest_runner.py
@@ -315,7 +315,10 @@ class _TestRunner(Thread):
         :param proc_name: Human-readable name for log messages.
         :param test: Test node-ID (used when writing the DB record).
         """
-        terminate_process_tree(proc.pid, terminate_timeout=max(self.update_rate, 2.0))
+        # reap_parent=False — we own the multiprocessing.Process lifecycle and
+        # reap it ourselves via join() below. Letting psutil reap it would leave
+        # the multiprocessing wrapper's is_alive() permanently True on POSIX.
+        terminate_process_tree(proc.pid, terminate_timeout=max(self.update_rate, 2.0), reap_parent=False)
         proc.join(0.5)  # reap the multiprocessing.Process wrapper
 
         if proc.is_alive():
@@ -372,12 +375,10 @@ class _TestRunner(Thread):
             while self.process.is_alive():
                 if self._stop_event.is_set() or self._force_stop_current_event.is_set():
                     self._handle_stop_request(test)
+                    # terminate_process_tree already SIGKILL'd; don't loop and retry
+                    break
 
-                # Poll / yield to avoid busy-looping
-                if self.process is None:
-                    time.sleep(self.update_rate)
-                else:
-                    self.process.join(self.update_rate)
+                self.process.join(self.update_rate)
 
             self.process.join(TIMEOUT)  # should already be done, but just in case
             if self.process.is_alive():


### PR DESCRIPTION
## Summary

CI was timing out at the 6-hour GitHub Actions wall clock because the test-runner worker thread entered a tight infinite loop spamming millions of `process for test "..." still alive after tree kill` warnings.

**Root cause:** `terminate_process_tree` called `psutil.wait_procs(descendants + [parent], ...)`. On POSIX, `psutil.Process.wait()` for a child of the current process calls `os.waitpid` and reaps it. The `multiprocessing.Process` wrapper's own subsequent `os.waitpid(pid, WNOHANG)` then raised `ChildProcessError`, `_popen.poll()` returned `None`, and `is_alive()` reported `True` forever. Each loop iteration in `_run_single_test` re-called `_handle_stop_request`, which logged a fresh warning and looped at full speed (psutil now found no such process, returned instantly; `proc.join` also returned instantly). The worker thread was non-daemon, so pytest could never exit. Windows uses Win32 handles, not `waitpid`, so this didn't reproduce locally.

## Changes

- `terminate_process_tree` gains a `reap_parent: bool = True` kwarg. Default behavior is unchanged for the existing `subprocess.Popen`-based tests. When `False`, the parent is signalled (SIGTERM, then best-effort SIGKILL) but not waited on via psutil, so the caller can reap via its own `join()`.
- `_run_single_test` passes `reap_parent=False` and breaks out of the polling loop after the first stop request — `terminate_process_tree` already SIGKILL'd, retrying is pointless.

## Test plan

- [x] `pytest tests/test_pytest_process.py tests/test_pytest_runner/` — all 17 tests pass locally on Windows
- [x] `ruff check src tests` and `ruff format --check` clean
- [ ] CI on Linux green — this is the failure mode we're fixing

Note: there's a separate issue with `test_pytest_runner_stop_kills_children` on Linux CI (the child fixture never writes its pid file within 30 s, likely a coverage/environment interaction); that's tracked separately and not blocked by this PR — once the spam is gone CI will surface that single test failure cleanly instead of timing out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)