### PR TITLE
Fix future "Last Pass Start" timestamp in RESUME mode

### DIFF
--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -8,6 +8,7 @@ GUI tabs.
 """
 
 import time
+from dataclasses import replace
 from pathlib import Path
 from queue import Empty
 
@@ -71,6 +72,21 @@ def build_tick_data(
     :return: A fully populated :class:`TickData` instance.
     """
     singletons = singleton_names if singleton_names is not None else set()
+
+    # RESUME mode copies prior-run records for already-passed tests into the current run so
+    # they appear in every GUI tab.  Those copies keep their genuine historical timestamps in
+    # the DB (so query_last_pass / the "Last Pass Start" column report real wall-clock times),
+    # but the Progress Graph and Run-tab status use current_run_start as their time-axis origin,
+    # so historical records would fall off the left edge.  Shift the carried-over records (those
+    # predating the run's start) onto the current run's timeline here, at render time, preserving
+    # their relative spacing and leaving the DB untouched.  Durations are delta-invariant, so the
+    # table's Runtime column is unaffected.
+    if current_run_start is not None:
+        earliest_carried = min((info.time_stamp for info in process_infos if info.time_stamp < current_run_start), default=None)
+        if earliest_carried is not None:
+            delta = current_run_start - earliest_carried
+            process_infos = [replace(info, time_stamp=info.time_stamp + delta) if info.time_stamp < current_run_start else info for info in process_infos]
+
     grouped = group_process_infos_by_name(process_infos)
     ordered_names = sorted(grouped, key=lambda n: (n in singletons, n))
     infos_by_name = {name: grouped[name] for name in ordered_names}

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -76,7 +76,11 @@ class ControlWindow(QGroupBox):
         self.prior_durations: dict[str, float] = {}
         self.num_processes: int = 1
         self._soft_stop_requested: bool = False
-        self.current_run_start: float | None = None
+        # Restore the most recent run's start so the Progress Graph keeps its time-axis origin
+        # after an app restart — RESUME-carried records (with genuine historical timestamps) are
+        # shifted onto this origin at render time in build_tick_data.
+        restored_run_start = get_pref().last_run_start
+        self.current_run_start: float | None = restored_run_start if restored_run_start > 0.0 else None
         self.singleton_names: set[str] = set()
         self.put_version_info: PutVersionInfo | None = None
 
@@ -161,6 +165,8 @@ class ControlWindow(QGroupBox):
         # from DB records (copied RESUME records also have exit_code == NONE,
         # which made the DB-derived origin fall back to a prior-run timestamp).
         self.current_run_start = time.time()
+        # Persist so the graph time-axis origin survives an app restart (see __init__).
+        pref.last_run_start = self.current_run_start
 
         if self.pytest_runner is not None and self.pytest_runner.is_running():
             self.pytest_runner.stop()
@@ -201,9 +207,11 @@ class ControlWindow(QGroupBox):
         # In RESUME mode (or CHECK-as-RESUME), copy the complete prior-run records for
         # previously-passed tests into the current run so they appear in all GUI tabs
         # (table, graph, status) with their original data (runtime, CPU, memory, output, etc.).
-        # Timestamps are shifted uniformly so the copied records fall within the current
-        # run's time window; the Progress Graph uses current_run_start as its origin, so
-        # records retaining their historical timestamps would render off the visible axis.
+        # The copies retain their genuine historical timestamps so query_last_pass — and thus
+        # the table's "Last Pass Start" column — reports real wall-clock times.  The Progress
+        # Graph, which uses current_run_start as its time-axis origin, shifts these carried-over
+        # records onto the current timeline at render time (see build_tick_data); the DB is left
+        # truthful rather than rewritten with synthetic timestamps.
         if effective_mode == RunMode.RESUME:
             skipped_node_ids = all_node_ids - {t.node_id for t in tests}
             if skipped_node_ids:
@@ -212,10 +220,9 @@ class ControlWindow(QGroupBox):
                     prior_by_name.setdefault(r.name, []).append(r)
                 records_to_copy = [rec for nid in sorted(skipped_node_ids) for rec in prior_by_name.get(nid, [])]
                 if records_to_copy:
-                    delta = self.current_run_start - min(r.time_stamp for r in records_to_copy)
                     with PytestProcessInfoDB(self.data_dir) as db:
                         for record in records_to_copy:
-                            db.write(replace(record, run_guid=self.run_guid, time_stamp=record.time_stamp + delta))
+                            db.write(replace(record, run_guid=self.run_guid))
 
         # Use last-pass durations for ETA estimation (from the most recent passing run)
         self.prior_durations = {name: duration for name, (_, duration) in last_pass_data.items()}

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -155,6 +155,10 @@ class FlyPreferences(Pref):
 
     perf_logging: bool = attrib(default=False)  # log per-tick phase timings (db query, build_tick_data, each tab update) to diagnose UI lag
 
+    # Wall-clock start of the most recent run; the Progress Graph time-axis origin, restored on
+    # restart so RESUME-carried records still shift onto the run timeline (0.0 = none).
+    last_run_start: float = attrib(default=0.0)
+
     def get_sqlite_path(self) -> Path:
         # Override pref's default appdirs-based resolution so storage lives under the active PUT.
         path = get_preferences_db_path()

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -806,3 +806,39 @@ def test_full_pipeline(app):
     graph.update_tick(tick)
     assert len(graph.progress_bars) == 1
     assert "tests/test_no_operation.py" in graph.progress_bars
+
+
+def test_build_tick_data_shifts_carried_over_records_for_graph(app):
+    """RESUME-carried records (genuine past timestamps) are shifted onto the current
+    run timeline at render time, so the Progress Graph/Status render them in-window
+    while the durations are preserved (delta-invariant)."""
+    guid = "test-guid-carried"
+    now = time.time()
+    run_start = now
+
+    infos = [
+        # Carried-over (already-passed in a prior run, copied with genuine past timestamps):
+        # started ~2 hours ago, ran for 5s.
+        _make_process_info(guid, "tests/test_old.py", None, PyTestFlyExitCode.NONE, time_stamp=now - 7200 - 1),
+        _make_process_info(guid, "tests/test_old.py", 1001, PyTestFlyExitCode.NONE, time_stamp=now - 7200),
+        _make_process_info(guid, "tests/test_old.py", 1001, PyTestFlyExitCode.OK, output="1 passed", time_stamp=now - 7200 + 5),
+        # Freshly running this session (at/after the run start).
+        _make_process_info(guid, "tests/test_new.py", None, PyTestFlyExitCode.NONE, time_stamp=run_start),
+        _make_process_info(guid, "tests/test_new.py", 1002, PyTestFlyExitCode.NONE, time_stamp=run_start + 1),
+    ]
+
+    tick = build_tick_data(infos, current_run_start=run_start)
+
+    # No record displayed before the run origin — the carried-over ones were shifted forward.
+    assert all(info.time_stamp >= run_start for info in tick.process_infos)
+
+    # The carried-over test's started records now sit at/after the origin, so the Run-tab
+    # status time window starts at the run origin rather than 2 hours in the past.
+    assert tick.min_time_stamp_started is not None
+    assert tick.min_time_stamp_started >= run_start
+
+    # Duration is delta-invariant: test_old's 5s span survives the shift.
+    old_infos = tick.infos_by_name["tests/test_old.py"]
+    old_started = min(i.time_stamp for i in old_infos if i.pid is not None)
+    old_finished = max(i.time_stamp for i in old_infos)
+    assert old_finished - old_started == 5


### PR DESCRIPTION
## Problem

The Table tab's **Last Pass Start** column could show a timestamp **in the future** (e.g. `2026-06-02 19:26:00` on a system whose clock is correct).

This was **not** a timezone bug — `datetime.fromtimestamp()` already renders local time. The real cause is RESUME mode's timestamp rewriting:

- When resuming, `ControlWindow.run()` copied already-passed tests' records into the new run and **shifted every timestamp forward** to align the earliest copied record with `current_run_start`, preserving relative spacing.
- A test that ran late in the historical suite got shifted to `current_run_start + (its offset)` — past "now", i.e. into the future.
- `query_last_pass()` reads `MIN(time_stamp)` of the most recent passing run, which is now the shifted copy — so the column displayed the synthetic future time.

The shift existed only so the **Progress Graph** (whose x-axis originates at `current_run_start`) could render carried-over tests in-window.

## Fix

Stop corrupting the DB; apply the offset at **render time** instead:

- **`control_window.py`** — RESUME copies now retain their **genuine historical timestamps**. `query_last_pass()` / "Last Pass Start" report real wall-clock times.
- **`gui_main.build_tick_data`** — carried-over records (those predating `current_run_start`) are shifted onto the current run's timeline **in-memory**, so the Progress Graph and Run-tab status render exactly as before. Durations are delta-invariant, so the table's Runtime column is unaffected.
- **`preferences.py` + `control_window.py`** — added `last_run_start`, persisted on run start and restored on construction, so the graph keeps its time-axis origin across an app restart (otherwise carried-over tests would render at their true historical position with a gap on the axis).

## Tests

- Added `test_build_tick_data_shifts_carried_over_records_for_graph` — verifies carried-over records are shifted into the run window for the graph while durations are preserved.
- Existing `test_pytest_runner_resume`'s copy helper already copied **without** a shift, so production now matches the test.
- Verified passing: `test_pytest_process_info_db`, `test_gui_display`, `test_table_tab`, `test_status_window`, `test_tick_data`, `test_pytest_runner_resume`, `test_gui_util`, `test_gui_run_windows`, `test_gui_widgets`, `test_configuration`.
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
