### PR TITLE
Raise test coverage from 78% to 87% (Tier 1 + Tier 2)

### DIFF
--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,148 @@
+"""Tests for the Configuration tab preference-editing logic."""
+
+import pytest
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QFileDialog, QMessageBox
+
+from pytest_fly.gui.configuration_tab.configuration import Configuration, OrderingAspectsWidget
+from pytest_fly.interfaces import RunMode
+from pytest_fly.preferences import get_pref, init_preferences_for_put
+
+
+@pytest.fixture(autouse=True)
+def _isolated_prefs(tmp_path):
+    """Rebind preferences to a per-test tmp dir so edits never touch shared state."""
+    init_preferences_for_put(tmp_path)
+
+
+def test_update_checkbox_prefs(app):
+    cfg = Configuration()
+    cfg.verbose_checkbox.setChecked(True)
+    cfg.update_verbose()
+    assert get_pref().verbose is True
+
+    cfg.perf_logging_checkbox.setChecked(True)
+    cfg.update_perf_logging()
+    assert get_pref().perf_logging is True
+
+
+def test_update_numeric_prefs_and_clamping(app):
+    cfg = Configuration()
+
+    cfg.update_processes("4")
+    assert get_pref().processes == 4
+    cfg.update_processes("not-a-number")  # ignored
+    assert get_pref().processes == 4
+
+    cfg.update_refresh_rate("2.5")
+    assert get_pref().refresh_rate == 2.5
+    cfg.update_refresh_rate("0.1")  # clamped up to the 1.0 minimum
+    assert get_pref().refresh_rate == 1.0
+    cfg.update_refresh_rate("bad")  # ValueError swallowed
+
+    cfg.update_tooltip_line_limit("10")
+    assert get_pref().tooltip_line_limit == 10
+    cfg.update_tooltip_line_limit("0")  # clamped up to minimum 1
+    assert get_pref().tooltip_line_limit == 1
+
+    cfg.update_chart_window_minutes("3.0")
+    assert get_pref().chart_window_minutes == 3.0
+    cfg.update_chart_window_minutes("bad")  # ValueError swallowed
+
+    cfg.update_graph_font_size("12")
+    assert get_pref().graph_font_size == 12
+    cfg.update_graph_font_size("bad")  # not numeric -> ignored
+
+
+def test_update_utilization_thresholds_warns(app, caplog):
+    cfg = Configuration()
+    cfg.update_utilization_high_threshold("0.8")
+    assert get_pref().utilization_high_threshold == 0.8
+    # low > high should log a warning via _validate_utilization_thresholds
+    cfg.update_utilization_low_threshold("0.95")
+    assert get_pref().utilization_low_threshold == 0.95
+    cfg.update_utilization_high_threshold("bad")  # ValueError swallowed
+    cfg.update_utilization_low_threshold("bad")  # ValueError swallowed
+
+
+def test_update_resume_skip_put_check(app):
+    cfg = Configuration()
+    get_pref().run_mode = RunMode.CHECK
+    cfg.resume_skip_put_check_checkbox.setChecked(True)
+    cfg.update_resume_skip_put_check()
+    assert get_pref().resume_skip_put_check is True
+    assert get_pref().run_mode == RunMode.RESUME
+
+    cfg.resume_skip_put_check_checkbox.setChecked(False)
+    cfg.update_resume_skip_put_check()
+    assert get_pref().run_mode == RunMode.CHECK
+
+
+def test_resume_reconciliation_on_construction(app):
+    """Existing RESUME users get resume_skip_put_check auto-enabled when the tab builds."""
+    pref = get_pref()
+    pref.run_mode = RunMode.RESUME
+    pref.resume_skip_put_check = False
+    Configuration()
+    assert get_pref().resume_skip_put_check is True
+
+
+def test_test_results_db_dir_update(app):
+    cfg = Configuration()
+    cfg.update_test_results_db_dir("  /some/dir  ")
+    assert get_pref().test_results_db_dir == "/some/dir"
+
+
+def test_commit_target_project_path(app, tmp_path, monkeypatch):
+    """A changed target path is persisted and surfaces the restart label."""
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
+    written = {}
+    monkeypatch.setattr("pytest_fly.gui.configuration_tab.configuration.write_last_target", lambda p: written.setdefault("path", p))
+
+    cfg = Configuration()
+    new_dir = tmp_path / "new_target"
+    new_dir.mkdir()
+    cfg.target_project_path_lineedit.setText(str(new_dir))
+    cfg._commit_target_project_path()
+
+    assert written["path"] == new_dir.resolve()
+    # isVisible() is False while the parent window is unshown; isHidden() reflects the explicit setVisible(True).
+    assert not cfg.target_project_path_restart_label.isHidden()
+
+
+def test_commit_target_project_path_empty_restores(app):
+    """Empty input restores the active PUT path and persists nothing."""
+    cfg = Configuration()
+    cfg.target_project_path_lineedit.setText("   ")
+    cfg._commit_target_project_path()
+    assert cfg.target_project_path_lineedit.text() == cfg._active_put_path
+
+
+def test_browse_dialogs(app, tmp_path, monkeypatch):
+    """The Browse buttons feed the picked directory into the line edits."""
+    picked = str(tmp_path / "picked")
+    (tmp_path / "picked").mkdir()
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *a, **k: picked)
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
+
+    cfg = Configuration()
+    cfg._browse_test_results_db_dir()
+    assert cfg.test_results_db_dir_lineedit.text() == picked
+
+    cfg._browse_target_project_path()
+    assert cfg.target_project_path_lineedit.text() == picked
+
+
+def test_ordering_widget_move_and_toggle(app):
+    """Up/Down reorder and checkbox toggles flow through the ordering widget."""
+    widget = OrderingAspectsWidget()
+    widget._list.setCurrentRow(1)
+    widget._move_selected(-1)  # up
+    widget._move_selected(1)  # down
+    widget._move_selected(-99)  # out of range -> no-op
+    widget._list.setCurrentRow(-1)
+    widget._move_selected(-1)  # no selection -> no-op
+
+    # Toggling a checkbox triggers _on_item_changed -> reorder + persist.
+    widget._list.item(0).setCheckState(Qt.CheckState.Unchecked)
+    widget._list.item(widget._list.count() - 1).setCheckState(Qt.CheckState.Checked)

--- a/tests/test_control_window.py
+++ b/tests/test_control_window.py
@@ -1,0 +1,57 @@
+"""Tests for ControlWindow button-state and stop wiring (excludes the subprocess-spawning run())."""
+
+from pytest_fly.gui.run_tab.control_window import ControlWindow
+
+from .paths import get_temp_dir
+
+
+class _FakeRunner:
+    """Minimal stand-in for PytestRunner exposing the methods ControlWindow calls."""
+
+    def __init__(self):
+        self.soft_stopped = False
+        self.stopped = False
+        self._running = True
+
+    def is_running(self):
+        return self._running
+
+    def soft_stop(self):
+        self.soft_stopped = True
+
+    def stop(self):
+        self.stopped = True
+
+
+def test_refresh_button_state_no_runner(app):
+    """With no runner, Run is enabled and the stop buttons are disabled."""
+    cw = ControlWindow(None, get_temp_dir("control_none"))
+    cw.refresh_button_state()
+    assert cw.run_button.isEnabled()
+    assert not cw.stop_button.isEnabled()
+    assert not cw.force_stop_button.isEnabled()
+
+
+def test_button_states_running_and_stops(app):
+    """Running -> stop/force enabled; soft_stop and force_stop drive the runner and button states."""
+    cw = ControlWindow(None, get_temp_dir("control_run"))
+    runner = _FakeRunner()
+    cw.pytest_runner = runner
+
+    cw.refresh_button_state()  # running, not soft-stopped
+    assert not cw.run_button.isEnabled()
+    assert cw.stop_button.isEnabled()
+    assert cw.force_stop_button.isEnabled()
+
+    cw.soft_stop()
+    assert runner.soft_stopped is True
+    assert cw._soft_stop_requested is True
+
+    cw.refresh_button_state()  # soft-stop-requested branch
+    assert not cw.stop_button.isEnabled()
+    assert cw.force_stop_button.isEnabled()
+
+    cw.force_stop()
+    assert runner.stopped is True
+    assert cw.run_button.isEnabled()
+    assert cw.run_guid is None

--- a/tests/test_coverage_extra.py
+++ b/tests/test_coverage_extra.py
@@ -1,0 +1,29 @@
+"""Additional coverage for per-test coverage edge cases in :mod:`pytest_fly.pytest_runner.coverage`.
+
+Uses the ``tmp_path`` fixture rather than ``TemporaryDirectory`` because the coverage
+library can keep a handle on a (corrupt) ``.coverage`` file briefly, which would make an
+eager context-manager cleanup fail on Windows; pytest's fixture teardown tolerates that.
+"""
+
+from pytest_fly.file_util import sanitize_test_name
+from pytest_fly.pytest_runner.coverage import compute_per_test_coverage
+
+
+def test_compute_per_test_coverage_missing_dir(tmp_path):
+    """No coverage directory -> empty mapping."""
+    assert compute_per_test_coverage(tmp_path, ["tests/test_a.py"]) == {}
+
+
+def test_compute_per_test_coverage_no_matching_files(tmp_path):
+    """Coverage dir exists but no per-test files match -> empty mapping (total lines == 0)."""
+    (tmp_path / "coverage").mkdir()
+    assert compute_per_test_coverage(tmp_path, ["tests/test_a.py"]) == {}
+
+
+def test_compute_per_test_coverage_corrupt_file_is_skipped(tmp_path):
+    """A corrupt .coverage file is skipped (load error swallowed) and yields no entry."""
+    cov_dir = tmp_path / "coverage"
+    cov_dir.mkdir()
+    bad = cov_dir / f"{sanitize_test_name('tests/test_a.py')}.coverage"
+    bad.write_text("this is not a coverage sqlite db")
+    assert compute_per_test_coverage(tmp_path, ["tests/test_a.py"]) == {}

--- a/tests/test_db_extra.py
+++ b/tests/test_db_extra.py
@@ -1,0 +1,63 @@
+"""Additional coverage for :class:`pytest_fly.db.PytestProcessInfoDB`."""
+
+import sqlite3
+import time
+
+from pytest_fly.__version__ import application_name
+from pytest_fly.db import PytestProcessInfoDB
+from pytest_fly.guid import generate_uuid
+from pytest_fly.interfaces import PyTestFlyExitCode, PytestProcessInfo
+
+from .paths import get_temp_dir
+
+
+def _info(guid, name, pid, exit_code, ts):
+    return PytestProcessInfo(run_guid=guid, name=name, pid=pid, exit_code=exit_code, output=None, time_stamp=ts)
+
+
+def test_query_ever_run_names_excludes_unstarted():
+    """query_ever_run_names returns started tests (pid set) and excludes queued-only ones."""
+    db_dir = get_temp_dir("test_ever_run_names")
+    guid = generate_uuid()
+    now = time.time()
+    with PytestProcessInfoDB(db_dir) as db:
+        db.write(_info(guid, "test_started", 100, PyTestFlyExitCode.OK, now))
+        db.write(_info(guid, "test_queued_only", None, PyTestFlyExitCode.NONE, now))
+        names = db.query_ever_run_names()
+    assert "test_started" in names
+    assert "test_queued_only" not in names
+
+
+def test_delete_all_drops_table():
+    """delete() with no guid drops the table; subsequent queries degrade gracefully to empty."""
+    db_dir = get_temp_dir("test_delete_all")
+    guid = generate_uuid()
+    now = time.time()
+    with PytestProcessInfoDB(db_dir) as db:
+        db.write(_info(guid, "test_a", 1, PyTestFlyExitCode.OK, now))
+        db.delete()  # None -> DROP TABLE
+        # The table is gone; query_ever_run_names catches the OperationalError and returns empty.
+        assert db.query_ever_run_names() == set()
+        assert db.query_last_pass() == {}
+
+
+def test_schema_change_drops_and_recreates(tmp_path):
+    """An on-disk table with a stale schema is dropped and recreated on open."""
+    db_path = tmp_path / f"{application_name}.db"
+    # Seed a table whose columns don't match the current dataclass-derived schema.
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("CREATE TABLE pytest_process_info (obsolete_column TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Ensure the one-shot init guard doesn't skip the schema check for this path.
+    PytestProcessInfoDB._initialized_paths.discard(db_path)
+
+    guid = generate_uuid()
+    with PytestProcessInfoDB(tmp_path) as db:
+        db.write(_info(guid, "test_a", 1, PyTestFlyExitCode.OK, time.time()))
+        rows = db.query(guid)
+    assert len(rows) == 1
+    assert rows[0].name == "test_a"

--- a/tests/test_main_app.py
+++ b/tests/test_main_app.py
@@ -1,0 +1,69 @@
+"""Tests for the application bootstrap in :mod:`pytest_fly.main`."""
+
+from pathlib import Path
+
+from pytest_fly import main as main_module
+from pytest_fly.main import _parse_args, app_main
+
+
+def test_parse_args_defaults():
+    """No CLI args -> all options fall back to their defaults."""
+    args = _parse_args([])
+    assert args.target is None
+    assert args.data_dir is None
+    assert args.auto_start is False
+    assert args.auto_quit_on_done is False
+
+
+def test_parse_args_all_options():
+    """Every option is parsed into the namespace."""
+    args = _parse_args(["--target", "proj", "--data-dir", "results", "--auto-start", "--auto-quit-on-done"])
+    assert Path(args.target) == Path("proj")
+    assert Path(args.data_dir) == Path("results")
+    assert args.auto_start is True
+    assert args.auto_quit_on_done is True
+
+
+def test_app_main_resolves_target_and_launches(tmp_path, monkeypatch):
+    """app_main wires the resolved PUT/data dirs into fly_main and creates the data dir."""
+    captured = {}
+
+    def fake_fly_main(data_dir, *, auto_start=False, auto_quit_on_done=False):
+        captured["data_dir"] = data_dir
+        captured["auto_start"] = auto_start
+        captured["auto_quit_on_done"] = auto_quit_on_done
+
+    # Stub out the blocking GUI launch and the global-logging reconfig / last-target side effect.
+    monkeypatch.setattr(main_module, "fly_main", fake_fly_main)
+    monkeypatch.setattr(main_module, "init_parent_logger", lambda verbose: None)
+    monkeypatch.setattr(main_module, "write_last_target", lambda target: None)
+
+    target = tmp_path / "put"
+    target.mkdir()
+    data_dir = tmp_path / "results"
+
+    app_main(["--target", str(target), "--data-dir", str(data_dir), "--auto-start"])
+
+    assert captured["data_dir"] == data_dir.resolve()
+    assert captured["auto_start"] is True
+    assert captured["auto_quit_on_done"] is False
+    assert data_dir.exists()  # app_main creates the data dir
+
+
+def test_app_main_uses_saved_target_when_no_arg(tmp_path, monkeypatch):
+    """With no --target, app_main falls back to the persisted last-target path."""
+    captured = {}
+    saved_target = tmp_path / "saved_put"
+    saved_target.mkdir()
+
+    monkeypatch.setattr(main_module, "fly_main", lambda data_dir, **kw: captured.setdefault("data_dir", data_dir))
+    monkeypatch.setattr(main_module, "init_parent_logger", lambda verbose: None)
+    monkeypatch.setattr(main_module, "write_last_target", lambda target: captured.setdefault("written", target))
+    monkeypatch.setattr(main_module, "read_last_target", lambda: saved_target)
+
+    data_dir = tmp_path / "results2"
+    app_main(["--data-dir", str(data_dir)])
+
+    # The saved target was resolved and persisted again.
+    assert captured["written"].resolve() == saved_target.resolve()
+    assert captured["data_dir"] == data_dir.resolve()

--- a/tests/test_paths_extra.py
+++ b/tests/test_paths_extra.py
@@ -1,0 +1,36 @@
+"""Tests for last-target persistence in :mod:`pytest_fly.paths`."""
+
+import pytest_fly.paths as paths_module
+from pytest_fly.paths import _last_target_file, read_last_target, write_last_target
+
+
+def test_last_target_file_name():
+    """The real config path ends with the expected file name."""
+    assert _last_target_file().name == "last_target.txt"
+
+
+def test_read_last_target_missing(tmp_path, monkeypatch):
+    """No file on disk -> None."""
+    monkeypatch.setattr(paths_module, "_last_target_file", lambda: tmp_path / "last_target.txt")
+    assert read_last_target() is None
+
+
+def test_read_last_target_empty_file(tmp_path, monkeypatch):
+    """A whitespace-only file -> None."""
+    target_file = tmp_path / "last_target.txt"
+    target_file.write_text("   \n", encoding="utf-8")
+    monkeypatch.setattr(paths_module, "_last_target_file", lambda: target_file)
+    assert read_last_target() is None
+
+
+def test_write_then_read_last_target(tmp_path, monkeypatch):
+    """write_last_target persists a resolved path that read_last_target returns."""
+    target_file = tmp_path / "cfg" / "last_target.txt"  # parent dir does not exist yet
+    monkeypatch.setattr(paths_module, "_last_target_file", lambda: target_file)
+
+    put = tmp_path / "my_put"
+    put.mkdir()
+    write_last_target(put)
+
+    assert target_file.is_file()
+    assert read_last_target() == put.resolve()

--- a/tests/test_platform_info_extra.py
+++ b/tests/test_platform_info_extra.py
@@ -1,0 +1,23 @@
+"""Additional coverage for :mod:`pytest_fly.platform.platform_info`."""
+
+from pytest_fly.platform.platform_info import (
+    get_efficiency_core_count,
+    get_performance_core_count,
+    get_platform_info,
+)
+
+
+def test_get_platform_info_with_details():
+    """details=True adds the extended CPU fields without error."""
+    info = get_platform_info(details=True)
+    assert info["computer_name"]
+    assert info["cpu_count_logical"] >= 1
+    assert "memory_total" in info
+
+
+def test_core_counts_are_consistent():
+    """Performance + efficiency cores never exceed the logical thread count and are non-negative."""
+    p = get_performance_core_count()
+    e = get_efficiency_core_count()
+    assert p >= 1
+    assert e >= 0

--- a/tests/test_platform_os_extra.py
+++ b/tests/test_platform_os_extra.py
@@ -1,0 +1,89 @@
+"""Additional coverage for cross-platform helpers in :mod:`pytest_fly.platform.os`.
+
+Several helpers branch on :func:`is_windows`.  Since CI runs on Linux and the
+Windows branches would otherwise never execute there (and vice versa), the
+permission tests force both branches via monkeypatch so coverage is platform-independent.
+"""
+
+import pytest
+
+import pytest_fly.platform.os as os_module
+from pytest_fly.platform.os import (
+    is_file_locked,
+    is_read_only,
+    is_read_write,
+    mk_dirs,
+    remove_readonly_onerror,
+    rm_file,
+    set_read_only,
+    set_read_write,
+)
+
+
+@pytest.mark.parametrize("force_windows", [True, False])
+def test_read_only_read_write_roundtrip(tmp_path, monkeypatch, force_windows):
+    """set/is read-only and read-write round-trip under both the Windows and POSIX branches."""
+    monkeypatch.setattr(os_module, "is_windows", lambda: force_windows)
+    f = tmp_path / "perm.txt"
+    f.write_text("data")
+
+    set_read_only(f)
+    assert is_read_only(f)
+
+    set_read_write(f)
+    assert is_read_write(f)
+
+    # leave it writable so the tmp dir can be cleaned up
+    set_read_write(f)
+
+
+def test_is_file_locked_false_for_normal_file(tmp_path):
+    """A normal, closed file is not reported as locked."""
+    f = tmp_path / "f.txt"
+    f.write_text("x")
+    assert is_file_locked(f) is False
+
+
+def test_is_file_locked_false_for_missing_file(tmp_path):
+    """A non-existent file is not locked."""
+    assert is_file_locked(tmp_path / "missing.txt") is False
+
+
+def test_rm_file_removes_file(tmp_path):
+    """rm_file deletes the file and returns True."""
+    f = tmp_path / "x.txt"
+    f.write_text("x")
+    assert rm_file(f) is True
+    assert not f.exists()
+
+
+def test_rm_file_on_missing_is_success(tmp_path):
+    """Removing an already-absent file succeeds (nothing to do)."""
+    assert rm_file(tmp_path / "gone.txt") is True
+
+
+def test_remove_readonly_onerror_clears_flag_and_retries(tmp_path):
+    """The rmtree onerror callback strips read-only then re-invokes the failed op."""
+    f = tmp_path / "ro.txt"
+    f.write_text("x")
+    set_read_write(f)
+    retried = []
+    remove_readonly_onerror(lambda p: retried.append(p), str(f), None)
+    assert retried == [str(f)]
+
+
+def test_mk_dirs_creates_nested(tmp_path):
+    """mk_dirs creates a nested directory tree."""
+    d = tmp_path / "a" / "b" / "c"
+    mk_dirs(d)
+    assert d.is_dir()
+
+
+def test_mk_dirs_remove_first(tmp_path):
+    """mk_dirs(remove_first=True) clears existing contents first."""
+    d = tmp_path / "d"
+    d.mkdir()
+    (d / "old.txt").write_text("stale")
+    mk_dirs(d, remove_first=True)
+    assert d.is_dir()
+    assert not (d / "old.txt").exists()

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -1,0 +1,76 @@
+"""Paint and interaction coverage for the Graph-tab PytestProgressBar."""
+
+import time
+
+from PySide6.QtCore import QEvent, QPointF, Qt
+from PySide6.QtGui import QMouseEvent
+
+from pytest_fly.gui.graph_tab.progress_bar import PytestProgressBar
+from pytest_fly.interfaces import PyTestFlyExitCode, PytestProcessInfo
+from pytest_fly.pytest_runner.pytest_runner import PytestRunState
+
+
+def _info(name, pid, exit_code, ts, output=None):
+    return PytestProcessInfo(run_guid="g", name=name, pid=pid, exit_code=exit_code, output=output, time_stamp=ts)
+
+
+def test_progress_bar_paints_running(app):
+    """A running bar paints a filled rectangle up to 'now'."""
+    now = time.time()
+    infos = [_info("tests/test_a.py", None, PyTestFlyExitCode.NONE, now - 10), _info("tests/test_a.py", 1, PyTestFlyExitCode.NONE, now - 9)]
+    bar = PytestProgressBar(infos, now - 10, now, PytestRunState(infos))
+    bar.resize(400, 20)
+    bar.grab()
+    assert bar._last_bar_rect is not None  # a bar was drawn
+
+
+def test_progress_bar_paints_completed_singleton(app):
+    """A completed singleton bar paints and labels itself accordingly."""
+    now = time.time()
+    infos = [
+        _info("tests/test_b.py", None, PyTestFlyExitCode.NONE, now - 10),
+        _info("tests/test_b.py", 1, PyTestFlyExitCode.NONE, now - 9),
+        _info("tests/test_b.py", 1, PyTestFlyExitCode.OK, now - 5, output="1 passed"),
+    ]
+    bar = PytestProgressBar(infos, now - 10, now, PytestRunState(infos), is_singleton=True)
+    bar.resize(400, 20)
+    bar.grab()
+
+
+def test_progress_bar_empty_paints_nothing(app):
+    """An empty status list paints via the base class and keeps no bar rect."""
+    now = time.time()
+    bar = PytestProgressBar([], now - 10, now, PytestRunState([]))
+    bar.resize(400, 20)
+    bar.grab()
+    assert bar._last_bar_rect is None
+
+
+def test_progress_bar_mouse_move_shows_and_hides_tooltip(app):
+    """Moving over the drawn bar shows a tooltip; moving outside hides it."""
+    now = time.time()
+    infos = [
+        _info("tests/test_c.py", None, PyTestFlyExitCode.NONE, now - 10),
+        _info("tests/test_c.py", 1, PyTestFlyExitCode.NONE, now - 9),
+        _info("tests/test_c.py", 1, PyTestFlyExitCode.OK, now - 5, output="captured output line"),
+    ]
+    bar = PytestProgressBar(infos, now - 10, now, PytestRunState(infos))
+    bar.resize(400, 20)
+    bar.grab()
+    assert bar._last_bar_rect is not None
+
+    center = bar._last_bar_rect.center()
+    over = QMouseEvent(QEvent.Type.MouseMove, QPointF(center), QPointF(center), Qt.MouseButton.NoButton, Qt.MouseButton.NoButton, Qt.KeyboardModifier.NoModifier)
+    bar.mouseMoveEvent(over)  # inside the bar -> showText branch
+
+    outside = QPointF(bar._last_bar_rect.right() + 50, bar._last_bar_rect.bottom() + 50)
+    away = QMouseEvent(QEvent.Type.MouseMove, outside, outside, Qt.MouseButton.NoButton, Qt.MouseButton.NoButton, Qt.KeyboardModifier.NoModifier)
+    bar.mouseMoveEvent(away)  # outside -> hideText branch
+
+
+def test_progress_bar_leave_event(app):
+    """leaveEvent hides any visible tooltip without error."""
+    now = time.time()
+    infos = [_info("tests/test_d.py", 1, PyTestFlyExitCode.OK, now, output="x")]
+    bar = PytestProgressBar(infos, now - 10, now, PytestRunState(infos))
+    bar.leaveEvent(QEvent(QEvent.Type.Leave))

--- a/tests/test_project_info.py
+++ b/tests/test_project_info.py
@@ -81,6 +81,30 @@ def test_from_installed_metadata_parses_fields(monkeypatch):
     assert info.repository_url == "https://example.com/repo"
 
 
+def test_from_installed_metadata_home_page_fallback(monkeypatch):
+    """When only a Home-page scalar is present, it fills home_url and then repository_url."""
+    fake = _FakeMeta(
+        scalars={"Name": "pkg", "Version": "1.0", "Author": "A", "Home-page": "https://example.com/hp"},
+        multi={},
+    )
+    monkeypatch.setattr(project_info.metadata, "metadata", lambda _name: fake)
+    info = _from_installed_metadata()
+    assert info.home_url == "https://example.com/hp"
+    assert info.repository_url == "https://example.com/hp"  # cross-filled from home
+
+
+def test_from_installed_metadata_repository_only_fills_home(monkeypatch):
+    """When only a Repository URL is present, home_url is cross-filled from it."""
+    fake = _FakeMeta(
+        scalars={"Name": "pkg", "Version": "1.0", "Author": "A"},
+        multi={"Project-URL": ["Repository, https://example.com/repo"]},
+    )
+    monkeypatch.setattr(project_info.metadata, "metadata", lambda _name: fake)
+    info = _from_installed_metadata()
+    assert info.repository_url == "https://example.com/repo"
+    assert info.home_url == "https://example.com/repo"  # cross-filled from repository
+
+
 def test_get_project_info_falls_back_to_installed_metadata(monkeypatch):
     """When pyproject yields no usable version, get_project_info uses installed metadata."""
     monkeypatch.setattr(project_info, "_from_pyproject", lambda: None)

--- a/tests/test_put_version_extra.py
+++ b/tests/test_put_version_extra.py
@@ -1,0 +1,47 @@
+"""Additional coverage for the metadata-parsing branches of :mod:`pytest_fly.put_version`."""
+
+from pytest_fly.put_version import detect_put_version
+
+
+def _write(tmp_path, name, body):
+    (tmp_path / name).write_text(body, encoding="utf-8")
+
+
+def test_pyproject_malformed_toml(tmp_path):
+    """A pyproject that won't parse leaves name/version unset (parse error swallowed)."""
+    _write(tmp_path, "pyproject.toml", "this is not = valid = toml ===\n[[[")
+    info = detect_put_version(tmp_path)
+    assert info.name is None
+    assert info.version is None
+
+
+def test_pyproject_non_string_name_is_dropped(tmp_path):
+    """A non-string name is coerced to None while a valid version is still read."""
+    _write(tmp_path, "pyproject.toml", '[project]\nname = 123\nversion = "1.0"\n')
+    info = detect_put_version(tmp_path)
+    assert info.name is None
+    assert info.version == "1.0"
+    assert info.source == "pyproject"
+
+
+def test_pyproject_author_extracted(tmp_path):
+    """The first author with a name is captured."""
+    _write(tmp_path, "pyproject.toml", '[project]\nname = "w"\nversion = "1.0"\nauthors = [{name = "Jane Doe"}]\n')
+    info = detect_put_version(tmp_path)
+    assert info.author == "Jane Doe"
+
+
+def test_setup_cfg_malformed(tmp_path):
+    """A setup.cfg with no section header fails to parse and yields no metadata."""
+    _write(tmp_path, "setup.cfg", "name = orphan\nversion = 1.0\n")  # missing [section] header
+    info = detect_put_version(tmp_path)
+    assert info.name is None
+    assert info.version is None
+
+
+def test_setup_cfg_without_metadata_section(tmp_path):
+    """A valid setup.cfg lacking a [metadata] section yields no name/version."""
+    _write(tmp_path, "setup.cfg", "[options]\npackages = find:\n")
+    info = detect_put_version(tmp_path)
+    assert info.name is None
+    assert info.version is None

--- a/tests/test_status_window.py
+++ b/tests/test_status_window.py
@@ -1,0 +1,87 @@
+"""Tests for the run-tab StatusWindow aggregate-summary logic."""
+
+import time
+
+from pytest_fly.gui.gui_main import build_tick_data
+from pytest_fly.gui.run_tab.status_window import StatusWindow
+from pytest_fly.interfaces import PutVersionInfo, PyTestFlyExitCode, PytestProcessInfo
+
+
+def _info(name, pid, exit_code, ts):
+    return PytestProcessInfo(run_guid="g", name=name, pid=pid, exit_code=exit_code, output=None, time_stamp=ts)
+
+
+def _put(dirty=False):
+    return PutVersionInfo(name="pkg", version="1.0", source="pyproject", git_describe=None, git_sha="abc1234", git_branch="main", git_dirty=dirty, project_root="/x")
+
+
+def test_status_window_complete_all_pass(app):
+    """An all-passing completed run turns the pass-rate label green."""
+    window = StatusWindow(None)
+    tick = build_tick_data([_info("test_p.py", 1, PyTestFlyExitCode.OK, time.time())])
+    window.update_tick(tick)
+    assert "green" in window.pass_rate_label.styleSheet()
+
+
+def test_status_window_complete_with_failure(app):
+    """A completed run with a failure turns the pass-rate label red."""
+    now = time.time()
+    infos = [_info("test_p.py", 1, PyTestFlyExitCode.OK, now), _info("test_f.py", 2, PyTestFlyExitCode.TESTS_FAILED, now)]
+    window = StatusWindow(None)
+    window.update_tick(build_tick_data(infos))
+    assert "red" in window.pass_rate_label.styleSheet()
+
+
+def test_status_window_running_calculating_pass_rate(app):
+    """While a test is running with no completions, pass rate shows '(calculating...)'."""
+    window = StatusWindow(None)
+    tick = build_tick_data([_info("test_a.py", 1, PyTestFlyExitCode.NONE, time.time())])
+    window.update_tick(tick)
+    assert "calculating" in window.pass_rate_label.text()
+
+
+def test_status_window_rich_tick_with_soft_stop(app):
+    """A rich tick exercises PUT line, coverage, parallelism, ETA, and soft-stop messaging."""
+    now = time.time()
+    infos = [
+        _info("test_run.py", None, PyTestFlyExitCode.NONE, now - 3),
+        _info("test_run.py", 1, PyTestFlyExitCode.NONE, now - 2),  # running
+        _info("test_q.py", None, PyTestFlyExitCode.NONE, now),  # queued
+        _info("test_p.py", 2, PyTestFlyExitCode.OK, now - 1),  # passed
+    ]
+    tick = build_tick_data(infos)
+    tick.put_version_info = _put(dirty=True)
+    tick.prior_durations = {"test_run.py": 10.0, "test_q.py": 5.0}
+    tick.soft_stop_requested = True
+    tick.num_processes = 2
+    tick.average_parallelism = 1.5
+    tick.coverage_history = [(now - 5, 0.5)]
+    tick.total_lines = 100
+    tick.covered_lines = 50
+    tick.min_time_stamp_started = now - 5
+    tick.max_time_stamp_started = now
+
+    window = StatusWindow(None)
+    window.update_tick(tick)
+    text = window.status_widget.toPlainText()
+
+    assert "PUT: pkg 1.0" in text
+    assert "uncommitted changes" in text
+    assert "Coverage: 50.0%" in text
+    assert "Avg parallelism: 1.5x" in text
+    assert "Total time:" in text
+    assert "Estimated remaining:" in text
+    assert "Stopping" in text
+    assert "Estimated finish:" in text
+
+
+def test_status_window_empty_with_put_info(app):
+    """The no-tests-yet branch still renders the PUT line."""
+    tick = build_tick_data([])
+    tick.put_version_info = _put(dirty=True)
+    window = StatusWindow(None)
+    window.update_tick(tick)
+    text = window.status_widget.toPlainText()
+    assert "PUT: pkg" in text
+    assert "uncommitted changes" in text
+    assert "press Run" in text

--- a/tests/test_table_tab.py
+++ b/tests/test_table_tab.py
@@ -1,0 +1,211 @@
+"""Tests for the per-test TableTab grid logic."""
+
+import time
+
+from PySide6.QtGui import QColor
+
+from pytest_fly.gui.gui_main import build_tick_data
+from pytest_fly.gui.table_tab.table_tab import Columns, TableTab, _SortableItem, set_utilization_color
+from pytest_fly.interfaces import PyTestFlyExitCode, PytestProcessInfo
+from pytest_fly.pytest_runner.live_output import live_output_path
+
+from .paths import get_temp_dir
+
+
+def _info(name, pid, exit_code, ts, cpu=None, mem=None, output=None):
+    return PytestProcessInfo(run_guid="g", name=name, pid=pid, exit_code=exit_code, output=output, time_stamp=ts, cpu_percent=cpu, memory_percent=mem)
+
+
+def _completed_tick():
+    now = time.time()
+    infos = [
+        _info("tests/test_a.py", None, PyTestFlyExitCode.NONE, now - 10),
+        _info("tests/test_a.py", 1, PyTestFlyExitCode.NONE, now - 9),
+        _info("tests/test_a.py", 1, PyTestFlyExitCode.OK, now - 5, cpu=150.0, mem=2.5, output="1 passed"),
+        _info("tests/test_b.py", None, PyTestFlyExitCode.NONE, now - 10),
+        _info("tests/test_b.py", 2, PyTestFlyExitCode.TESTS_FAILED, now - 4, cpu=80.0, mem=1.0, output="1 failed"),
+    ]
+    return build_tick_data(infos)
+
+
+# ---------------------------------------------------------------------------
+# pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_set_utilization_color_thresholds(app):
+    """Cell color is red above high, yellow above low, default otherwise."""
+    from PySide6.QtWidgets import QTableWidgetItem
+
+    item = QTableWidgetItem()
+    set_utilization_color(item, 0.95, 0.8, 0.5)
+    assert item.foreground().color() == QColor("red")
+    set_utilization_color(item, 0.6, 0.8, 0.5)
+    assert item.foreground().color() == QColor("yellow")
+    set_utilization_color(item, 0.1, 0.8, 0.5)  # default brush, no crash
+    assert item.foreground().color() != QColor("red")
+
+
+def test_sortable_item_numeric_and_text(app):
+    """_SortableItem compares by numeric key when both present, else by text."""
+    from pytest_fly.gui.table_tab.table_tab import _SORT_KEY_ROLE
+
+    a = _SortableItem()
+    b = _SortableItem()
+    a.setData(_SORT_KEY_ROLE, 1.0)
+    b.setData(_SORT_KEY_ROLE, 2.0)
+    assert a < b  # numeric
+
+    c = _SortableItem()
+    c.setText("alpha")
+    d = _SortableItem()
+    d.setText("beta")
+    assert c < d  # text fallback (no numeric keys)
+
+    assert c.__lt__("not an item") is NotImplemented
+
+
+# ---------------------------------------------------------------------------
+# update_tick / row lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_table_tab_populates_rows(app):
+    """update_tick fills a row per test with state and resource columns."""
+    table = TableTab(get_temp_dir("table_populate"))
+    table.update_tick(_completed_tick())
+    assert table.table_widget.rowCount() == 2
+    states = {table.table_widget.item(r, Columns.STATE.value).text() for r in range(2)}
+    assert "Pass" in states
+    assert "Fail" in states
+
+
+def test_table_tab_running_reads_live_output(app):
+    """A running test pulls its tooltip from the live-output file on disk."""
+    data_dir = get_temp_dir("table_live")
+    name = "tests/test_run.py"
+    path = live_output_path(data_dir, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("live tail line\n")
+
+    now = time.time()
+    infos = [_info(name, None, PyTestFlyExitCode.NONE, now - 2), _info(name, 1, PyTestFlyExitCode.NONE, now - 1)]
+    table = TableTab(data_dir)
+    table.update_tick(build_tick_data(infos))
+    state_item = table.table_widget.item(0, Columns.STATE.value)
+    assert "live tail line" in state_item.toolTip()
+
+
+def test_table_tab_singleton_name(app):
+    """A singleton test gets a '(singleton)' suffix in the name column."""
+    now = time.time()
+    infos = [_info("tests/test_s.py", 1, PyTestFlyExitCode.OK, now, output="ok")]
+    tick = build_tick_data(infos)
+    tick.singleton_names = {"tests/test_s.py"}
+    table = TableTab(get_temp_dir("table_singleton"))
+    table.update_tick(tick)
+    assert "(singleton)" in table.table_widget.item(0, Columns.NAME.value).text()
+
+
+def test_table_tab_per_test_coverage_and_last_pass(app):
+    """Coverage and last-pass columns are populated from tick data."""
+    tick = _completed_tick()
+    tick.per_test_coverage = {"tests/test_a.py": 0.42}
+    tick.last_pass_data = {"tests/test_a.py": (time.time() - 100, 4.0)}
+    table = TableTab(get_temp_dir("table_cov"))
+    table.update_tick(tick)
+    table._rebuild_row_by_name()
+    row = table._row_by_name["tests/test_a.py"]
+    assert "42.0%" in table.table_widget.item(row, Columns.COVERAGE.value).text()
+    assert table.table_widget.item(row, Columns.LAST_PASS_DURATION.value).text() != ""
+
+
+def test_table_tab_reset_clears_rows(app):
+    """reset clears all rows and the name->row index."""
+    table = TableTab(get_temp_dir("table_reset"))
+    table.update_tick(_completed_tick())
+    assert table.table_widget.rowCount() > 0
+    table.reset()
+    assert table.table_widget.rowCount() == 0
+    assert table._row_by_name == {}
+
+
+def test_table_tab_rebuild_when_tests_shrink(app):
+    """When the known test set is no longer a subset, the table rebuilds."""
+    table = TableTab(get_temp_dir("table_shrink"))
+    table.update_tick(_completed_tick())  # test_a, test_b
+    now = time.time()
+    smaller = build_tick_data([_info("tests/test_c.py", 1, PyTestFlyExitCode.OK, now, output="ok")])
+    table.update_tick(smaller)  # different set -> rebuild
+    names = {table.table_widget.item(r, Columns.NAME.value).data(0x0100) for r in range(table.table_widget.rowCount())}  # UserRole
+    assert "tests/test_c.py" in {n for n in names if n}
+
+
+def test_table_tab_sorting(app):
+    """Activating a sort column sorts rows and survives subsequent ticks."""
+    table = TableTab(get_temp_dir("table_sort"))
+    table.update_tick(_completed_tick())
+    table._on_header_double_clicked(Columns.NAME.value)  # ascending
+    table._on_header_double_clicked(Columns.NAME.value)  # toggle to descending
+    table.update_tick(_completed_tick())  # re-sort path
+    assert table._sort_column == Columns.NAME.value
+
+
+def test_table_tab_copy_selected_text(app):
+    """copy_selected_text places the selected cells on the clipboard."""
+    from PySide6.QtGui import QGuiApplication
+
+    table = TableTab(get_temp_dir("table_copy"))
+    table.update_tick(_completed_tick())
+    table.table_widget.selectAll()
+    table.copy_selected_text()
+    assert QGuiApplication.clipboard().text() != ""
+
+
+def _menu_exec_returning(action_text):
+    """Return a QMenu.exec_ replacement that selects the action with the given text."""
+
+    def _fake_exec(self, *args, **kwargs):
+        for action in self.actions():
+            if action.text() == action_text:
+                return action
+        return None
+
+    return _fake_exec
+
+
+def test_table_tab_context_menu_copies_output(app, monkeypatch):
+    """The 'Copy Pytest Output' menu entry copies a test's full output to the clipboard."""
+    from PySide6.QtCore import QPoint
+    from PySide6.QtGui import QGuiApplication
+    from PySide6.QtWidgets import QMenu
+
+    table = TableTab(get_temp_dir("table_menu_copy"))
+    table.update_tick(_completed_tick())
+    QGuiApplication.clipboard().clear()
+    table.table_widget.setCurrentCell(0, Columns.NAME.value)  # so currentItem() resolves the row
+
+    monkeypatch.setattr(QMenu, "exec_", _menu_exec_returning("Copy Pytest Output"))
+    table.show_context_menu(QPoint(0, 0))
+    # test_a.py's output ("1 passed") or test_b.py's ("1 failed") lands on the clipboard
+    assert QGuiApplication.clipboard().text() in {"1 passed", "1 failed"}
+
+
+def test_table_tab_context_menu_force_stop_emits(app, monkeypatch):
+    """The 'Force Stop' entry (shown only for running tests) emits the node_id signal."""
+    from PySide6.QtCore import QPoint
+    from PySide6.QtWidgets import QMenu
+
+    data_dir = get_temp_dir("table_menu_stop")
+    name = "tests/test_run.py"
+    now = time.time()
+    infos = [_info(name, None, PyTestFlyExitCode.NONE, now - 2), _info(name, 1, PyTestFlyExitCode.NONE, now - 1)]
+    table = TableTab(data_dir)
+    table.update_tick(build_tick_data(infos))
+    table.table_widget.setCurrentCell(0, Columns.NAME.value)
+
+    emitted = []
+    table.force_stop_test_requested.connect(emitted.append)
+    monkeypatch.setattr(QMenu, "exec_", _menu_exec_returning("Force Stop"))
+    table.show_context_menu(QPoint(0, 0))
+    assert emitted == [name]

--- a/tests/test_time_axis_paint.py
+++ b/tests/test_time_axis_paint.py
@@ -1,0 +1,35 @@
+"""Paint and interval-selection coverage for the Graph-tab time axis."""
+
+import time
+
+from pytest_fly.gui.graph_tab.time_axis import TimeAxisWidget, compute_grid_ticks
+
+
+def test_compute_grid_ticks_huge_window_uses_largest_interval():
+    """A window too large for any smaller interval falls back to the largest one."""
+    ticks = compute_grid_ticks(0.0, 10_000_000.0, 800)
+    assert len(ticks) > 0
+    # With the 24h (86400s) interval the ticks are spaced far apart but still produced.
+    assert ticks[0][1] == "0s"
+
+
+def test_compute_grid_ticks_none_inputs():
+    """Missing bounds or non-positive width yield no ticks."""
+    assert compute_grid_ticks(None, 1.0, 800) == []
+    assert compute_grid_ticks(0.0, 1.0, 0) == []
+
+
+def test_time_axis_widget_paints(app):
+    """A TimeAxisWidget with a valid window paints its tick marks and labels."""
+    widget = TimeAxisWidget()
+    widget.resize(400, 30)
+    now = time.time()
+    widget.update_time_window(now - 100, now)
+    widget.grab()  # forces paintEvent with a populated tick set
+
+
+def test_time_axis_widget_paints_empty(app):
+    """With no time window the widget paints nothing (early return path)."""
+    widget = TimeAxisWidget()
+    widget.resize(400, 30)
+    widget.grab()  # paintEvent with no ticks -> super().paintEvent


### PR DESCRIPTION
## Summary

Test-only change that raises coverage from **78% → 87%** (343 newly covered lines) by unit-testing previously-untested pure logic and GUI widgets. 328 tests pass; no production code changed.

## Tier 1 — pure logic / light mocking

| Module | Coverage focus |
|---|---|
| `main.py` | `app_main` bootstrap (was **0%**) — mocks `fly_main` |
| `paths.py` | last-target read/write persistence |
| `put_version.py` | metadata-parse branches (bad toml/cfg, non-string name, authors, no-metadata section) |
| `platform/os.py` | permission helpers under **both** `is_windows()` branches via monkeypatch (CI is Linux, so this keeps coverage platform-independent) |
| `db/db.py` | `query_ever_run_names`, delete-all/drop, schema-change recreate |
| `pytest_runner/coverage.py` | per-test edge cases (missing dir, corrupt `.coverage`) |
| `platform_info.py` / `project_info.py` | `details=True` path; installed-metadata URL fallbacks |

## Tier 2 — GUI widgets

Driven via `update_tick`, forced `paintEvent` (`widget.grab()`), and mocked modal dialogs:

- **status_window** — PUT line, coverage, parallelism, ETA, soft-stop messaging (98%)
- **graph_tab/time_axis** — paint + largest-interval fallback
- **graph_tab/progress_bar** — paint, tooltip mouse-move, leave event (91%)
- **table_tab** — populate/sort/reset/copy + context menu (mocked modal `QMenu`)
- **configuration** — preference edits, clamping, browse dialogs, ordering widget (98%)
- **control_window** — button states + soft/force stop via a fake runner

## What's intentionally left

The remaining gaps are dominated by **subprocess run-loops** (`pytest_process`, `system_monitor`, `process_monitor`, `test_list` collection) and the **event-loop-driven `fly_main`**. These execute in child processes / a live Qt loop and need integration tests rather than unit tests — out of scope here to keep the suite fast and non-flaky. (I tried `GetTests.run()` in-process; pytest's fd-level output capture prevents it, confirming it's genuinely subprocess-only.)

## Verification

- Full suite: **328 passed**
- `ruff check` + `ruff format`: clean
- Pre-existing `ty` diagnostics only (none introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)