### PR TITLE
Per-PUT preferences + configurable test-results DB dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.10"
+version = "0.4.11"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/scripts/capture_assets.py
+++ b/scripts/capture_assets.py
@@ -36,7 +36,7 @@ from PySide6.QtWidgets import QApplication  # noqa: E402
 
 from demo.demo import generate_tests  # noqa: E402
 from pytest_fly.gui.gui_main import FlyAppMainWindow  # noqa: E402
-from pytest_fly.preferences import get_pref  # noqa: E402
+from pytest_fly.preferences import init_preferences_for_put  # noqa: E402
 
 WINDOW_SIZE = (1700, 900)
 GIF_SAMPLE_INTERVAL_MS = 600
@@ -172,25 +172,20 @@ def main():
     print(f"capture data dir: {data_dir}")
     print(f"target project: {fly_demo_dir}")
 
-    # Point the GUI at the demo dir for this run, restoring the user's saved value on exit so
-    # the capture doesn't permanently mutate their preferences.
-    pref = get_pref()
-    saved_target = pref.target_project_path
-    pref.target_project_path = str(fly_demo_dir)
+    # Bind preference storage to the demo PUT — per-PUT prefs live alongside the demo dir,
+    # so there's nothing to restore on exit.
+    init_preferences_for_put(fly_demo_dir)
 
-    try:
-        app = QApplication.instance() or QApplication([])
-        window = FlyAppMainWindow(data_dir)
-        window.resize(*WINDOW_SIZE)
-        window.show()
+    app = QApplication.instance() or QApplication([])
+    window = FlyAppMainWindow(data_dir)
+    window.resize(*WINDOW_SIZE)
+    window.show()
 
-        capturer = Capturer(window, output_dir)
-        QTimer.singleShot(RUN_TRIGGER_DELAY_MS, window.run_tab.control_window.run)
-        QTimer.singleShot(RUN_TRIGGER_DELAY_MS + 100, capturer.start)
+    capturer = Capturer(window, output_dir)
+    QTimer.singleShot(RUN_TRIGGER_DELAY_MS, window.run_tab.control_window.run)
+    QTimer.singleShot(RUN_TRIGGER_DELAY_MS + 100, capturer.start)
 
-        app.exec()
-    finally:
-        pref.target_project_path = saved_target
+    app.exec()
 
     print("done.")
 

--- a/src/pytest_fly/gui/about_tab/about.py
+++ b/src/pytest_fly/gui/about_tab/about.py
@@ -7,11 +7,12 @@ import humanize
 from PySide6.QtCore import QObject, QThread, Signal
 from PySide6.QtWidgets import QSizePolicy, QVBoxLayout, QWidget
 
+from pytest_fly.__version__ import application_name
 from pytest_fly.gui.about_tab.project_info import get_project_info
 from pytest_fly.gui.gui_util import PlainTextWidget
 from pytest_fly.logger import get_log_directory
 from pytest_fly.platform.platform_info import get_performance_core_count, get_platform_info
-from pytest_fly.preferences import get_pref
+from pytest_fly.preferences import get_active_put_path, get_preferences_db_path
 from pytest_fly.put_version import detect_put_version
 
 # Preferred display order for Program Under Test fields; any fields not listed
@@ -28,6 +29,10 @@ class AboutDataWorker(QObject):
     """
 
     data_ready = Signal(str)
+
+    def __init__(self, data_dir: Path):
+        super().__init__()
+        self._data_dir = data_dir
 
     def run(self):
         text_lines = []
@@ -49,9 +54,7 @@ class AboutDataWorker(QObject):
                 text_lines.append(f"    {key}: {value}")
         text_lines.append("")
 
-        pref = get_pref()
-        project_root = Path(pref.target_project_path).resolve() if pref.target_project_path else Path.cwd()
-        put_info = detect_put_version(project_root)
+        put_info = detect_put_version(get_active_put_path())
         put_fields = asdict(put_info)
         text_lines.append("Program Under Test:")
         for key in _PUT_FIELD_ORDER:
@@ -72,6 +75,8 @@ class AboutDataWorker(QObject):
 
         text_lines.append("")
         text_lines.append(f"log_directory: {get_log_directory()}")
+        text_lines.append(f"test_results_db: {Path(self._data_dir, f'{application_name}.db')}")
+        text_lines.append(f"preferences_db: {get_preferences_db_path()}")
 
         text_lines.append("")
         text_lines.append("Notes:")
@@ -86,7 +91,7 @@ class About(QWidget):
     A window that shows information about the project and the system.
     """
 
-    def __init__(self, parent):
+    def __init__(self, parent, data_dir: Path):
         super().__init__(parent)
 
         self.setWindowTitle("About")
@@ -98,7 +103,7 @@ class About(QWidget):
         self.setLayout(vertical_layout)
         vertical_layout.addWidget(self.about_box)
 
-        self.worker = AboutDataWorker()
+        self.worker = AboutDataWorker(data_dir)
         self.thread = QThread()
         self.worker.moveToThread(self.thread)
         self.worker.data_ready.connect(self.update_about_box)

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -4,6 +4,7 @@ parallelism, refresh rate, and utilization thresholds.
 """
 
 from collections.abc import Callable
+from pathlib import Path
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QDoubleValidator, QIntValidator, QValidator
@@ -16,6 +17,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QListWidget,
     QListWidgetItem,
+    QMessageBox,
     QPushButton,
     QSizePolicy,
     QStyle,
@@ -28,9 +30,11 @@ from pytest_fly.gui.about_tab.project_info import get_project_info
 from pytest_fly.gui.gui_util import get_text_dimensions
 from pytest_fly.interfaces import OrderingAspect, RunMode
 from pytest_fly.logger import get_logger
+from pytest_fly.paths import get_default_data_dir, write_last_target
 from pytest_fly.platform.platform_info import get_performance_core_count
 from pytest_fly.preferences import (
     chart_window_minutes_default,
+    get_active_put_path,
     get_ordering_aspects_ordered,
     get_pref,
     graph_font_size_default,
@@ -335,18 +339,40 @@ class Configuration(QWidget):
 
         layout.addWidget(QLabel(""))  # space
 
-        # Target project path — empty means auto-detect from the current working directory at run time.
-        layout.addWidget(QLabel("Target Project Path (empty = auto-detect from current directory)"))
+        # Target project path (PUT). Per-PUT preferences live under <PUT>/.pytest-fly/, so
+        # the active PUT can't be changed without reopening the preference DB — edits here
+        # take effect on the next launch.
+        self._active_put_path = str(get_active_put_path())
+        layout.addWidget(QLabel("Target Project Path (program under test)"))
         target_path_row = QHBoxLayout()
         self.target_project_path_lineedit = QLineEdit()
-        self.target_project_path_lineedit.setText(pref.target_project_path)
-        self.target_project_path_lineedit.setPlaceholderText("(auto-detect)")
-        self.target_project_path_lineedit.textChanged.connect(self.update_target_project_path)
+        self.target_project_path_lineedit.setText(self._active_put_path)
+        self.target_project_path_lineedit.editingFinished.connect(self._commit_target_project_path)
         target_path_row.addWidget(self.target_project_path_lineedit)
         self.target_project_path_browse = QPushButton("Browse…")
         self.target_project_path_browse.clicked.connect(self._browse_target_project_path)
         target_path_row.addWidget(self.target_project_path_browse)
         layout.addLayout(target_path_row)
+        self.target_project_path_restart_label = QLabel("Restart pytest-fly to apply the new target.")
+        self.target_project_path_restart_label.setStyleSheet("color: #b25400;")
+        self.target_project_path_restart_label.setVisible(False)
+        layout.addWidget(self.target_project_path_restart_label)
+
+        layout.addWidget(QLabel(""))  # space
+
+        # Test results DB directory — empty means use the platform default (platformdirs user data dir).
+        default_results_dir = str(get_default_data_dir())
+        layout.addWidget(QLabel(f"Test Results DB Directory (empty = default: {default_results_dir})"))
+        results_dir_row = QHBoxLayout()
+        self.test_results_db_dir_lineedit = QLineEdit()
+        self.test_results_db_dir_lineedit.setText(pref.test_results_db_dir)
+        self.test_results_db_dir_lineedit.setPlaceholderText(default_results_dir)
+        self.test_results_db_dir_lineedit.textChanged.connect(self.update_test_results_db_dir)
+        results_dir_row.addWidget(self.test_results_db_dir_lineedit)
+        self.test_results_db_dir_browse = QPushButton("Browse…")
+        self.test_results_db_dir_browse.clicked.connect(self._browse_test_results_db_dir)
+        results_dir_row.addWidget(self.test_results_db_dir_browse)
+        layout.addLayout(results_dir_row)
 
         layout.addWidget(QLabel(""))  # space
 
@@ -445,15 +471,41 @@ class Configuration(QWidget):
         if value.isnumeric():
             pref.graph_font_size = max(int(value), minimum_graph_font_size)
 
-    def update_target_project_path(self, value: str):
-        """Persist the target-project path override (empty = auto-detect)."""
-        pref = get_pref()
-        pref.target_project_path = value.strip()
+    def _commit_target_project_path(self):
+        """Persist the target-project path and prompt for a restart if it changed."""
+        new_value = self.target_project_path_lineedit.text().strip()
+        if not new_value:
+            # Empty input is meaningless — restore the displayed value to the active PUT.
+            self.target_project_path_lineedit.setText(self._active_put_path)
+            return
+        new_path = Path(new_value).resolve()
+        if str(new_path) == self._active_put_path:
+            return  # no change
+        write_last_target(new_path)
+        self.target_project_path_restart_label.setVisible(True)
+        QMessageBox.information(
+            self,
+            "Restart required",
+            f"Target project will change to:\n\n{new_path}\n\nRestart pytest-fly to apply.",
+        )
 
     def _browse_target_project_path(self):
         """Open a directory picker to choose the target project path."""
-        pref = get_pref()
-        start = pref.target_project_path or ""
+        start = self.target_project_path_lineedit.text().strip() or self._active_put_path
         selected = QFileDialog.getExistingDirectory(self, "Select target project directory", start)
         if selected:
             self.target_project_path_lineedit.setText(selected)
+            self._commit_target_project_path()
+
+    def update_test_results_db_dir(self, value: str):
+        """Persist the test-results DB directory override (empty = platform default)."""
+        pref = get_pref()
+        pref.test_results_db_dir = value.strip()
+
+    def _browse_test_results_db_dir(self):
+        """Open a directory picker to choose the test-results DB directory."""
+        pref = get_pref()
+        start = pref.test_results_db_dir or str(get_default_data_dir())
+        selected = QFileDialog.getExistingDirectory(self, "Select test results DB directory", start)
+        if selected:
+            self.test_results_db_dir_lineedit.setText(selected)

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -151,7 +151,7 @@ class FlyAppMainWindow(QMainWindow):
         self.table_tab = TableTab(self.data_dir)
         self.coverage_tab = CoverageTab()
         self.configuration = Configuration()
-        self.about = About(self)
+        self.about = About(self, self.data_dir)
         self.tab_widget.addTab(self.run_tab, "Run")
         self.tab_widget.addTab(self.graph_tab, "Graph")
         self.tab_widget.addTab(self.table_tab, "Table")

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -18,7 +18,7 @@ from ...db import PytestProcessInfoDB
 from ...guid import generate_uuid
 from ...interfaces import OrderingAspect, PutVersionInfo, PyTestFlyExitCode, RunMode, ScheduledTest
 from ...logger import get_logger
-from ...preferences import ParallelismControl, get_ordering_aspects_ordered, get_pref
+from ...preferences import ParallelismControl, get_active_put_path, get_ordering_aspects_ordered, get_pref
 from ...put_version import detect_put_version
 from ...pytest_runner.coverage import compute_per_test_coverage
 from ...pytest_runner.ordering import OrderingContext, apply_ordering_aspects
@@ -114,10 +114,9 @@ class ControlWindow(QGroupBox):
         """Discover tests and launch a new :class:`PytestRunner`."""
         pref = get_pref()
 
-        # Resolve the project root from the preference override (if any) and detect the
-        # program-under-test version before starting collection so we can pass the path
-        # into GetTests for consistent discovery.
-        project_root = Path(pref.target_project_path).resolve() if pref.target_project_path else Path.cwd()
+        # Resolve the PUT path bound at app startup so test discovery and PUT-version
+        # detection use the same root the rest of the app sees.
+        project_root = get_active_put_path()
         self.put_version_info = detect_put_version(project_root)
         log.info(f"PUT detected: {self.put_version_info}")
 

--- a/src/pytest_fly/main.py
+++ b/src/pytest_fly/main.py
@@ -7,8 +7,8 @@ from .__version__ import application_name
 from .gui import fly_main
 from .gui.about_tab.project_info import get_project_info
 from .logger import get_logger, init_parent_logger
-from .paths import get_default_data_dir
-from .preferences import get_pref
+from .paths import get_default_data_dir, read_last_target, write_last_target
+from .preferences import get_pref, init_preferences_for_put
 from .put_version import detect_put_version
 
 log = get_logger(application_name)
@@ -16,8 +16,8 @@ log = get_logger(application_name)
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog=application_name, description="pytest-fly: pytest runner and observer GUI")
-    parser.add_argument("--target", type=Path, default=None, help="Target project directory (the program under test). Overrides the saved preference for this run only.")
-    parser.add_argument("--data-dir", type=Path, default=None, help="Override the application data directory (DB, logs). Useful for clean automated runs.")
+    parser.add_argument("--target", type=Path, default=None, help="Target project directory (the program under test). Defaults to the current working directory.")
+    parser.add_argument("--data-dir", type=Path, default=None, help="Override the test-results DB directory for this run. Takes precedence over the saved preference and the platform default.")
     parser.add_argument("--auto-start", action="store_true", help="Automatically click the Run button shortly after the window appears.")
     parser.add_argument("--auto-quit-on-done", action="store_true", help="Close the window once the active test run finishes. Pair with --auto-start for unattended runs.")
     return parser.parse_args(argv)
@@ -27,20 +27,35 @@ def app_main(argv: list[str] | None = None):
     """Initialize logging and launch the GUI."""
     args = _parse_args(argv)
 
-    init_parent_logger(verbose=get_pref().verbose)
+    # Resolve the PUT first; per-PUT preferences live under <PUT>/.pytest-fly/, so every
+    # subsequent pref access (including verbose-flag-driven log init) needs this bound.
+    # Precedence: explicit --target > persisted last_target file > cwd.
+    if args.target is not None:
+        put_path = args.target.resolve()
+    else:
+        saved = read_last_target()
+        put_path = saved.resolve() if saved is not None else Path.cwd()
+    init_preferences_for_put(put_path)
+    # Persist whichever PUT we just resolved so a no-arg relaunch picks the same one.
+    write_last_target(put_path)
+    log.info(f"program under test path: {put_path}")
+
+    pref = get_pref()
+    init_parent_logger(verbose=pref.verbose)
 
     project_info = get_project_info()
     log.info(f"{project_info.application_name} version {project_info.version}")
 
-    if args.target is not None:
-        target = args.target.resolve()
-        get_pref().target_project_path = str(target)
-        log.info(f"target project path overridden via --target: {target}")
-
-    data_dir = args.data_dir.resolve() if args.data_dir is not None else get_default_data_dir()
+    # Precedence: --data-dir CLI > pref.test_results_db_dir > platform default.
+    if args.data_dir is not None:
+        data_dir = args.data_dir.resolve()
+    elif pref.test_results_db_dir:
+        data_dir = Path(pref.test_results_db_dir).resolve()
+    else:
+        data_dir = get_default_data_dir()
     data_dir.mkdir(parents=True, exist_ok=True)
 
-    put_info = detect_put_version()
+    put_info = detect_put_version(put_path)
     log.info(f"program under test: {put_info.short_label()} (source={put_info.source}, project_root={put_info.project_root})")
 
     fly_main(data_dir, auto_start=args.auto_start, auto_quit_on_done=args.auto_quit_on_done)

--- a/src/pytest_fly/paths.py
+++ b/src/pytest_fly/paths.py
@@ -1,13 +1,15 @@
-"""Resolve the application data directory (platform-aware, overridable via env var)."""
+"""Resolve the application data directory and persist the last-selected PUT path."""
 
 import os
 from functools import cache
 from pathlib import Path
 
-from platformdirs import user_data_dir
+from platformdirs import user_config_dir, user_data_dir
 
 from .__version__ import application_name, author
 from .const import PYTEST_FLY_DATA_DIR_STRING
+
+_LAST_TARGET_FILE_NAME = "last_target.txt"
 
 
 @cache
@@ -20,3 +22,33 @@ def get_default_data_dir() -> Path:
     data_dir = Path(os.environ.get(PYTEST_FLY_DATA_DIR_STRING, Path(user_data_dir(application_name, author))))
     data_dir.mkdir(parents=True, exist_ok=True)
     return data_dir
+
+
+def _last_target_file() -> Path:
+    return Path(user_config_dir(application_name, author), _LAST_TARGET_FILE_NAME)
+
+
+def read_last_target() -> Path | None:
+    """Return the most recently selected PUT path, or ``None`` if none has been saved.
+
+    Per-PUT preferences live inside the PUT, so the "which PUT to open" choice
+    can't itself be stored there.  A small text file in the user config dir
+    persists the user's selection across launches.
+    """
+    path = _last_target_file()
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not text:
+        return None
+    return Path(text)
+
+
+def write_last_target(target: Path) -> None:
+    """Persist *target* as the last-selected PUT path."""
+    path = _last_target_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(target.resolve()), encoding="utf-8")

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -1,9 +1,11 @@
 """
-Persistent user preferences backed by a local SQLite file via the *pref* library.
+Persistent user preferences backed by a per-PUT SQLite file via the *pref* library.
 
-Default values for parallelism, refresh rate, and utilization thresholds are
-defined here so both the preference class and the configuration tab can share
-them without circular imports.
+Each program under test (PUT) gets its own preferences DB at
+``<PUT>/.pytest-fly/preferences.db``.  The PUT path is established at
+application startup via :func:`init_preferences_for_put`; every preference
+accessor downstream — including :class:`FlyPreferences` and the ordering-aspect
+:class:`PrefOrderedSet` — resolves storage relative to that path.
 """
 
 from enum import IntEnum
@@ -11,13 +13,13 @@ from pathlib import Path
 
 from attr import attrib, attrs
 from pref import Pref, PrefOrderedSet
-from pref.pref import appdirs as _pref_appdirs
 
 from .__version__ import application_name, author
 from .interfaces import OrderingAspect, RunMode
 from .platform import get_performance_core_count
 
-preferences_file_name = f"{application_name}_preferences.db"
+preferences_file_name = "preferences.db"
+preferences_dir_name = f".{application_name}"  # ".pytest-fly" — hidden dir inside the PUT root
 _ordering_aspects_table = "ordering_aspects"
 _default_ordering_aspect_seed: list[OrderingAspect] = [OrderingAspect.FAILED_FIRST, OrderingAspect.NEVER_RUN_FIRST]
 
@@ -39,9 +41,44 @@ class ParallelismControl(IntEnum):
     DYNAMIC = 2  # automatically dynamically determine max number of processes to run in parallel, while trying to avoid high utilization thresholds (see utilization_high_threshold)
 
 
+_active_put_path: Path | None = None
+
+
+def init_preferences_for_put(put_path: Path) -> None:
+    """Bind preference storage to ``put_path`` for the current process.
+
+    Must be called once at startup before any :func:`get_pref` or
+    :func:`get_ordering_aspects_set` call — the PUT path drives the SQLite
+    location for both :class:`FlyPreferences` and the ordering-aspect
+    :class:`PrefOrderedSet`.  Calling again with a different path invalidates
+    the cached pref instance so the next access reopens against the new PUT.
+    """
+    global _active_put_path
+    resolved = put_path.resolve()
+    if _active_put_path != resolved:
+        _active_put_path = resolved
+        reset_pref_cache()
+
+
+def get_active_put_path() -> Path:
+    """Return the PUT path bound via :func:`init_preferences_for_put`."""
+    if _active_put_path is None:
+        raise RuntimeError("init_preferences_for_put() must be called before accessing preferences")
+    return _active_put_path
+
+
+def get_preferences_db_path() -> Path:
+    """Return the path to the per-PUT preferences DB."""
+    return Path(get_active_put_path(), preferences_dir_name, preferences_file_name)
+
+
+def _ensure_preferences_dir() -> None:
+    get_preferences_db_path().parent.mkdir(parents=True, exist_ok=True)
+
+
 @attrs
 class FlyPreferences(Pref):
-    """Persistent user preferences backed by a local SQLite file via the *pref* library."""
+    """Persistent per-PUT user preferences backed by a local SQLite file."""
 
     window_x: int = attrib(default=-1)
     window_y: int = attrib(default=-1)
@@ -74,43 +111,41 @@ class FlyPreferences(Pref):
     run_tab_splitter_state: str = attrib(default="")  # Run-tab top-vs-failed-tests splitter (QSplitter.saveState() hex-encoded)
     run_tab_bottom_splitter_state: str = attrib(default="")  # Run-tab bottom pane: failed-tests-vs-live-output splitter (QSplitter.saveState() hex-encoded)
 
-    target_project_path: str = attrib(default="")  # absolute path to the program under test; empty means auto-detect from cwd at run time
+    test_results_db_dir: str = attrib(default="")  # override directory for the test-results SQLite DB; empty means use the platform default
 
     perf_logging: bool = attrib(default=False)  # log per-tick phase timings (db query, build_tick_data, each tab update) to diagnose UI lag
+
+    def get_sqlite_path(self) -> Path:
+        # Override pref's default appdirs-based resolution so storage lives under the active PUT.
+        path = get_preferences_db_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+
+class FlyOrderedSet(PrefOrderedSet):
+    """:class:`PrefOrderedSet` with per-PUT SQLite storage."""
+
+    def get_sqlite_path(self) -> Path:
+        path = get_preferences_db_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
 
 
 _cached_pref: FlyPreferences | None = None
 _cached_pref_path: Path | None = None
 
 
-def _resolve_pref_path() -> Path:
-    """Resolve the SQLite path that ``FlyPreferences`` would open right now.
-
-    Mirrors ``Pref.get_sqlite_path`` and uses pref's own ``appdirs`` import so
-    test fixtures that monkeypatch ``pref.pref.appdirs.user_config_dir`` are
-    honored — this is what lets the cache invalidate across tests with isolated
-    storage dirs.
-    """
-    return Path(_pref_appdirs.user_config_dir(application_name, author), preferences_file_name)
-
-
 def get_pref() -> FlyPreferences:
     """Return a :class:`FlyPreferences` instance (reads from / auto-saves to disk).
 
-    The instance is cached process-wide.  Constructing ``FlyPreferences``
-    reopens the backing ``SqliteDict`` and issues one SELECT per attribute,
-    so calling ``get_pref()`` on every tick — including from each progress
-    bar — was a measurable contributor to UI latency.  Writes go through
-    ``FlyPreferences.__setattr__`` directly to disk, so the cached instance
-    stays consistent with persistent storage.
-
-    The cache is keyed on the resolved storage path, so tests that redirect
-    pref storage to a tmp dir transparently get a fresh instance.  Tests can
-    also call :func:`reset_pref_cache` explicitly if the path-key heuristic
-    isn't enough (e.g., when bypassing the appdirs monkeypatch path).
+    The instance is cached process-wide and keyed on the resolved per-PUT
+    storage path, so switching PUT via :func:`init_preferences_for_put` will
+    transparently reopen the right DB on the next access.  Constructing
+    ``FlyPreferences`` issues one SELECT per attribute, so caching matters for
+    UI tick performance.
     """
     global _cached_pref, _cached_pref_path
-    current_path = _resolve_pref_path()
+    current_path = get_preferences_db_path()
     if _cached_pref is None or _cached_pref_path != current_path:
         _cached_pref = FlyPreferences(application_name, author, file_name=preferences_file_name)
         _cached_pref_path = current_path
@@ -124,9 +159,9 @@ def reset_pref_cache() -> None:
     _cached_pref_path = None
 
 
-def get_ordering_aspects_set() -> PrefOrderedSet:
-    """Return the :class:`PrefOrderedSet` backing the enabled-and-ordered aspect list."""
-    return PrefOrderedSet(application_name, author, table=_ordering_aspects_table, file_name=preferences_file_name)
+def get_ordering_aspects_set() -> FlyOrderedSet:
+    """Return the :class:`FlyOrderedSet` backing the enabled-and-ordered aspect list."""
+    return FlyOrderedSet(application_name, author, table=_ordering_aspects_table, file_name=preferences_file_name)
 
 
 def get_ordering_aspects_ordered() -> list[OrderingAspect]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,19 @@ from pathlib import Path
 import pytest
 from PySide6.QtWidgets import QApplication
 
+from pytest_fly.preferences import init_preferences_for_put
+
 pytest_plugins = "pytester"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _bind_test_prefs(tmp_path_factory):
+    """Bind pref storage to a session-scoped tmp PUT so tests never touch the user's real prefs.
+
+    Per-test fixtures (e.g. the ordering-aspects suite) can call
+    :func:`init_preferences_for_put` again to redirect into their own tmp dirs.
+    """
+    init_preferences_for_put(tmp_path_factory.mktemp("pytest_fly_test_prefs"))
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -516,9 +516,9 @@ def test_project_info():
     assert info.version in s
 
 
-def test_about(qtbot):
+def test_about(qtbot, tmp_path):
     """About tab should load project and platform info in background."""
-    about = About(None)
+    about = About(None, tmp_path)
     qtbot.addWidget(about)
     qtbot.waitUntil(lambda: not about.thread.isRunning(), timeout=10000)
     text = about.about_box.toPlainText()

--- a/tests/test_preferences_ordering_aspects.py
+++ b/tests/test_preferences_ordering_aspects.py
@@ -1,7 +1,6 @@
 """Tests for the PrefOrderedSet-backed ordering-aspect persistence helpers."""
 
 import pytest
-from pref import pref as pref_mod
 
 from pytest_fly.interfaces import OrderingAspect
 from pytest_fly.preferences import (
@@ -9,23 +8,20 @@ from pytest_fly.preferences import (
     get_ordering_aspects_ordered,
     get_ordering_aspects_set,
     get_pref,
+    init_preferences_for_put,
     reset_pref_cache,
     set_ordering_aspects_ordered,
 )
 
 
 @pytest.fixture
-def isolated_prefs(tmp_path, monkeypatch):
-    """Redirect pref's SQLite storage to a unique tmp dir for each test.
+def isolated_prefs(tmp_path):
+    """Bind preference storage to a unique tmp PUT dir for each test.
 
-    The pref library resolves its storage via ``appdirs.user_config_dir`` at
-    instantiation time, so patching it on the ``pref.pref`` module is enough
-    to send every pref (including :class:`PrefOrderedSet`) into tmp_path.
-    Also drops :func:`get_pref`'s in-process cache before and after the test
-    so a stale instance from prior code paths can't bleed in.
+    Per-PUT preferences live at ``<PUT>/.pytest-fly/preferences.db``; pointing
+    the PUT at ``tmp_path`` gives each test a fresh, isolated DB.
     """
-    reset_pref_cache()
-    monkeypatch.setattr(pref_mod.appdirs, "user_config_dir", lambda *a, **kw: str(tmp_path))
+    init_preferences_for_put(tmp_path)
     yield tmp_path
     reset_pref_cache()
 


### PR DESCRIPTION
## Summary
- Preferences now live inside the program under test at `<PUT>/.pytest-fly/preferences.db` so each project gets its own settings, instead of one shared user-wide pref DB.
- Active PUT is established at app startup from `--target` or cwd; the last selection is persisted to a small file in the user config dir so a no-arg relaunch keeps the same project.
- Configuration tab gets a new **Test Results DB Directory** override (defaults to the existing platformdirs location) and brings back **Target Project Path** as a relaunch-prompt editor.
- About tab shows both resolved database paths.
- Version bumped to 0.4.11.

## Test plan
- [x] Full test suite passes locally (192 passed).
- [x] Smoke-tested per-PUT pref DB writes land at `<PUT>/.pytest-fly/preferences.db`.
- [ ] CI on Windows + Linux matrices.
- [ ] Manual: launch GUI, change Target Project Path, confirm restart prompt, relaunch with no args, confirm new PUT is active.
- [ ] Manual: change Test Results DB Directory, confirm DB file appears in the chosen location on next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)