### PR TITLE
Include subprocess CPU in the per-test CPU% column

### DIFF
--- a/src/pytest_fly/interfaces.py
+++ b/src/pytest_fly/interfaces.py
@@ -169,7 +169,7 @@ class PytestProcessInfo:
     exit_code: PyTestFlyExitCode | ExitCode
     output: str | None  # output from the pytest run, None if the test is still running
     time_stamp: float  # time stamp of the info update
-    cpu_percent: float | None = None  # peak CPU usage during the run, as reported by psutil (100.0 = one full logical CPU; can exceed 100 on multi-core)
+    cpu_percent: float | None = None  # peak CPU usage of the process subtree during the run, per psutil (100.0 = one full core; can exceed 100 on multi-core / busy subprocesses)
     memory_percent: float | None = None  # peak memory usage during the run (percent of total physical RAM)
     put_version: str | None = None  # program-under-test short label (e.g. "pytest-fly 0.3.19 (abc1234)")
     put_fingerprint: str | None = None  # program-under-test fingerprint for RunMode.CHECK comparison

--- a/src/pytest_fly/pytest_runner/process_monitor.py
+++ b/src/pytest_fly/pytest_runner/process_monitor.py
@@ -7,7 +7,7 @@ import time
 from dataclasses import dataclass
 from multiprocessing import Event, Process, Queue
 
-from psutil import NoSuchProcess
+from psutil import AccessDenied, NoSuchProcess
 from psutil import Process as PsutilProcess
 from typeguard import typechecked
 
@@ -22,7 +22,7 @@ class PytestProcessMonitorInfo:
     run_guid: str  # pytest run GUID
     name: str  # process name
     pid: int | None  # process ID from the OS
-    cpu_percent: float | None  # CPU usage percent
+    cpu_percent: float | None  # CPU usage percent of the process subtree (raw psutil scale: one full core == 100, so a multi-core subtree can exceed 100)
     memory_percent: float | None  # Memory usage percent
     time_stamp: float  # time stamp of the info update
     commit_bytes: int | None = None  # commit charge of the process subtree in bytes (Windows: pagefile)
@@ -69,16 +69,45 @@ class ProcessMonitor(Process):
         psutil_process = PsutilProcess(self._pid)
         psutil_process.cpu_percent()  # initialize psutil's CPU usage (ignore the first 0.0)
 
+        # Persistent per-descendant handle cache. psutil's cpu_percent() reports usage as a delta
+        # against the SAME Process object's previous call, so a child handle must persist across
+        # samples — re-creating it each sample would make every descendant read the meaningless
+        # first-call 0.0, silently dropping the CPU of any subprocess/.exe a test spawns (the test
+        # would then look near-idle even while a child burned a core).
+        child_cpu_procs: dict[int, PsutilProcess] = {}
+
+        def subtree_cpu_percent() -> float | None:
+            """Sum CPU percent of the target process plus all descendants (raw psutil scale)."""
+            try:
+                total = psutil_process.cpu_percent()
+            except NoSuchProcess:
+                return None
+            try:
+                children = psutil_process.children(recursive=True)
+            except (NoSuchProcess, AccessDenied):
+                children = []
+            for child in children:
+                cached = child_cpu_procs.get(child.pid)
+                try:
+                    if cached is None:
+                        # New descendant: cache + prime now (contributes 0 this sample, real after).
+                        child_cpu_procs[child.pid] = child
+                        child.cpu_percent()
+                    else:
+                        total += cached.cpu_percent()
+                except (NoSuchProcess, AccessDenied):
+                    child_cpu_procs.pop(child.pid, None)
+            return total
+
         def put_process_monitor_data():
             """Take one CPU/memory sample and enqueue it."""
             if psutil_process.is_running():
                 try:
                     # memory percent default is "rss"
-                    cpu_percent = psutil_process.cpu_percent()
                     memory_percent = psutil_process.memory_percent()
                 except NoSuchProcess:
-                    cpu_percent = None
                     memory_percent = None
+                cpu_percent = subtree_cpu_percent()
                 if cpu_percent is not None and memory_percent is not None:
                     # Commit charge of the whole process subtree (the test may spawn children).
                     commit_bytes = subtree_commit(self._pid)

--- a/tests/test_process_monitor_cpu_subtree.py
+++ b/tests/test_process_monitor_cpu_subtree.py
@@ -1,0 +1,96 @@
+"""The per-test CPU% the monitor reports must include the test's subprocesses.
+
+``ProcessMonitor`` samples one target process (in production, a test's ``pytest`` subprocess) and
+feeds the table's CPU% column.  A test often offloads its real work to a spawned subprocess/.exe, so
+the monitor sums CPU across the whole process subtree.  This guards that the busy descendant's CPU is
+actually counted — it would read ~0 if only the (idle) target process were sampled.
+"""
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from queue import Empty
+
+import psutil
+
+from pytest_fly.pytest_runner.process_monitor import ProcessMonitor
+
+from .paths import get_temp_dir
+
+# Recursive spawner: each level Popens the next; the leaf burns one core. Mirrors a test that
+# launches an application -> subprocess -> busy .exe.  argv: <remaining:int> <stop_file>.
+_CHAIN_SRC = """\
+import os, sys, time, subprocess
+
+remaining = int(sys.argv[1])
+stop_file = sys.argv[2]
+safety_deadline = time.time() + 60.0
+
+if remaining > 0:
+    child = subprocess.Popen([sys.executable, __file__, str(remaining - 1), stop_file])
+    while not os.path.exists(stop_file) and time.time() < safety_deadline:
+        time.sleep(0.2)  # idle ancestor; near-zero CPU
+    child.terminate()
+else:
+    x = 0
+    while not os.path.exists(stop_file) and time.time() < safety_deadline:
+        x += 1  # one full core busy
+"""
+
+_DEPTH = 3  # root + 3 generations: the busy leaf is a great-grandchild of the monitored root
+
+
+def test_process_monitor_counts_busy_descendant_cpu():
+    """A CPU-busy great-grandchild is reflected in the monitor's reported CPU%, even though the
+    monitored root and the intermediate processes are idle."""
+    work_dir = get_temp_dir("process_monitor_cpu_subtree")
+    helper = Path(work_dir, "mon_chain.py")
+    helper.write_text(_CHAIN_SRC, encoding="utf-8")
+    stop_file = Path(work_dir, f"stop_{os.getpid()}.flag")
+    stop_file.unlink(missing_ok=True)
+
+    root = subprocess.Popen([sys.executable, str(helper), str(_DEPTH), str(stop_file)])
+    monitor = ProcessMonitor("test-run-guid", "tests/test_x.py", root.pid, update_rate=0.3)
+    try:
+        monitor.start()
+        time.sleep(4.0)  # gather several samples; the leaf primes on first sight, reads real after
+        monitor.request_stop()
+        monitor.join(10.0)
+
+        cpu_samples = []
+        while True:
+            try:
+                info = monitor.process_monitor_queue.get(timeout=0.2)
+            except Empty:
+                break
+            if info.cpu_percent is not None:
+                cpu_samples.append(info.cpu_percent)
+
+        assert cpu_samples, "monitor produced no CPU samples"
+        peak = max(cpu_samples)
+        # One fully-busy descendant core reads ~100 on psutil's raw scale; the idle root + idle
+        # intermediates alone would be near 0. A generous floor keeps this robust across machines.
+        assert peak > 50.0, f"busy descendant CPU not counted in subtree sample (peak={peak})"
+    finally:
+        stop_file.write_text("stop", encoding="utf-8")
+        if monitor.is_alive():
+            monitor.request_stop()
+            monitor.join(5.0)
+            if monitor.is_alive():
+                monitor.kill()
+        try:
+            proc = psutil.Process(root.pid)
+            for child in proc.children(recursive=True):
+                try:
+                    child.kill()
+                except psutil.NoSuchProcess:
+                    pass
+            proc.kill()
+        except psutil.NoSuchProcess:
+            pass
+        try:
+            root.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass


### PR DESCRIPTION
## Background

Follow-up to #132. While fixing the stall watchdog's subtree CPU sampler, I noticed the table's per-test **CPU%** column has the same blind spot: `ProcessMonitor` sampled only the target test process's *own* CPU (`psutil_process.cpu_percent()`) — it walked the subtree for **memory/commit** but not for **CPU**. So a test that offloads its real work to a subprocess/`.exe` showed a near-zero CPU% in the table even while a child was burning a core.

## The change

Sum CPU across the whole process subtree in `ProcessMonitor`. As in #132, psutil's `cpu_percent()` is a delta against the **same** `Process` object's previous call, so descendant handles are **cached and reused across samples** (priming newly-seen ones, dropping exited ones) rather than re-created each tick — otherwise every descendant would perpetually report the meaningless first-call `0.0`.

- Raw psutil scale is preserved: one full core == 100, a multi-core subtree can exceed 100 (matches the existing `PytestProcessInfo.cpu_percent` contract).
- `peak_cpu = max(samples)` (`pytest_process.py`) now reflects the subtree peak.
- The table already normalizes + clamps for display (`table_tab.py` via `normalize_cpu_percent`), so no display change is needed.
- **Memory%** is intentionally left as the main-process RSS (out of scope); commit charge remains subtree as before.

`src/pytest_fly/pytest_runner/process_monitor.py` (sampler), `src/pytest_fly/interfaces.py` (doc).

## The test

`tests/test_process_monitor_cpu_subtree.py` monitors a root whose busy work is in a **great-grandchild** (root → idle app → idle subprocess → busy `.exe`, the leaf being `sys.executable`) and asserts the reported CPU% reflects it. **Fails pre-change** (`peak = 0.0`, confirmed), **passes after**.

## Verification

- New test: 1 passed; fails against the pre-change monitor (`assert 0.0 > 50.0`).
- Existing `tests/test_pytest_process.py`: 9 passed.
- Full suite: **370 passed**.
- `ruff check` / `ruff format --check` clean; `ty` unchanged at baseline (37 diagnostics, all pre-existing).

Independent of #132 (different file) — mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
