### PR TITLE
Increase code coverage with unit tests for under-tested modules

### DIFF
--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,0 +1,38 @@
+"""Tests for :mod:`pytest_fly.colors` — verify the color palette is well-formed."""
+
+from PySide6.QtGui import QColor
+
+from pytest_fly import colors
+from pytest_fly.interfaces import PytestRunnerState
+
+_SCALAR_COLOR_NAMES = [
+    "GRID_LINE_COLOR",
+    "COVERAGE_LINE_COLOR",
+    "COVERAGE_FILL_COLOR",
+    "CPU_LINE_COLOR",
+    "MEMORY_LINE_COLOR",
+    "DISK_READ_COLOR",
+    "DISK_WRITE_COLOR",
+    "NET_SENT_COLOR",
+    "NET_RECV_COLOR",
+]
+
+
+def test_bar_colors_cover_every_state(app):
+    """BAR_COLORS has a valid QColor for every runner state."""
+    assert set(colors.BAR_COLORS) == set(PytestRunnerState)
+    assert all(isinstance(color, QColor) and color.isValid() for color in colors.BAR_COLORS.values())
+
+
+def test_table_colors_cover_every_state(app):
+    """TABLE_COLORS has a valid QColor for every runner state."""
+    assert set(colors.TABLE_COLORS) == set(PytestRunnerState)
+    assert all(isinstance(color, QColor) and color.isValid() for color in colors.TABLE_COLORS.values())
+
+
+def test_scalar_colors_are_valid_qcolors(app):
+    """Each standalone chart/grid color constant is a valid QColor."""
+    for name in _SCALAR_COLOR_NAMES:
+        color = getattr(colors, name)
+        assert isinstance(color, QColor), name
+        assert color.isValid(), name

--- a/tests/test_gui_run_windows.py
+++ b/tests/test_gui_run_windows.py
@@ -1,0 +1,118 @@
+"""Tests for the run-tab windows: FailedTestsWindow and LiveOutputWindow."""
+
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from PySide6.QtWidgets import QApplication
+
+from pytest_fly.gui.gui_main import build_tick_data
+from pytest_fly.gui.run_tab.failed_tests_window import FailedTestsWindow
+from pytest_fly.gui.run_tab.live_output_window import LiveOutputWindow
+from pytest_fly.interfaces import PyTestFlyExitCode, PytestProcessInfo
+from pytest_fly.pytest_runner.live_output import live_output_path
+
+
+def _info(name, pid, exit_code, time_stamp):
+    return PytestProcessInfo(run_guid="g", name=name, pid=pid, exit_code=exit_code, output=None, time_stamp=time_stamp)
+
+
+def _fail_tick():
+    """A tick where test_b has failed and test_a passed."""
+    now = time.time()
+    infos = [
+        _info("tests/test_a.py", 1, PyTestFlyExitCode.NONE, now - 5),
+        _info("tests/test_a.py", 1, PyTestFlyExitCode.OK, now - 1),
+        _info("tests/test_b.py", 2, PyTestFlyExitCode.NONE, now - 5),
+        _info("tests/test_b.py", 2, PyTestFlyExitCode.TESTS_FAILED, now - 1),
+    ]
+    return build_tick_data(infos)
+
+
+# ---------------------------------------------------------------------------
+# FailedTestsWindow
+# ---------------------------------------------------------------------------
+
+
+def test_failed_tests_window_empty(app):
+    """No data -> placeholder text and a disabled copy button."""
+    window = FailedTestsWindow(None)
+    window.update_tick(build_tick_data([]))
+    assert window._text_widget.toPlainText() == "(none)"
+    assert not window._copy_button.isEnabled()
+
+
+def test_failed_tests_window_lists_failures(app):
+    """A failed test is listed and the copy button is enabled."""
+    window = FailedTestsWindow(None)
+    window.update_tick(_fail_tick())
+    text = window._text_widget.toPlainText()
+    assert "tests/test_b.py" in text
+    assert "tests/test_a.py" not in text  # passing test is not listed
+    assert window._copy_button.isEnabled()
+
+
+def test_failed_tests_window_copy_to_clipboard(app):
+    """Copying puts the failed test names on the system clipboard."""
+    window = FailedTestsWindow(None)
+    window.update_tick(_fail_tick())
+    window._copy_to_clipboard()
+    assert "tests/test_b.py" in QApplication.clipboard().text()
+
+
+# ---------------------------------------------------------------------------
+# LiveOutputWindow
+# ---------------------------------------------------------------------------
+
+
+def test_live_output_window_no_running_tests(app):
+    """With no running tests the selector shows the placeholder and is disabled."""
+    with TemporaryDirectory() as tmp:
+        window = LiveOutputWindow(None, Path(tmp))
+        window.update_tick(build_tick_data([]))
+        assert not window._test_selector.isEnabled()
+        assert window._test_selector.currentText() == "(no tests running)"
+        assert window._selected_name is None
+
+
+def test_live_output_window_shows_running_test_output(app):
+    """A running test populates the selector and renders its live output tail."""
+    with TemporaryDirectory() as tmp:
+        data_dir = Path(tmp)
+        now = time.time()
+        name = "tests/test_running.py"
+        infos = [_info(name, 1, PyTestFlyExitCode.NONE, now - 2)]  # started, no terminal code -> RUNNING
+        tick = build_tick_data(infos)
+
+        # Write the live-output file the window will tail.
+        path = live_output_path(data_dir, name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("running output line\n")
+
+        window = LiveOutputWindow(None, data_dir)
+        window.update_tick(tick)
+
+        assert window._test_selector.isEnabled()
+        assert window._selected_name == name
+        assert "running output line" in window._text_view.toPlainText()
+        assert "Elapsed:" in window._elapsed_label.text()
+
+
+def test_live_output_window_scroll_disables_follow_tail(app):
+    """Scrolling away from the bottom turns off follow-tail."""
+    with TemporaryDirectory() as tmp:
+        window = LiveOutputWindow(None, Path(tmp))
+        assert window._follow_tail_checkbox.isChecked()
+        # Give the scrollbar a real range so a value below the maximum means "scrolled up".
+        window._text_view.verticalScrollBar().setRange(0, 100)
+        window._on_scroll_changed(10)  # 10 < 100 -> user scrolled away from the bottom
+        assert not window._follow_tail_checkbox.isChecked()
+
+
+def test_live_output_window_scroll_noop_when_follow_off(app):
+    """When follow-tail is already off, a scroll event is a no-op."""
+    with TemporaryDirectory() as tmp:
+        window = LiveOutputWindow(None, Path(tmp))
+        window._follow_tail_checkbox.setChecked(False)
+        window._on_scroll_changed(0)  # must not raise or re-enable
+        assert not window._follow_tail_checkbox.isChecked()

--- a/tests/test_gui_util.py
+++ b/tests/test_gui_util.py
@@ -1,0 +1,253 @@
+"""Tests for :mod:`pytest_fly.gui.gui_util`."""
+
+import time
+
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QWidget
+
+from pytest_fly.gui.gui_main import build_tick_data
+from pytest_fly.gui.gui_util import (
+    PhaseTimer,
+    PlainTextWidget,
+    compute_average_parallelism,
+    compute_time_window,
+    count_test_states,
+    extract_test_duration,
+    format_runtime,
+    get_font,
+    get_text_dimensions,
+    group_process_infos_by_name,
+    tool_tip_limiter,
+    window_text_color,
+)
+from pytest_fly.interfaces import PyTestFlyExitCode, PytestProcessInfo
+
+
+def _info(name, pid, exit_code, time_stamp):
+    """Minimal PytestProcessInfo for a single observation of a test."""
+    return PytestProcessInfo(run_guid="g", name=name, pid=pid, exit_code=exit_code, output=None, time_stamp=time_stamp)
+
+
+# ---------------------------------------------------------------------------
+# group_process_infos_by_name
+# ---------------------------------------------------------------------------
+
+
+def test_group_process_infos_by_name_empty():
+    assert group_process_infos_by_name([]) == {}
+
+
+def test_group_process_infos_by_name_groups_in_order():
+    infos = [
+        _info("a", None, PyTestFlyExitCode.NONE, 1.0),
+        _info("b", None, PyTestFlyExitCode.NONE, 2.0),
+        _info("a", 10, PyTestFlyExitCode.NONE, 3.0),
+    ]
+    grouped = group_process_infos_by_name(infos)
+    assert list(grouped) == ["a", "b"]
+    assert [i.time_stamp for i in grouped["a"]] == [1.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# compute_time_window
+# ---------------------------------------------------------------------------
+
+
+def test_compute_time_window_empty():
+    assert compute_time_window([]) == (None, None)
+
+
+def test_compute_time_window_min_max():
+    infos = [
+        _info("a", 1, PyTestFlyExitCode.NONE, 5.0),
+        _info("a", 1, PyTestFlyExitCode.NONE, 2.0),
+        _info("a", 1, PyTestFlyExitCode.NONE, 9.0),
+    ]
+    assert compute_time_window(infos) == (2.0, 9.0)
+
+
+def test_compute_time_window_require_pid_skips_unstarted():
+    infos = [
+        _info("a", None, PyTestFlyExitCode.NONE, 1.0),  # not started — ignored when require_pid
+        _info("a", 1, PyTestFlyExitCode.NONE, 4.0),
+        _info("a", 1, PyTestFlyExitCode.NONE, 7.0),
+    ]
+    assert compute_time_window(infos, require_pid=True) == (4.0, 7.0)
+
+
+# ---------------------------------------------------------------------------
+# format_runtime
+# ---------------------------------------------------------------------------
+
+
+def test_format_runtime_seconds():
+    assert "second" in format_runtime(3)
+
+
+def test_format_runtime_minutes():
+    result = format_runtime(135)
+    assert "minute" in result and "second" in result
+
+
+# ---------------------------------------------------------------------------
+# extract_test_duration
+# ---------------------------------------------------------------------------
+
+
+def test_extract_test_duration_start_and_end():
+    infos = [
+        _info("a", None, PyTestFlyExitCode.NONE, 1.0),  # queued
+        _info("a", 10, PyTestFlyExitCode.NONE, 2.0),  # started
+        _info("a", 10, PyTestFlyExitCode.OK, 5.0),  # finished
+    ]
+    assert extract_test_duration(infos) == (2.0, 5.0)
+
+
+def test_extract_test_duration_never_started():
+    infos = [_info("a", None, PyTestFlyExitCode.NONE, 1.0)]
+    assert extract_test_duration(infos) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# compute_average_parallelism
+# ---------------------------------------------------------------------------
+
+
+def test_compute_average_parallelism_serial_is_one():
+    infos_by_name = {"a": [_info("a", 1, PyTestFlyExitCode.NONE, 0.0), _info("a", 1, PyTestFlyExitCode.OK, 10.0)]}
+    assert compute_average_parallelism(infos_by_name) == 1.0
+
+
+def test_compute_average_parallelism_overlap_above_one():
+    # Two tests each running 0..10 (fully overlapping): total 20s over 10s wall = 2.0.
+    infos_by_name = {
+        "a": [_info("a", 1, PyTestFlyExitCode.NONE, 0.0), _info("a", 1, PyTestFlyExitCode.OK, 10.0)],
+        "b": [_info("b", 2, PyTestFlyExitCode.NONE, 0.0), _info("b", 2, PyTestFlyExitCode.OK, 10.0)],
+    }
+    assert compute_average_parallelism(infos_by_name) == 2.0
+
+
+def test_compute_average_parallelism_running_uses_now():
+    # A still-running test (no terminal exit code) contributes up to "now".
+    start = time.time() - 5.0
+    infos_by_name = {"a": [_info("a", 1, PyTestFlyExitCode.NONE, start)]}
+    result = compute_average_parallelism(infos_by_name)
+    assert result is not None and result > 0.0
+
+
+def test_compute_average_parallelism_empty_is_none():
+    assert compute_average_parallelism({}) is None
+
+
+def test_compute_average_parallelism_zero_wall_is_none():
+    # A single instantaneous record: start == end -> zero wall clock -> None.
+    infos_by_name = {"a": [_info("a", 1, PyTestFlyExitCode.OK, 5.0)]}
+    assert compute_average_parallelism(infos_by_name) is None
+
+
+# ---------------------------------------------------------------------------
+# count_test_states
+# ---------------------------------------------------------------------------
+
+
+def test_count_test_states():
+    now = time.time()
+    infos = [
+        _info("pass", 1, PyTestFlyExitCode.NONE, now),
+        _info("pass", 1, PyTestFlyExitCode.OK, now + 1),
+        _info("fail", 2, PyTestFlyExitCode.NONE, now),
+        _info("fail", 2, PyTestFlyExitCode.TESTS_FAILED, now + 1),
+        _info("queued", None, PyTestFlyExitCode.NONE, now),
+    ]
+    tick = build_tick_data(infos)
+    counts = count_test_states(tick.run_states)
+    # Exactly three tests, one in each terminal/queued state.
+    assert sum(counts.values()) == 3
+    assert max(counts.values()) == 1
+
+
+# ---------------------------------------------------------------------------
+# PhaseTimer
+# ---------------------------------------------------------------------------
+
+
+def test_phase_timer_records_phases_in_order():
+    timer = PhaseTimer()
+    with timer.time("first"):
+        pass
+    with timer.time("second"):
+        pass
+    assert list(timer.phases) == ["first", "second"]
+    formatted = timer.format()
+    assert formatted.startswith("first=")
+    assert "second=" in formatted
+
+
+# ---------------------------------------------------------------------------
+# tool_tip_limiter
+# ---------------------------------------------------------------------------
+
+
+def test_tool_tip_limiter_none():
+    assert tool_tip_limiter(None) == ""
+
+
+def test_tool_tip_limiter_strips_trailing_blank_lines():
+    assert tool_tip_limiter("body\n\n  \n", line_limit=10) == "body"
+
+
+def test_tool_tip_limiter_keeps_tail_with_marker():
+    text = "\n".join(f"line{n}" for n in range(10))
+    result = tool_tip_limiter(text, line_limit=3)
+    assert result.startswith("...\n")
+    assert result.endswith("line9")
+    assert "line0" not in result
+
+
+def test_tool_tip_limiter_truncates_wide_lines():
+    long_line = "x" * 200
+    result = tool_tip_limiter(long_line, line_limit=10, width_limit=50)
+    assert result.endswith("...")
+    assert len(result) == 50
+
+
+def test_tool_tip_limiter_uses_preference_default():
+    # line_limit=None reads get_pref().tooltip_line_limit (bound to tmp prefs in conftest).
+    text = "\n".join(f"line{n}" for n in range(500))
+    result = tool_tip_limiter(text)
+    # Whatever the preference is, the result must be a non-empty bounded tail.
+    assert result
+    assert len(result.splitlines()) <= 500
+
+
+# ---------------------------------------------------------------------------
+# Qt-dependent helpers
+# ---------------------------------------------------------------------------
+
+
+def test_get_font_is_cached_and_sizable(app):
+    assert get_font() is get_font()  # lru_cache returns the same object
+    sized = get_font(14)
+    assert sized.pointSize() == 14
+
+
+def test_get_text_dimensions_pad_is_larger(app):
+    plain = get_text_dimensions("hello")
+    padded = get_text_dimensions("hello", pad=True)
+    assert padded.width() > plain.width()
+    assert padded.height() > plain.height()
+
+
+def test_window_text_color_returns_qcolor(app):
+    widget = QWidget()
+    assert isinstance(window_text_color(widget), QColor)
+
+
+def test_plain_text_widget_set_text(app):
+    widget = PlainTextWidget(None, "initial")
+    assert widget.toPlainText() == "initial"
+    widget.set_text("changed")
+    assert widget.toPlainText() == "changed"
+    # Setting the same text again is a no-op (does not raise, content stable).
+    widget.set_text("changed")
+    assert widget.toPlainText() == "changed"

--- a/tests/test_live_output.py
+++ b/tests/test_live_output.py
@@ -1,0 +1,113 @@
+"""Tests for :mod:`pytest_fly.pytest_runner.live_output`."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from pytest_fly.file_util import sanitize_test_name
+from pytest_fly.pytest_runner import live_output
+from pytest_fly.pytest_runner.live_output import (
+    clear_live_output,
+    live_output_dir,
+    live_output_path,
+    read_live_output,
+)
+
+
+def _write_log(data_dir: Path, test_name: str, data: bytes) -> Path:
+    """Create the live-output file for a test and write raw bytes to it."""
+    path = live_output_path(data_dir, test_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return path
+
+
+def test_live_output_dir():
+    """Directory is the live_output subdir of the data dir."""
+    data_dir = Path("some", "data")
+    assert live_output_dir(data_dir) == Path("some", "data", "live_output")
+
+
+def test_live_output_path_sanitizes_name():
+    """File name is the sanitized test node id with a .log suffix."""
+    data_dir = Path("data")
+    name = "tests/test_a.py::test_b"
+    path = live_output_path(data_dir, name)
+    assert path == Path("data", "live_output", f"{sanitize_test_name(name)}.log")
+    # The unsafe characters must not survive into the filename.
+    assert "/" not in path.name and ":" not in path.name
+
+
+def test_read_live_output_missing_returns_none():
+    """A test with no live-output file yields None."""
+    with TemporaryDirectory() as tmp:
+        assert read_live_output(Path(tmp), "tests/test_missing.py") is None
+
+
+def test_read_live_output_roundtrips_small_file():
+    """A small file is returned verbatim."""
+    live_output._read_cache.clear()
+    with TemporaryDirectory() as tmp:
+        data_dir = Path(tmp)
+        _write_log(data_dir, "tests/test_a.py", b"hello\nworld\n")
+        assert read_live_output(data_dir, "tests/test_a.py") == "hello\nworld\n"
+
+
+def test_read_live_output_uses_cache_for_unchanged_file():
+    """A second read of an unchanged file returns the cached value."""
+    live_output._read_cache.clear()
+    with TemporaryDirectory() as tmp:
+        data_dir = Path(tmp)
+        path = _write_log(data_dir, "tests/test_a.py", b"first\n")
+        assert read_live_output(data_dir, "tests/test_a.py") == "first\n"
+        # Mutate the cache entry directly: if the file is re-read, this fake value
+        # is overwritten; if the cache is used, it is returned unchanged.
+        size, mtime, _ = live_output._read_cache[path]
+        live_output._read_cache[path] = (size, mtime, "CACHED")
+        assert read_live_output(data_dir, "tests/test_a.py") == "CACHED"
+
+
+def test_read_live_output_truncates_large_file():
+    """A file larger than max_bytes drops the first partial line and is marked truncated."""
+    live_output._read_cache.clear()
+    with TemporaryDirectory() as tmp:
+        data_dir = Path(tmp)
+        # 5 lines of 100 'a' chars each; read only the tail so the first line is partial.
+        body = b"\n".join(b"a" * 100 for _ in range(5)) + b"\n"
+        _write_log(data_dir, "tests/test_big.py", body)
+        result = read_live_output(data_dir, "tests/test_big.py", max_bytes=250)
+        assert result is not None
+        assert result.startswith("...[truncated]...\n")
+        # The partial leading line was dropped, so only whole lines remain after the marker.
+        assert result.count("a" * 100) < 5
+
+
+def test_read_live_output_replaces_invalid_utf8():
+    """Non-UTF-8 bytes decode with replacement instead of crashing."""
+    live_output._read_cache.clear()
+    with TemporaryDirectory() as tmp:
+        data_dir = Path(tmp)
+        _write_log(data_dir, "tests/test_bin.py", b"ok\xff\xfe done\n")
+        result = read_live_output(data_dir, "tests/test_bin.py")
+        assert result is not None
+        assert "ok" in result and "done" in result
+        assert "�" in result  # replacement character
+
+
+def test_clear_live_output_removes_directory():
+    """clear_live_output deletes the directory and resets the cache."""
+    live_output._read_cache.clear()
+    with TemporaryDirectory() as tmp:
+        data_dir = Path(tmp)
+        _write_log(data_dir, "tests/test_a.py", b"data\n")
+        read_live_output(data_dir, "tests/test_a.py")  # populate the cache
+        assert live_output_dir(data_dir).exists()
+
+        clear_live_output(data_dir)
+        assert not live_output_dir(data_dir).exists()
+        assert live_output._read_cache == {}
+
+
+def test_clear_live_output_safe_when_absent():
+    """clear_live_output does not error when the directory does not exist."""
+    with TemporaryDirectory() as tmp:
+        clear_live_output(Path(tmp))  # no live_output dir created — must not raise

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -1,0 +1,53 @@
+"""Direct tests for the private :func:`_key_for` sort-key helper in the ordering module.
+
+The public :func:`apply_ordering_aspects` is covered by ``test_ordering_aspects.py``;
+this file exercises the per-aspect key edge cases (missing prior data, the
+coverage-efficiency fallback, and the unknown-aspect guard).
+"""
+
+import math
+
+import pytest
+
+from pytest_fly.interfaces import OrderingAspect, ScheduledTest
+from pytest_fly.pytest_runner.ordering import OrderingContext, _key_for
+
+
+def _t(name, singleton=False, duration=None, coverage=None):
+    return ScheduledTest(node_id=name, singleton=singleton, duration=duration, coverage=coverage)
+
+
+def test_key_for_failed_first():
+    ctx = OrderingContext(failed_names={"a"})
+    assert _key_for(OrderingAspect.FAILED_FIRST, _t("a"), ctx) == 0.0
+    assert _key_for(OrderingAspect.FAILED_FIRST, _t("b"), ctx) == 1.0
+
+
+def test_key_for_never_run_first():
+    ctx = OrderingContext(ever_run_names={"a"})
+    assert _key_for(OrderingAspect.NEVER_RUN_FIRST, _t("a"), ctx) == 1.0  # has run -> later
+    assert _key_for(OrderingAspect.NEVER_RUN_FIRST, _t("b"), ctx) == 0.0  # never run -> first
+
+
+def test_key_for_longest_prior_first():
+    ctx = OrderingContext(prior_durations={"a": 9.0})
+    assert _key_for(OrderingAspect.LONGEST_PRIOR_FIRST, _t("a"), ctx) == -9.0
+    # Missing prior duration -> 0.0 (sorts after tests that have a measured duration).
+    assert _key_for(OrderingAspect.LONGEST_PRIOR_FIRST, _t("b"), ctx) == 0.0
+
+
+def test_key_for_coverage_efficiency_with_data():
+    # lines_per_second = coverage / duration = 0.5 / 2 = 0.25; negated so higher sorts first.
+    key = _key_for(OrderingAspect.COVERAGE_EFFICIENCY, _t("a", duration=2.0, coverage=0.5), OrderingContext())
+    assert key == -0.25
+
+
+def test_key_for_coverage_efficiency_missing_data_is_inf():
+    # No duration/coverage -> efficiency unknown -> sorts last.
+    key = _key_for(OrderingAspect.COVERAGE_EFFICIENCY, _t("a"), OrderingContext())
+    assert key == math.inf
+
+
+def test_key_for_unknown_aspect_raises():
+    with pytest.raises(ValueError):
+        _key_for("not_an_aspect", _t("a"), OrderingContext())

--- a/tests/test_project_info.py
+++ b/tests/test_project_info.py
@@ -1,0 +1,108 @@
+"""Tests for :mod:`pytest_fly.gui.about_tab.project_info`."""
+
+from importlib import metadata
+
+from pytest_fly.gui.about_tab import project_info
+from pytest_fly.gui.about_tab.project_info import (
+    ProjectInfo,
+    _from_installed_metadata,
+    _from_pyproject,
+    _license_from_classifiers,
+    get_project_info,
+)
+
+
+def test_license_from_classifiers_finds_license():
+    """Returns the tail of the first 'License ::' classifier."""
+    classifiers = ["Programming Language :: Python", "License :: OSI Approved :: MIT License"]
+    assert _license_from_classifiers(classifiers) == "MIT License"
+
+
+def test_license_from_classifiers_none_when_absent():
+    """Returns None when there is no license classifier."""
+    assert _license_from_classifiers(["Topic :: Testing"]) is None
+    assert _license_from_classifiers(None) is None
+
+
+def test_from_pyproject_reads_repo_metadata():
+    """Walking up to the repo pyproject.toml yields pytest-fly's real metadata."""
+    info = _from_pyproject()
+    assert info is not None
+    assert info.application_name == "pytest-fly"
+    assert info.version != "Unknown"
+    assert "MIT" in info.license
+    assert "github.com/jamesabel/pytest-fly" in info.home_url
+    assert "github.com/jamesabel/pytest-fly" in info.repository_url
+
+
+def test_from_installed_metadata_none_when_not_installed(monkeypatch):
+    """A missing package surfaces as None rather than raising."""
+
+    def _raise(_name):
+        raise metadata.PackageNotFoundError
+
+    monkeypatch.setattr(project_info.metadata, "metadata", _raise)
+    assert _from_installed_metadata() is None
+
+
+class _FakeMeta:
+    """Minimal stand-in for importlib.metadata's Message object."""
+
+    def __init__(self, scalars, multi):
+        self._scalars = scalars
+        self._multi = multi
+
+    def get(self, key, default=None):
+        return self._scalars.get(key, default)
+
+    def get_all(self, key):
+        return self._multi.get(key)
+
+
+def test_from_installed_metadata_parses_fields(monkeypatch):
+    """The installed-metadata path extracts name, version, author, license, and URLs."""
+    fake = _FakeMeta(
+        scalars={"Name": "pytest-fly", "Version": "9.9.9", "Author-email": "Jane <jane@example.com>", "Summary": "a runner"},
+        multi={
+            "Classifier": ["License :: OSI Approved :: MIT License"],
+            "Project-URL": ["Homepage, https://example.com/home", "Repository, https://example.com/repo"],
+        },
+    )
+    monkeypatch.setattr(project_info.metadata, "metadata", lambda _name: fake)
+
+    info = _from_installed_metadata()
+    assert info is not None
+    assert info.application_name == "pytest-fly"
+    assert info.version == "9.9.9"
+    assert "jane@example.com" in info.author
+    assert info.description == "a runner"
+    assert info.license == "MIT License"
+    assert info.home_url == "https://example.com/home"
+    assert info.repository_url == "https://example.com/repo"
+
+
+def test_get_project_info_falls_back_to_installed_metadata(monkeypatch):
+    """When pyproject yields no usable version, get_project_info uses installed metadata."""
+    monkeypatch.setattr(project_info, "_from_pyproject", lambda: None)
+    fake = _FakeMeta(scalars={"Name": "pytest-fly", "Version": "1.0.0", "Author": "Jane"}, multi={})
+    monkeypatch.setattr(project_info.metadata, "metadata", lambda _name: fake)
+
+    get_project_info.cache_clear()
+    info = get_project_info()
+    get_project_info.cache_clear()  # don't leak the patched value to other tests
+    assert info.version == "1.0.0"
+
+
+def test_get_project_info_is_populated():
+    """The public accessor returns a ProjectInfo with a real version."""
+    get_project_info.cache_clear()
+    info = get_project_info()
+    assert isinstance(info, ProjectInfo)
+    assert info.application_name == "pytest-fly"
+    assert info.version != "Unknown"
+
+
+def test_project_info_str():
+    """__str__ renders name, version, and author on separate lines."""
+    info = ProjectInfo(application_name="demo", author="Jane", version="1.2.3")
+    assert str(info) == "demo\n1.2.3\nJane"

--- a/tests/test_tick_data.py
+++ b/tests/test_tick_data.py
@@ -1,0 +1,21 @@
+"""Tests for :class:`pytest_fly.tick_data.TickData`."""
+
+from pytest_fly.tick_data import TickData
+
+
+def test_effective_min_time_stamp_prefers_run_start():
+    """When current_run_start is set it wins over the earliest observed record."""
+    tick = TickData(process_infos=[], min_time_stamp=100.0, current_run_start=150.0)
+    assert tick.effective_min_time_stamp == 150.0
+
+
+def test_effective_min_time_stamp_falls_back_to_min():
+    """With no explicit run start, fall back to the earliest record timestamp."""
+    tick = TickData(process_infos=[], min_time_stamp=100.0, current_run_start=None)
+    assert tick.effective_min_time_stamp == 100.0
+
+
+def test_effective_min_time_stamp_none_when_both_unset():
+    """No run start and no records -> None."""
+    tick = TickData(process_infos=[])
+    assert tick.effective_min_time_stamp is None


### PR DESCRIPTION
## Summary

Raises code coverage by adding **61 direct unit tests** across 7 new test files for modules that were previously exercised only indirectly (or not at all). Overall coverage moves from **75% → 77%**, with the targeted modules now at or near full coverage.

All changes are **test-only** — no production code was modified.

## Per-module coverage

| Module | Before | After |
|---|---|---|
| `gui/gui_util.py` | partial | **100%** |
| `tick_data.py` | indirect | **100%** |
| `colors.py` | indirect | **100%** |
| `pytest_runner/ordering.py` | partial | **100%** |
| `gui/run_tab/failed_tests_window.py` | none | **94%** |
| `pytest_runner/live_output.py` | none | **92%** |
| `gui/run_tab/live_output_window.py` | none | **87%** |
| `gui/about_tab/project_info.py` | 58% | **86%** |

## New test files

- `test_gui_util.py` — grouping, time-window, average-parallelism, `PhaseTimer`, `tool_tip_limiter`, and Qt font/text helpers
- `test_live_output.py` — path/read/clear helpers incl. truncation, mtime caching, and invalid-UTF-8 handling
- `test_tick_data.py` — `effective_min_time_stamp` property
- `test_project_info.py` — `pyproject.toml` and installed-metadata parsing (incl. fallback chain)
- `test_colors.py` — palette well-formedness (every state mapped to a valid `QColor`)
- `test_gui_run_windows.py` — first direct widget tests for `FailedTestsWindow` and `LiveOutputWindow`
- `test_ordering.py` — direct `_key_for` edge cases per ordering aspect

## Test approach

Reuses existing patterns: the `app`/`_bind_test_prefs` fixtures from `conftest.py`, `build_tick_data` (which derives `run_states`) for GUI windows, and the simple direct-import style of `test_file_util.py`.

## Verification

- All 61 new tests pass (incl. random ordering via pytest-randomly)
- Full suite: **251 passed**
- `ruff check` and `ruff format --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)