### PR TITLE
CI: bump GitHub Actions to Node 24-based majors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,14 @@ jobs:
       matrix:
         python-version: ['3.12']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Qt dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libegl1 libxkbcommon0 libdbus-1-3
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -40,7 +40,7 @@ jobs:
         run: coverage xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
@
## Summary

CI flagged three actions as running on the deprecated Node.js 20 runtime (GitHub forces Node 24 on 2026-06-16 and removes Node 20 on 2026-09-16). This bumps them to the current Node 24-based majors:

- `actions/checkout` v4 → **v5**
- `actions/setup-python` v5 → **v6**
- `codecov/codecov-action` v4 → **v5**

No workflow logic or input changes were needed — only the version tags.

## Testing

CI on this PR exercises all three updated actions end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@