### PR TITLE
Move Coverage tab 'View HTML Report' button to the top

### DIFF
--- a/src/pytest_fly/gui/coverage_tab/coverage_tab.py
+++ b/src/pytest_fly/gui/coverage_tab/coverage_tab.py
@@ -166,9 +166,6 @@ class CoverageTab(QGroupBox):
         layout = QVBoxLayout()
         self.setLayout(layout)
 
-        self.chart = _CoverageChart()
-        layout.addWidget(self.chart, stretch=1)
-
         self.view_report_button: QPushButton | None = None
         if data_dir is not None:
             button_row = QHBoxLayout()
@@ -179,6 +176,9 @@ class CoverageTab(QGroupBox):
             self.view_report_button.clicked.connect(self._on_view_report)
             button_row.addWidget(self.view_report_button)
             layout.addLayout(button_row)
+
+        self.chart = _CoverageChart()
+        layout.addWidget(self.chart, stretch=1)
 
     def _on_view_report(self) -> None:
         """Generate a fresh HTML coverage report from the current data and open it."""


### PR DESCRIPTION
## Summary

Moves the "View HTML Report" button on the Coverage tab from the bottom of the widget to the **top**, above the coverage chart.

Pure layout change — the button is now added to the `QVBoxLayout` before the chart instead of after it. Behavior (on-demand report generation, enable/disable based on coverage data) is unchanged.

## Verification

- Coverage-tab + GUI tests: **56 passed**
- `ruff check` + `ruff format --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)