### PR TITLE
Fix duplicate y-axis labels on integer-count charts (Activity)

### DIFF
--- a/src/pytest_fly/gui/run_tab/system_metrics_window.py
+++ b/src/pytest_fly/gui/run_tab/system_metrics_window.py
@@ -107,6 +107,21 @@ class _MetricChart(QWidget):
             return float(max(math.ceil(peak * 1.15), 1))  # whole-number axis, never collapse to zero
         return max(peak * 1.15, 1.0)  # 15% headroom, but never collapse to zero
 
+    def _y_grid_ticks(self, y_max: float) -> list[float]:
+        """Y-axis tick values (in data units) for horizontal gridlines and labels.
+
+        Continuous charts (CPU, Memory, MB/s) use evenly spaced fractions of ``y_max``.
+        Integer-count charts (e.g. Activity) instead use a whole-number step so the labels
+        are always distinct and the top tick lands exactly on ``y_max`` — fixed fractions of
+        a small max otherwise round to duplicates (e.g. ``y_max == 1`` → 0, 0, 1, 1).
+        """
+        if not self._integer_y:
+            return [y_max * pct for pct in _Y_GRID_PCTS]
+        top = max(int(round(y_max)), 1)
+        step = max(1, math.ceil(top / len(_Y_GRID_PCTS)))
+        # Build from the top down so the highest tick is always y_max, then present ascending.
+        return [float(value) for value in range(top, 0, -step)][::-1]
+
     def _format_y_label(self, value: float) -> str:
         if self._integer_y:
             return str(int(round(value)))
@@ -140,16 +155,20 @@ class _MetricChart(QWidget):
 
         text_color = window_text_color(self)
 
-        # Horizontal grid lines + y labels
+        # Horizontal grid lines + y labels (tick values are in data units so integer-count
+        # charts get distinct whole-number labels rather than rounded fractions).
+        y_ticks = self._y_grid_ticks(y_max)
         painter.setPen(QPen(GRID_LINE_COLOR, 1))
-        for pct in _Y_GRID_PCTS:
+        for value in y_ticks:
+            pct = value / y_max if y_max > 0 else 0.0
             y = margin_top + int(chart_h * (1.0 - pct))
             painter.drawLine(margin_left, y, w - 4, y)
 
         painter.setPen(QPen(text_color, 1))
-        for pct in _Y_GRID_PCTS:
+        for value in y_ticks:
+            pct = value / y_max if y_max > 0 else 0.0
             y = margin_top + int(chart_h * (1.0 - pct))
-            label = self._format_y_label(y_max * pct)
+            label = self._format_y_label(value)
             label_w = get_text_dimensions(label).width()
             painter.drawText(margin_left - label_w - 4, y + 4, label)
 

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -122,6 +122,22 @@ def test_system_metrics_window_activity_chart(qtbot):
     _force_paint(window._activity_chart, 300, 150)
 
 
+def test_activity_chart_y_labels_are_distinct_integers(qtbot):
+    """Integer-count charts must never render duplicate y-axis labels (regression).
+
+    With fixed 0.25/0.5/0.75/1.0 fractions, a small ``y_max`` (e.g. 1) rounded to integers
+    produced duplicates like 0, 0, 1, 1. Whole-number ticks keep every label distinct and
+    put the top tick exactly on ``y_max``.
+    """
+    chart = SystemMetricsWindow(None)._activity_chart
+    for y_max in [1, 2, 3, 4, 5, 7, 8, 10, 16, 19, 32]:
+        ticks = chart._y_grid_ticks(float(y_max))
+        labels = [chart._format_y_label(value) for value in ticks]
+        assert len(labels) == len(set(labels)), f"duplicate y labels for {y_max=}: {labels}"
+        assert all("." not in label for label in labels), f"non-integer y label for {y_max=}: {labels}"
+        assert ticks[-1] == float(y_max), f"top tick should equal y_max for {y_max=}: {ticks}"
+
+
 def test_coverage_tab_paint_forced(qtbot):
     """Force a real paintEvent on the coverage chart with data."""
     tab = CoverageTab()


### PR DESCRIPTION
## Problem

The Activity chart's y-axis showed repeated values — e.g. two `0`s and two `1`s.

The chart drew y-axis labels at fixed fractions of `y_max` — `0.25, 0.50, 0.75, 1.00` — then rounded each to an integer for count charts like Activity (`integer_y=True`). When activity is low, `y_max` is `1`, so those fractions are `0.25, 0.5, 0.75, 1.0`, which round to **0, 0, 1, 1**. (For `y_max=2` you'd get `0, 1, 2, 2`, etc.)

## Fix

Add `_y_grid_ticks(y_max)`:

- **Continuous charts** (CPU, Memory, Disk/Network MB/s) return the same even fractions as before — **no visual change**.
- **Integer-count charts** return whole-number ticks at a computed step, built top-down so labels are always distinct and the top tick lands exactly on `y_max`.

`paintEvent` now iterates those tick values (in data units) for both gridlines and labels, positioning each by `value / y_max`.

Examples of the new integer ticks: `1 → [1]`, `2 → [1,2]`, `4 → [1,2,3,4]`, `10 → [1,4,7,10]`, `19 → [4,9,14,19]` — all distinct, top always equals `y_max`.

## Tests

Added `test_activity_chart_y_labels_are_distinct_integers` asserting no duplicate labels, integer-only labels, and top-tick == `y_max` across many maxima. `test_gui_widgets.py` passes. `ruff check` + `ruff format` clean; `ty` adds no new diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)