### PR TITLE
Fix misleading "Calculating..." idle status; bump to 0.4.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.11"
+version = "0.4.12"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/status_window.py
+++ b/src/pytest_fly/gui/run_tab/status_window.py
@@ -29,11 +29,11 @@ class StatusWindow(QGroupBox):
         layout.addWidget(self.progress_bar)
 
         label_font = get_font()
-        self.complete_label = QLabel("Complete: (calculating...)", self)
+        self.complete_label = QLabel("Complete: —", self)
         self.complete_label.setFont(label_font)
         layout.addWidget(self.complete_label)
 
-        self.pass_rate_label = QLabel("Pass rate: (calculating...)", self)
+        self.pass_rate_label = QLabel("Pass rate: —", self)
         self.pass_rate_label.setFont(label_font)
         layout.addWidget(self.pass_rate_label)
 
@@ -127,12 +127,12 @@ class StatusWindow(QGroupBox):
                 if tick.put_version_info.git_dirty:
                     put_line += "  [uncommitted changes]"
                 lines.extend([put_line, ""])
-            lines.append("Calculating...")
+            lines.append("No test run yet — press Run to start.")
 
             self.progress_bar.setValue(0)
-            self.complete_label.setText("Complete: (calculating...)")
+            self.complete_label.setText("Complete: —")
             self.complete_label.setStyleSheet("font-weight: normal;")
-            self.pass_rate_label.setText("Pass rate: (calculating...)")
+            self.pass_rate_label.setText("Pass rate: —")
             self.pass_rate_label.setStyleSheet("")
 
         self.status_widget.set_text("\n".join(lines))

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -75,13 +75,15 @@ def _make_tick_data_with_tests():
 
 
 def test_status_window_empty(app):
-    """StatusWindow should display 'Calculating...' when there is no data."""
+    """StatusWindow should prompt the user to press Run when there is no data."""
     window = StatusWindow(None)
     tick = _make_tick_data_empty()
     window.update_tick(tick)
 
     text = window.status_widget.toPlainText()
-    assert "Calculating..." in text
+    assert "press Run" in text
+    assert window.complete_label.text() == "Complete: —"
+    assert window.pass_rate_label.text() == "Pass rate: —"
 
 
 def test_status_window_with_data(app):


### PR DESCRIPTION
@
## Summary

The Run-tab **Status** panel showed **"Calculating..."** whenever there were no test-result records for the current run. In a fresh environment (empty results DB), this idle/no-data state persisted indefinitely until **Run** was pressed, making the app look busy and stuck rather than simply idle.

## Changes

- Reword the empty/no-data state to **"No test run yet — press Run to start."**
- Show **`Complete: —`** / **`Pass rate: —`** instead of `(calculating...)` for the idle state (both initial labels and the no-data branch).
- The in-progress pass-rate text (a run is underway but nothing has completed yet) is left unchanged, since "calculating" is accurate there.
- Updated `test_status_window_empty` to assert the new copy.
- Bump version 0.4.11 → 0.4.12.

## Testing

- `python -m pytest tests/` — 192 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@