### PR TITLE
Fix process-monitor sample loss; bump to 0.4.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.9"
+version = "0.4.10"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/pytest_runner/process_monitor.py
+++ b/src/pytest_fly/pytest_runner/process_monitor.py
@@ -87,10 +87,6 @@ class ProcessMonitor(Process):
             put_process_monitor_data()
             self._stop_event.wait(self._update_rate)
         put_process_monitor_data()
-        # Prevent the multiprocessing Queue feeder thread from blocking process exit.
-        # Without this, if the consumer (PytestProcess) is waiting in join() rather than
-        # draining the queue, the pipe buffer fills and this process hangs indefinitely.
-        self.process_monitor_queue.cancel_join_thread()
 
     def request_stop(self):
         """Signal the monitor loop to exit after the current sample."""

--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -223,26 +223,30 @@ class PytestProcess(Process):
                     if hasattr(_handler, "stream") and getattr(_handler.stream, "closed", False):
                         _lgr.removeHandler(_handler)
 
-        # stop the process monitor
+        # Stop the monitor and drain its queue while it exits. Draining as the
+        # producer shuts down keeps the OS pipe from filling, which would otherwise
+        # block the monitor's feeder thread and hang its process exit.
         self._process_monitor_process.request_stop()
-        self._process_monitor_process.join(100.0)  # plenty of time for the monitor to stop
-        if self._process_monitor_process.is_alive():
-            log.warning(f"{self._process_monitor_process} is alive")
-            self._process_monitor_process.kill()
-            self._process_monitor_process.join(5.0)
-
-        # drain the process monitor queue to compute peak CPU and memory usage
         cpu_samples = []
         memory_samples = []
+        drain_deadline = time.time() + 100.0
         while True:
             try:
-                monitor_info = self._process_monitor_process.process_monitor_queue.get_nowait()
+                monitor_info = self._process_monitor_process.process_monitor_queue.get(timeout=0.1)
                 if monitor_info.cpu_percent is not None:
                     cpu_samples.append(monitor_info.cpu_percent)
                 if monitor_info.memory_percent is not None:
                     memory_samples.append(monitor_info.memory_percent)
             except Empty:
-                break
+                if not self._process_monitor_process.is_alive():
+                    break
+                if time.time() >= drain_deadline:
+                    break
+        self._process_monitor_process.join(5.0)
+        if self._process_monitor_process.is_alive():
+            log.warning(f"{self._process_monitor_process} is alive")
+            self._process_monitor_process.kill()
+            self._process_monitor_process.join(5.0)
         peak_cpu = max(cpu_samples) if cpu_samples else None
         peak_memory = max(memory_samples) if memory_samples else None
 


### PR DESCRIPTION
## Summary
- `ProcessMonitor` no longer calls `cancel_join_thread()` on its queue. That call was dropping samples the feeder thread hadn't yet flushed to the OS pipe, which broke `test_process_monitor_samples_own_process` reliably.
- `PytestProcess` now drains the monitor queue *while* the monitor is shutting down (drain-with-timeout, then `join`), instead of join-then-drain. This keeps the OS pipe flowing so the producer can always flush and exit cleanly — preserving the hang protection PR #102 was after, without dropping data.
- Version bumped to 0.4.10.

## Test plan
- [x] `pytest tests/test_process_monitor.py` — 5/5 pass (previously 1 failed)
- [x] Full local suite: 192 passed
- [x] `test_pytest_runner_multiprocess` confirms non-`None` cpu/memory samples flow through the new drain path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)