### PR TITLE
Wire ViewCoverage into the GUI (Coverage tab 'View HTML Report' button)

### DIFF
--- a/src/pytest_fly/gui/coverage_tab/coverage_tab.py
+++ b/src/pytest_fly/gui/coverage_tab/coverage_tab.py
@@ -2,15 +2,27 @@
 Coverage tab — displays a step-function line chart of combined code coverage over time.
 """
 
+from pathlib import Path
+
 from PySide6.QtCore import QPointF, Qt
 from PySide6.QtGui import QBrush, QPainter, QPen, QPolygonF
-from PySide6.QtWidgets import QGroupBox, QSizePolicy, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QPushButton, QSizePolicy, QVBoxLayout, QWidget
 
 from ...colors import COVERAGE_FILL_COLOR, COVERAGE_LINE_COLOR, GRID_LINE_COLOR
 from ...interfaces import PytestRunnerState
+from ...logger import get_logger
+from ...pytest_runner.coverage import calculate_coverage
 from ...tick_data import TickData
 from ..graph_tab.time_axis import TimeAxisMapping, compute_grid_ticks
 from ..gui_util import count_test_states, get_text_dimensions, window_text_color
+from ..run_tab.view_coverage import ViewCoverage
+
+log = get_logger()
+
+# Test identifier used when generating the on-demand HTML report.  Kept distinct from
+# the live tracker's "current" identifier so clicking the button never races with the
+# periodic coverage recalculation writing to the same combined data file.
+_HTML_REPORT_IDENTIFIER = "html_report"
 
 # Horizontal grid lines at these percentages
 _Y_GRID_PCTS = [0.25, 0.50, 0.75, 1.00]
@@ -137,18 +149,46 @@ class _CoverageChart(QWidget):
 
 
 class CoverageTab(QGroupBox):
-    """Tab displaying a line chart of combined code coverage over time."""
+    """Tab displaying a line chart of combined code coverage over time.
 
-    def __init__(self):
+    :param data_dir: Application data directory.  When provided, a "View HTML Report"
+        button is shown that generates and opens the detailed line-by-line coverage
+        report.  When ``None`` (e.g. in isolated widget tests) the button is omitted.
+    """
+
+    def __init__(self, data_dir: Path | None = None):
         super().__init__()
         self.setTitle("Coverage")
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+
+        self._data_dir = data_dir
 
         layout = QVBoxLayout()
         self.setLayout(layout)
 
         self.chart = _CoverageChart()
         layout.addWidget(self.chart, stretch=1)
+
+        self.view_report_button: QPushButton | None = None
+        if data_dir is not None:
+            button_row = QHBoxLayout()
+            button_row.addStretch()
+            self.view_report_button = QPushButton("View HTML Report")
+            self.view_report_button.setToolTip("Generate and open the detailed line-by-line HTML coverage report in your browser.")
+            self.view_report_button.setEnabled(False)  # enabled once there is coverage data to report
+            self.view_report_button.clicked.connect(self._on_view_report)
+            button_row.addWidget(self.view_report_button)
+            layout.addLayout(button_row)
+
+    def _on_view_report(self) -> None:
+        """Generate a fresh HTML coverage report from the current data and open it."""
+        if self._data_dir is None:
+            return
+        try:
+            calculate_coverage(_HTML_REPORT_IDENTIFIER, self._data_dir, write_report=True)
+        except Exception as e:
+            log.warning(f"HTML coverage report generation failed: {e}")
+        ViewCoverage(self._data_dir).view()
 
     def update_tick(self, tick: TickData) -> None:
         # Compute status indicator from run states
@@ -166,3 +206,7 @@ class CoverageTab(QGroupBox):
             status_text = ""
 
         self.chart.update_data(tick.coverage_history, tick.effective_min_time_stamp, tick.max_time_stamp, status_text, tick.covered_lines, tick.total_lines)
+
+        # Only offer the report once there is coverage data to render.
+        if self.view_report_button is not None:
+            self.view_report_button.setEnabled(tick.total_lines > 0)

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -149,7 +149,7 @@ class FlyAppMainWindow(QMainWindow):
         self.run_tab = RunTab(self, self.data_dir)
         self.graph_tab = GraphTab()
         self.table_tab = TableTab(self.data_dir)
-        self.coverage_tab = CoverageTab()
+        self.coverage_tab = CoverageTab(self.data_dir)
         self.configuration = Configuration()
         self.about = About(self, self.data_dir)
         self.tab_widget.addTab(self.run_tab, "Run")

--- a/tests/test_coverage_tab_report.py
+++ b/tests/test_coverage_tab_report.py
@@ -1,0 +1,73 @@
+"""Tests for the CoverageTab 'View HTML Report' button wiring."""
+
+import webbrowser
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from pytest_fly.gui.coverage_tab import CoverageTab
+from pytest_fly.gui.coverage_tab import coverage_tab as coverage_tab_module
+from pytest_fly.tick_data import TickData
+
+
+def test_no_button_without_data_dir(app):
+    """Without a data_dir the report button is omitted entirely."""
+    tab = CoverageTab()
+    assert tab.view_report_button is None
+
+
+def test_button_present_but_disabled_without_data(app):
+    """With a data_dir the button exists but is disabled until there is coverage data."""
+    with TemporaryDirectory() as tmp:
+        tab = CoverageTab(Path(tmp))
+        assert tab.view_report_button is not None
+        assert not tab.view_report_button.isEnabled()
+
+
+def test_button_enables_only_when_coverage_data_present(app):
+    """update_tick enables the button when total_lines > 0 and disables it otherwise."""
+    with TemporaryDirectory() as tmp:
+        tab = CoverageTab(Path(tmp))
+        tab.update_tick(TickData(process_infos=[], total_lines=120, covered_lines=90))
+        assert tab.view_report_button.isEnabled()
+        tab.update_tick(TickData(process_infos=[], total_lines=0))
+        assert not tab.view_report_button.isEnabled()
+
+
+def test_view_report_generates_html_and_opens_viewer(app, monkeypatch):
+    """Clicking generates a fresh HTML report (write_report=True) then opens it."""
+    calls = {}
+
+    def _fake_calculate(identifier, data_dir, write_report):
+        calls["calc"] = (identifier, data_dir, write_report)
+        return 0.5, 50, 100
+
+    class _FakeViewer:
+        def __init__(self, data_dir):
+            calls["viewer_dir"] = data_dir
+
+        def view(self):
+            calls["viewed"] = True
+
+    monkeypatch.setattr(coverage_tab_module, "calculate_coverage", _fake_calculate)
+    monkeypatch.setattr(coverage_tab_module, "ViewCoverage", _FakeViewer)
+
+    with TemporaryDirectory() as tmp:
+        data_dir = Path(tmp)
+        tab = CoverageTab(data_dir)
+        tab._on_view_report()
+
+    assert calls["calc"][0] == "html_report"  # dedicated identifier, not the live tracker's "current"
+    assert calls["calc"][1] == data_dir
+    assert calls["calc"][2] is True  # write_report
+    assert calls["viewer_dir"] == data_dir
+    assert calls["viewed"] is True
+
+
+def test_view_report_graceful_with_no_coverage_data(app, monkeypatch):
+    """With no coverage data on disk the handler must not raise and must not open a browser."""
+    opened = []
+    monkeypatch.setattr(webbrowser, "open", lambda uri: opened.append(uri))
+    with TemporaryDirectory() as tmp:
+        tab = CoverageTab(Path(tmp))
+        tab._on_view_report()  # empty data dir -> no report produced
+    assert opened == []


### PR DESCRIPTION
## Summary

`ViewCoverage` was **orphaned** — defined and unit-tested, but never referenced by any application code, so the HTML coverage report it opens was unreachable from the UI. On top of that, the app only ever called `calculate_coverage(..., write_report=False)`, so the HTML report was never even generated.

This PR wires the feature in on the **Coverage tab**:

- `CoverageTab` now accepts an optional `data_dir`. When provided, it shows a **"View HTML Report"** button (disabled until there is coverage data, i.e. `total_lines > 0`).
- Clicking **generates a fresh HTML report on demand** (`calculate_coverage("html_report", data_dir, write_report=True)`) and then opens it via `ViewCoverage(data_dir).view()`.
- A dedicated `"html_report"` identifier is used so generation never races with the live tracker's `"current"` combined data file.
- `gui_main` passes `data_dir` into `CoverageTab`.

`data_dir` is optional, so existing chart-only widget tests (which call `CoverageTab()`) keep working unchanged.

## Tests

New `tests/test_coverage_tab_report.py` (5 tests):
- button omitted when no `data_dir`; present-but-disabled with `data_dir` and no data
- `update_tick` enables/disables the button based on `total_lines`
- the click handler calls `calculate_coverage(write_report=True)` then `ViewCoverage.view()`
- graceful no-op (no browser opened, no exception) when there is no coverage data on disk

## Verification

- Full suite: **258 passed**
- `ruff check` + `ruff format --check`: clean
- Pre-existing `ty` diagnostics only (none introduced by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)