### PR TITLE
Fix Windows crash when live-output log is locked across suite restarts

### DIFF
--- a/src/pytest_fly/pytest_runner/pytest_process.py
+++ b/src/pytest_fly/pytest_runner/pytest_process.py
@@ -11,6 +11,7 @@ import traceback
 from multiprocessing import Process
 from pathlib import Path
 from queue import Empty
+from typing import TextIO
 
 import psutil
 import pytest
@@ -223,6 +224,35 @@ class PytestProcess(Process):
 
         self._process_monitor_process = None
 
+    def _open_live_output(self, live_path: Path, retry_timeout: float = 5.0, retry_interval: float = 0.2) -> tuple[TextIO, Path]:
+        """Open the per-test live-output log for writing, tolerating a transiently locked file.
+
+        The live-output path is keyed by test name only, so when the suite auto-restarts on a
+        code change the previous run's process for the same test may still be terminating and
+        holding this file open. Windows then refuses to truncate or delete it (WinError 32), and
+        an uncaught error here would kill this whole process so the test never runs and never
+        records a result. Opening in ``"w"`` mode truncates (no separate ``unlink`` needed);
+        retry briefly, and if the file stays locked fall back to a pid-unique sibling so the test
+        always runs. In that rare fallback the GUI (which tails the canonical path) won't show
+        this test's live output, but the completed output still lands in the DB.
+
+        :param live_path: The preferred live-output path (the one the GUI tails).
+        :param retry_timeout: Seconds to keep retrying the canonical path before falling back.
+        :param retry_interval: Seconds to wait between retries.
+        :return: ``(open_file, actual_path)`` — *actual_path* is the pid-unique fallback if locked.
+        """
+        deadline = time.time() + retry_timeout
+        last_error: OSError | None = None
+        while time.time() < deadline:
+            try:
+                return open(live_path, "w", buffering=1, encoding="utf-8", errors="replace", newline=""), live_path
+            except OSError as e:  # PermissionError (WinError 32) etc. while another holder has it open
+                last_error = e
+                time.sleep(retry_interval)
+        fallback = live_path.with_name(f"{live_path.stem}.{self.pid}{live_path.suffix}")
+        log.warning(f"live-output file {live_path} stayed locked ({last_error}); falling back to {fallback}")
+        return open(fallback, "w", buffering=1, encoding="utf-8", errors="replace", newline=""), fallback
+
     def run(self) -> None:
 
         configure_child_logger(f"{sanitize_test_name(self.name)}.log")
@@ -251,8 +281,8 @@ class PytestProcess(Process):
         # pytest's own capture so prints stream immediately.
         live_path = live_output_path(self.data_dir, self.name)
         live_path.parent.mkdir(parents=True, exist_ok=True)
-        live_path.unlink(missing_ok=True)
-        with open(live_path, "w", buffering=1, encoding="utf-8", errors="replace", newline="") as live_file:
+        live_file, live_path = self._open_live_output(live_path)
+        with live_file:
             with contextlib.redirect_stdout(live_file), contextlib.redirect_stderr(live_file):
                 # create a temp coverage file and then move it so if the file exists, the content is complete (the save is not necessarily instantaneous and atomic)
                 coverage_dir = Path(self.data_dir, "coverage")

--- a/tests/test_pytest_process.py
+++ b/tests/test_pytest_process.py
@@ -1,3 +1,4 @@
+import builtins
 import subprocess
 import sys
 import time
@@ -9,6 +10,7 @@ import psutil
 from pytest_fly.db import PytestProcessInfoDB
 from pytest_fly.guid import generate_uuid
 from pytest_fly.interfaces import PyTestFlyExitCode
+from pytest_fly.pytest_runner.live_output import live_output_path
 from pytest_fly.pytest_runner.pytest_process import PytestProcess, terminate_process_tree
 
 
@@ -28,6 +30,73 @@ def test_pytest_process():
         execution_time = results[-1].time_stamp - results[0].time_stamp
         print(f"{execution_time=}")
         assert execution_time >= 0.0  # 1.4768257141113281 has been observed
+
+
+def _make_process(data_dir: str) -> PytestProcess:
+    return PytestProcess(generate_uuid(), Path("tests/test_no_operation.py"), Path(data_dir), 3.0)
+
+
+def test_open_live_output_truncates_existing_content():
+    """The canonical path is opened in 'w' mode, truncating any stale content."""
+    with TemporaryDirectory() as data_dir:
+        process = _make_process(data_dir)
+        live_path = live_output_path(Path(data_dir), process.name)
+        live_path.parent.mkdir(parents=True, exist_ok=True)
+        live_path.write_text("stale content from a previous run\n")
+
+        live_file, actual_path = process._open_live_output(live_path)
+        with live_file:
+            live_file.write("fresh\n")
+        assert actual_path == live_path
+        assert live_path.read_text() == "fresh\n"  # stale content was truncated
+
+
+def test_open_live_output_retries_then_succeeds(monkeypatch):
+    """A briefly-locked canonical path is retried and then opened successfully (no fallback)."""
+    with TemporaryDirectory() as data_dir:
+        process = _make_process(data_dir)
+        live_path = live_output_path(Path(data_dir), process.name)
+        live_path.parent.mkdir(parents=True, exist_ok=True)
+
+        real_open = builtins.open
+        calls = {"n": 0}
+
+        def flaky_open(file, *args, **kwargs):
+            if Path(file) == live_path and calls["n"] < 2:
+                calls["n"] += 1
+                raise PermissionError(32, "locked")
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", flaky_open)
+        live_file, actual_path = process._open_live_output(live_path, retry_timeout=5.0, retry_interval=0.01)
+        with live_file:
+            live_file.write("ok\n")
+        assert actual_path == live_path  # recovered on the canonical path
+        assert calls["n"] == 2  # two failures then success
+
+
+def test_open_live_output_falls_back_when_persistently_locked(monkeypatch):
+    """A persistently-locked canonical path falls back to a pid-unique sibling instead of raising."""
+    with TemporaryDirectory() as data_dir:
+        process = _make_process(data_dir)
+        live_path = live_output_path(Path(data_dir), process.name)
+        live_path.parent.mkdir(parents=True, exist_ok=True)
+
+        real_open = builtins.open
+
+        def locked_open(file, *args, **kwargs):
+            if Path(file) == live_path:
+                raise PermissionError(32, "locked")
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", locked_open)
+        live_file, actual_path = process._open_live_output(live_path, retry_timeout=0.05, retry_interval=0.01)
+        with live_file:
+            live_file.write("fallback\n")
+        assert actual_path != live_path  # used the fallback sibling
+        assert actual_path.parent == live_path.parent
+        assert actual_path.suffix == live_path.suffix  # still a .log file
+        assert actual_path.read_text() == "fallback\n"
 
 
 def _wait_pid_gone(pid: int, timeout: float = 5.0) -> bool:


### PR DESCRIPTION
## Problem

On Windows, running a real suite produced repeated crashes like:

```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process:
'...\live_output\test_..._one_study.py.log'
  File ".../pytest_runner/pytest_process.py", line ..., in run
    live_path.unlink(missing_ok=True)
```

The per-test live-output log path is keyed by **test name only** (no run GUID), so when the suite auto-restarts on a code change, the *previous* run's still-terminating process for the same test holds that log file open. Windows then refuses to `unlink`/truncate it (WinError 32). The error was uncaught and killed the entire `PytestProcess` **before pytest ever ran** — so the test never executed and never recorded a result. The GUI's per-tick `read_live_output` (which doesn't grant `FILE_SHARE_DELETE`) can race the same way.

## Fix

Replace the fragile `unlink()` + `open("w")` with a resilient `_open_live_output()` helper:

- Opening in `"w"` mode truncates, so the separate `unlink` (the actual crash site) is gone.
- Retry the canonical path briefly while a transient lock clears (the dying old process finishes releasing the handle).
- If the lock persists, fall back to a pid-unique sibling file so the test **always runs and records a result**. In that rare case the GUI just won't show that one test's live tail, but completed output still lands in the DB — a strict improvement over crashing.
- Retry timing is injectable so tests stay fast.

## Tests

Added three unit tests (truncate stale content, retry-then-succeed, persistent-lock fallback). Existing process / live-output / table / GUI suites pass. `ruff check` + `ruff format` clean; `ty` adds no new diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)