### PR TITLE
Incorporate live Processes count into the running scheduler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.13"
+version = "0.4.14"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -89,6 +89,33 @@ class ControlWindow(QGroupBox):
         max_width += 30
         self.setFixedWidth(max_width)
 
+    def _desired_process_count(self) -> int:
+        """Number of worker processes the current preferences call for.
+
+        Serial mode pins this to 1; parallel mode uses the configured Processes count.
+        Read live from preferences so a change in the Configuration tab (or the
+        parallelism selector) is reflected without restarting the run.
+        """
+        pref = get_pref()
+        return 1 if pref.parallelism == ParallelismControl.SERIAL else pref.processes
+
+    def reconcile_process_count(self):
+        """Push the live Processes preference into the active runner, mid-run.
+
+        Called every GUI tick so a change to the Processes count (or the parallelism
+        selector) is incorporated into the running scheduler — growing or shrinking
+        the worker pool — without requiring the user to restart the run.
+        """
+        # Keep the "Parallel (N)" label in sync with the live preference, even when idle.
+        self.parallelism_box.refresh_label()
+
+        if self.pytest_runner is None or not self.pytest_runner.is_running():
+            return
+        desired = self._desired_process_count()
+        if desired != self.num_processes:
+            self.num_processes = desired
+            self.pytest_runner.set_number_of_processes(desired)
+
     def refresh_button_state(self):
         """Enable/disable run, stop, and force stop buttons based on the runner state.
 
@@ -135,7 +162,7 @@ class ControlWindow(QGroupBox):
             self.pytest_runner.stop()
             self.pytest_runner.join()
 
-        processes = 1 if pref.parallelism == ParallelismControl.SERIAL else pref.processes
+        processes = self._desired_process_count()
 
         while get_tests.is_alive():
             get_tests.join(1)

--- a/src/pytest_fly/gui/run_tab/parallelism_control_box.py
+++ b/src/pytest_fly/gui/run_tab/parallelism_control_box.py
@@ -37,9 +37,18 @@ class ParallelismControlBox(QGroupBox):
     def update_preferences(self):
         """Sync the selected radio button back to user preferences."""
         pref = get_pref()
-        self.parallelism_parallel.setText(f"Parallel ({pref.processes})")
-        self.parallelism_parallel.setToolTip(f"Run a fixed number of tests ({pref.processes}) in parallel.")
+        self.refresh_label()
         if self.parallelism_serial.isChecked():
             pref.parallelism = ParallelismControl.SERIAL
         elif self.parallelism_parallel.isChecked():
             pref.parallelism = ParallelismControl.PARALLEL
+
+    def refresh_label(self):
+        """Update the "Parallel (N)" label/tooltip from the live Processes preference.
+
+        Called on each GUI tick so the count shown here tracks edits made in the
+        Configuration tab, matching what the scheduler will actually use.
+        """
+        pref = get_pref()
+        self.parallelism_parallel.setText(f"Parallel ({pref.processes})")
+        self.parallelism_parallel.setToolTip(f"Run a fixed number of tests ({pref.processes}) in parallel.")

--- a/src/pytest_fly/gui/run_tab/run_tab.py
+++ b/src/pytest_fly/gui/run_tab/run_tab.py
@@ -75,6 +75,7 @@ class RunTab(QWidget):
         self.failed_tests_window.update_tick(tick)
         self.live_output_window.update_tick(tick)
         self.system_metrics_window.update_tick()
+        self.control_window.reconcile_process_count()
         self.control_window.refresh_button_state()
 
     def _restore_splitter_state(self) -> None:

--- a/src/pytest_fly/pytest_runner/pytest_runner.py
+++ b/src/pytest_fly/pytest_runner/pytest_runner.py
@@ -10,7 +10,7 @@ tests in parallel via :class:`PytestProcess` subprocesses.
 import time
 from pathlib import Path
 from queue import Empty, Queue
-from threading import Condition, Event, Thread
+from threading import Condition, Event, Lock, Thread
 from typing import Optional
 
 from PySide6.QtGui import QColor
@@ -106,7 +106,14 @@ class PytestRunner(Thread):
         self.put_version = put_version
         self.put_fingerprint = put_fingerprint
 
+        # Worker pool. _pool_lock guards _test_runners, _next_worker_id, and
+        # number_of_processes so the pool can be resized from the GUI thread
+        # (via set_number_of_processes) while run() spins it up on this thread.
+        self._pool_lock = Lock()
         self._test_runners = {}
+        self._next_worker_id = 0
+        self._test_queue: Queue | None = None
+        self._coordinator: _SingletonCoordinator | None = None
         self._started_event = Event()
         self._written_to_db = set()
 
@@ -133,23 +140,72 @@ class PytestRunner(Thread):
 
         coordinator = _SingletonCoordinator()
 
-        for thread_number in range(self.number_of_processes):
-            test_runner = _TestRunner(
-                self.run_guid,
-                test_queue,
-                self.data_dir,
-                self.update_rate,
-                coordinator,
-                put_version=self.put_version,
-                put_fingerprint=self.put_fingerprint,
-            )
-            test_runner.start()
-            self._test_runners[thread_number] = test_runner
-        self._started_event.set()
+        # Publish the queue/coordinator and spawn the initial pool atomically so a
+        # concurrent set_number_of_processes() either sees "not yet started" (and
+        # just records the count for us to use here) or a fully-wired pool.
+        with self._pool_lock:
+            self._test_queue = test_queue
+            self._coordinator = coordinator
+            for _ in range(self.number_of_processes):
+                self._spawn_worker_locked()
+            self._started_event.set()
+
+    def _spawn_worker_locked(self) -> None:
+        """Start one worker thread pulling from the shared queue. Caller holds ``_pool_lock``."""
+        test_runner = _TestRunner(
+            self.run_guid,
+            self._test_queue,
+            self.data_dir,
+            self.update_rate,
+            self._coordinator,
+            put_version=self.put_version,
+            put_fingerprint=self.put_fingerprint,
+        )
+        test_runner.start()
+        self._test_runners[self._next_worker_id] = test_runner
+        self._next_worker_id += 1
+
+    @typechecked()
+    def set_number_of_processes(self, number_of_processes: int) -> None:
+        """Resize the worker pool to *number_of_processes* while the run is in progress.
+
+        Growing spawns additional workers that pull from the same shared queue;
+        shrinking retires the most-recently-spawned workers — each finishes its
+        current test, then exits *without* draining the queue, so its remaining
+        tests stay available to the surviving workers.
+
+        Reconciles against the count of live, non-retiring workers, so it is
+        self-correcting and safe to call repeatedly.  If the pool has not been
+        spun up yet, the new count is simply recorded and used by :meth:`run`.
+
+        :param number_of_processes: Desired number of concurrently-working test processes (>= 1).
+        """
+        if number_of_processes < 1:
+            return
+        with self._pool_lock:
+            self.number_of_processes = number_of_processes
+            if not self._started_event.is_set():
+                # run() has not spawned the pool yet; it will use the updated count.
+                return
+            # Drop workers that have already exited so the reconciliation below
+            # counts only workers that can still pick up (or are running) tests.
+            self._test_runners = {tid: r for tid, r in self._test_runners.items() if r.is_alive()}
+            active = [r for r in self._test_runners.values() if not r.is_retiring()]
+            delta = number_of_processes - len(active)
+            if delta > 0:
+                for _ in range(delta):
+                    self._spawn_worker_locked()
+            elif delta < 0:
+                # Retire the most-recently-spawned workers (dict preserves insertion order).
+                for test_runner in active[delta:]:
+                    test_runner.retire()
+            log.info(f"resized worker pool to {number_of_processes} ({len(active)} active before, delta {delta}) ({self.run_guid=})")
 
     def is_running(self) -> bool:
         """Return ``True`` if any worker thread is still alive."""
-        return any(test_runner.is_alive() for test_runner in self._test_runners.values())
+        with self._pool_lock:
+            test_runners = list(self._test_runners.values())
+        return any(test_runner.is_alive() for test_runner in test_runners)
 
     @typechecked()
     def join(self, timeout_seconds: float | None = None) -> bool:
@@ -162,13 +218,17 @@ class PytestRunner(Thread):
         else:
             self._started_event.wait()
 
-        for test_runner in self._test_runners.values():
+        with self._pool_lock:
+            test_runners = list(self._test_runners.values())
+        for test_runner in test_runners:
             test_runner.join(timeout_seconds)
-        return all(not test_runner.is_alive() for test_runner in self._test_runners.values())
+        return all(not test_runner.is_alive() for test_runner in test_runners)
 
     def stop(self):
         try:
-            for test_runner in self._test_runners.values():
+            with self._pool_lock:
+                test_runners = list(self._test_runners.values())
+            for test_runner in test_runners:
                 test_runner.stop()
         except (OSError, RuntimeError, PermissionError) as e:
             log.error(f"error stopping pytest runner,{self.run_guid=},{e}", exc_info=True, stack_info=True)
@@ -176,7 +236,9 @@ class PytestRunner(Thread):
     def soft_stop(self):
         """Signal workers to finish their current test and stop picking up new ones."""
         try:
-            for test_runner in self._test_runners.values():
+            with self._pool_lock:
+                test_runners = list(self._test_runners.values())
+            for test_runner in test_runners:
                 test_runner.soft_stop()
         except (OSError, RuntimeError, PermissionError) as e:
             log.error(f"error soft-stopping pytest runner,{self.run_guid=},{e}", exc_info=True, stack_info=True)
@@ -189,7 +251,9 @@ class PytestRunner(Thread):
 
         :param test_name: The test node_id to terminate.
         """
-        for test_runner in self._test_runners.values():
+        with self._pool_lock:
+            test_runners = list(self._test_runners.values())
+        for test_runner in test_runners:
             proc = test_runner.process
             if proc is not None and proc.name == test_name:
                 test_runner.force_stop_current()
@@ -296,6 +360,7 @@ class _TestRunner(Thread):
         self.process: Optional[PytestProcess] = None
         self._stop_event = Event()
         self._soft_stop_event = Event()
+        self._retire_event = Event()
         self._force_stop_current_event = Event()
 
         self._coordinator = coordinator
@@ -396,7 +461,7 @@ class _TestRunner(Thread):
         """Consume tests from the queue until it is empty or a stop is requested."""
 
         def should_abort() -> bool:
-            return self._stop_event.is_set() or self._soft_stop_event.is_set()
+            return self._stop_event.is_set() or self._soft_stop_event.is_set() or self._retire_event.is_set()
 
         while not should_abort():
             try:
@@ -418,6 +483,12 @@ class _TestRunner(Thread):
                     break
                 if self._soft_stop_event.is_set():
                     self._drain_queue()
+                    break
+                if self._retire_event.is_set():
+                    # Pool was shrunk while we waited for a slot. Hand the test we
+                    # dequeued back so a surviving worker runs it, then exit without
+                    # draining — the remaining queue belongs to the other workers.
+                    self.pytest_test_queue.put(scheduled_test)
                     break
                 break
 
@@ -441,6 +512,18 @@ class _TestRunner(Thread):
     def soft_stop(self):
         """Signal the worker to finish its current test and stop picking up new ones."""
         self._soft_stop_event.set()
+
+    def retire(self):
+        """Signal the worker to finish its current test, then exit without draining the queue.
+
+        Used to shrink the pool mid-run; unlike :meth:`soft_stop`, the remaining
+        queued tests are left for the surviving workers rather than marked STOPPED.
+        """
+        self._retire_event.set()
+
+    def is_retiring(self) -> bool:
+        """Return ``True`` if this worker has been asked to retire."""
+        return self._retire_event.is_set()
 
     def force_stop_current(self):
         """Signal this worker to terminate its currently running test."""

--- a/tests/test_pytest_runner/test_pytest_runner_resize.py
+++ b/tests/test_pytest_runner/test_pytest_runner_resize.py
@@ -1,0 +1,78 @@
+import time
+
+from pytest_fly.db import PytestProcessInfoDB
+from pytest_fly.guid import generate_uuid
+from pytest_fly.interfaces import PyTestFlyExitCode, ScheduledTest
+from pytest_fly.pytest_runner import PytestRunner
+
+from ..paths import get_temp_dir
+
+
+def test_pytest_runner_grow_pool(app):
+    """Growing the pool mid-run lets queued tests run in parallel without a restart."""
+
+    data_dir = get_temp_dir("test_pytest_runner_grow_pool")
+    with PytestProcessInfoDB(data_dir) as db:
+        db.delete()
+    run_guid = generate_uuid()
+
+    # Two distinct 3-second modules. With one worker they run serially (~9s incl.
+    # process startup); growing to two workers runs them in parallel (~5s).
+    scheduled_tests = [
+        ScheduledTest(node_id="tests/test_3_sec_operation.py", singleton=False, duration=None, coverage=None),
+        ScheduledTest(node_id="tests/test_sleep.py", singleton=False, duration=None, coverage=None),
+    ]
+
+    runner = PytestRunner(run_guid, scheduled_tests, number_of_processes=1, data_dir=data_dir, update_rate=1.0)
+    start = time.time()
+    runner.start()
+    time.sleep(0.5)  # let run() spin up the initial single worker
+    runner.set_number_of_processes(2)
+    completed = runner.join(30.0)
+    elapsed = time.time() - start
+
+    assert completed
+    assert not runner.is_running()
+
+    with PytestProcessInfoDB(data_dir) as db:
+        results = db.query(run_guid)
+    for name in ("tests/test_3_sec_operation.py", "tests/test_sleep.py"):
+        final = [r for r in results if r.name == name][-1]
+        assert final.exit_code == PyTestFlyExitCode.OK
+
+    # Serial execution would take ~9s; parallel ~5s. The midpoint threshold proves
+    # the second worker spawned by the resize actually picked up the queued test.
+    assert elapsed < 7.5, f"expected parallel execution after grow, took {elapsed:.1f}s"
+
+
+def test_pytest_runner_shrink_pool_preserves_queue(app):
+    """Shrinking the pool retires a worker without losing the queued test — a survivor runs it."""
+
+    data_dir = get_temp_dir("test_pytest_runner_shrink_pool_preserves_queue")
+    with PytestProcessInfoDB(data_dir) as db:
+        db.delete()
+    run_guid = generate_uuid()
+
+    # Two long tests occupy both workers; one instant test stays queued.
+    scheduled_tests = [
+        ScheduledTest(node_id="tests/test_3_sec_operation.py", singleton=False, duration=None, coverage=None),
+        ScheduledTest(node_id="tests/test_sleep.py", singleton=False, duration=None, coverage=None),
+        ScheduledTest(node_id="tests/test_no_operation.py", singleton=False, duration=None, coverage=None),
+    ]
+
+    runner = PytestRunner(run_guid, scheduled_tests, number_of_processes=2, data_dir=data_dir, update_rate=1.0)
+    runner.start()
+    time.sleep(1.0)  # let both workers pick up the two long tests
+    runner.set_number_of_processes(1)  # retire one worker; the survivor must drain the queue
+    completed = runner.join(30.0)
+
+    assert completed
+    assert not runner.is_running()
+
+    with PytestProcessInfoDB(data_dir) as db:
+        results = db.query(run_guid)
+
+    # The queued instant test must NOT be marked STOPPED — a surviving worker runs it.
+    for name in ("tests/test_3_sec_operation.py", "tests/test_sleep.py", "tests/test_no_operation.py"):
+        final = [r for r in results if r.name == name][-1]
+        assert final.exit_code == PyTestFlyExitCode.OK, f"{name} ended {final.exit_code!r}, expected OK"


### PR DESCRIPTION
## Summary

The **Processes** count was read once, at Run-button click, and baked into a fixed-size worker pool for the life of the run. Editing it in the Configuration tab had no effect until the next run. Now the count is reconciled into the live run on every GUI tick — the scheduler always uses the current configured value.

## Changes

**Scheduler (`pytest_runner.py`)**
- `PytestRunner.set_number_of_processes(n)` — resizes the worker pool mid-run, reconciling against the count of live, non-retiring workers (self-correcting). Grow spawns workers; shrink retires them.
- `_TestRunner.retire()` / `is_retiring()` — a retired worker finishes its current test then exits **without draining the queue**, leaving remaining tests for the surviving workers (re-enqueues a test it had already dequeued).
- Added a `_pool_lock` and made `run()`, `is_running()`, `join()`, `stop()`, `soft_stop()`, `force_stop_test()` resize-safe (pool can change from the GUI thread).

**Run tab / Control widget**
- `ControlWindow.reconcile_process_count()` (called every tick) pushes the live preference into the active runner whenever it differs, and updates `num_processes` so ETA tracks the new count.
- `ParallelismControlBox.refresh_label()` keeps the "Parallel (N)" label/tooltip in sync with the live preference.

## Tests
- `test_pytest_runner_grow_pool` — grow 1→2 mid-run; both tests complete and wall-clock proves parallel execution.
- `test_pytest_runner_shrink_pool_preserves_queue` — shrink 2→1 mid-run; the queued test is run by the survivor, not marked STOPPED.

Full runner suite (12) and the 28 GUI/control/config tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)