### PR TITLE
Avoid pytest temp-dir symlink-cleanup error on Windows (fixed basetemp)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import faulthandler
 import multiprocessing
 import os
+import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -24,6 +26,34 @@ if os.environ.get("CI"):
     faulthandler.dump_traceback_later(1200, exit=True)
 
 pytest_plugins = "pytester"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """On Windows, route pytest's temp dirs to a fixed basetemp.
+
+    pytest's default temp scheme creates a ``pytest-current`` *directory* symlink and prunes
+    numbered run dirs as an atexit cleanup. On Windows that cleanup calls ``Path.unlink()`` on the
+    directory symlink, which raises ``PermissionError`` (WinError 5) — directory symlinks require
+    ``rmdir`` — producing a noisy "Exception ignored in atexit callback" after every run and, once
+    the symlink gets stuck, leaking numbered run dirs. Giving pytest an explicit ``--basetemp``
+    makes it use that dir directly and skip the numbered-dir + ``pytest-current`` symlink machinery
+    entirely, so the failing path never runs. Scoped to Windows so Linux/CI behavior is unchanged;
+    an explicit ``--basetemp`` on the command line is respected.
+
+    The basetemp lives under the system temp dir (not in the repo) so that tests which create a
+    fake project in ``tmp_path`` and probe its surroundings — e.g. PUT git-version detection that
+    walks parent dirs for ``.git`` — don't accidentally pick up this repo's ``.git``.
+    """
+    if sys.platform != "win32" or config.option.basetemp:
+        return
+    basetemp = Path(tempfile.gettempdir()) / "pytest_fly_basetemp"
+    config.option.basetemp = str(basetemp)
+    # The tmp-path factory captured the (then-empty) option in its own tryfirst pytest_configure,
+    # which runs before this hook. getbasetemp() is lazy, so pushing the resolved path onto the
+    # live factory before any temp dir is created still takes effect.
+    factory = getattr(config, "_tmp_path_factory", None)
+    if factory is not None and getattr(factory, "_basetemp", None) is None:
+        factory._given_basetemp = basetemp.resolve()
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
## Problem

On Windows, after a pytest run you'd see (and it was reported):

```
Exception ignored in atexit callback <function cleanup_numbered_dir ...>:
...
PermissionError: [WinError 5] Access is denied: '...\Temp\pytest-of-JamesAbel\pytest-current'
```

It's **not** a test failure — it's pytest's own `atexit` temp cleanup, and Python ignores the exception (results/exit code unaffected). Root cause: `pytest-current` is a *directory* symlink, and pytest's `cleanup_dead_symlinks` removes it with `Path.unlink()`, which on Windows maps to `DeleteFileW` and refuses directory symlinks with `WinError 5` (those require `rmdir`). It's a pytest/Windows limitation in `_pytest/pathlib.py`.

Secondary effect: once the symlink gets stuck, the run-dir pruning aborts each run, so numbered `pytest-NNNN` dirs stop being cleaned and **leak** (27 had accumulated on the reporting machine).

## Fix

Give pytest an explicit `--basetemp` via a Windows-scoped `pytest_configure` hook in `tests/conftest.py`. When basetemp is set explicitly, pytest uses that directory directly and **skips the numbered-dir + `pytest-current` symlink machinery entirely**, so the failing cleanup path never runs.

- Scoped to `win32` — Linux/CI behavior is unchanged (no symlink bug there).
- Respects an explicit `--basetemp` on the command line.
- The basetemp is a fixed dir under the **system temp** (`tempfile.gettempdir()/pytest_fly_basetemp`), deliberately **not** inside the repo — otherwise tests that build a fake project in `tmp_path` and walk parent dirs for `.git` (the `test_put_version*` suite) would pick up this repo's `.git`. (An earlier in-repo location broke 6 such tests; moving it to system temp fixed them.)

The tmp-path factory reads the basetemp option in its own `tryfirst` `pytest_configure` (before this hook), so the hook also pushes the resolved path onto the live factory — `getbasetemp()` is lazy, so this still takes effect before any temp dir is created.

## Verification

- After the change: full suite **369 passed**, with **no** "Exception ignored in atexit callback" / `WinError 5` / access-denied output.
- Confirmed the hook actually applies: pytest now creates `<system-temp>/pytest_fly_basetemp/...` directly, and no new `pytest-of-*`/`pytest-current` numbered scheme is created.
- Two consecutive runs produce no atexit error and no run-dir accumulation (basetemp is wiped + recreated each session).
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
