### PR TITLE
Allow pre-releases in CI (3.15 deferred — no PySide6 wheel)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12', '3.15']
+        python-version: ['3.12']
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.12', '3.15']
     steps:
       - uses: actions/checkout@v5
 
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install dependencies
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py312,pypy3,ruff
+envlist = py312,py315,pypy3,ruff
 
 [testenv]
 deps = pytest>=6.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py312,py315,pypy3,ruff
+envlist = py312,pypy3,ruff
 
 [testenv]
 deps = pytest>=6.2.0


### PR DESCRIPTION
## Summary
- Set `allow-prereleases: true` on `setup-python` so pre-release Pythons can install in CI
- **Deferred adding 3.15 to the matrix**: PySide6 has no wheel (and no sdist) for `3.15.0-beta.1`, so `pip install -e .` fails to resolve the GUI dependency

## Why 3.15 is not in the matrix yet
Initial attempt added `3.15` to the matrix. CI showed:
```
ERROR: Could not find a version that satisfies the requirement pyside6
ERROR: No matching distribution found for pyside6
```
PySide6 does not yet ship 3.15 wheels. Rather than block PRs on a red 3.15 check, 3.15 is removed for now. With `allow-prereleases: true` left in place, re-adding it later is a one-line matrix change once upstream wheels land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)