### PR TITLE
Revert #134 fixed-basetemp (caused full-session failures on locked temp files)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,6 @@
 import faulthandler
 import multiprocessing
 import os
-import sys
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -26,34 +24,6 @@ if os.environ.get("CI"):
     faulthandler.dump_traceback_later(1200, exit=True)
 
 pytest_plugins = "pytester"
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    """On Windows, route pytest's temp dirs to a fixed basetemp.
-
-    pytest's default temp scheme creates a ``pytest-current`` *directory* symlink and prunes
-    numbered run dirs as an atexit cleanup. On Windows that cleanup calls ``Path.unlink()`` on the
-    directory symlink, which raises ``PermissionError`` (WinError 5) — directory symlinks require
-    ``rmdir`` — producing a noisy "Exception ignored in atexit callback" after every run and, once
-    the symlink gets stuck, leaking numbered run dirs. Giving pytest an explicit ``--basetemp``
-    makes it use that dir directly and skip the numbered-dir + ``pytest-current`` symlink machinery
-    entirely, so the failing path never runs. Scoped to Windows so Linux/CI behavior is unchanged;
-    an explicit ``--basetemp`` on the command line is respected.
-
-    The basetemp lives under the system temp dir (not in the repo) so that tests which create a
-    fake project in ``tmp_path`` and probe its surroundings — e.g. PUT git-version detection that
-    walks parent dirs for ``.git`` — don't accidentally pick up this repo's ``.git``.
-    """
-    if sys.platform != "win32" or config.option.basetemp:
-        return
-    basetemp = Path(tempfile.gettempdir()) / "pytest_fly_basetemp"
-    config.option.basetemp = str(basetemp)
-    # The tmp-path factory captured the (then-empty) option in its own tryfirst pytest_configure,
-    # which runs before this hook. getbasetemp() is lazy, so pushing the resolved path onto the
-    # live factory before any temp dir is created still takes effect.
-    factory = getattr(config, "_tmp_path_factory", None)
-    if factory is not None and getattr(factory, "_basetemp", None) is None:
-        factory._given_basetemp = basetemp.resolve()
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
## Why

#134 added a Windows-scoped `pytest_configure` hook that pointed pytest at a **fixed** `--basetemp`. That backfired:

- pytest **wipes** the basetemp at the start of every session.
- On Windows, if any file from a prior run is still locked (here a coverage test's `.coverage` file held open by a lingering process — `WinError 32`), the wipe fails.
- It fails inside the session-autouse `_bind_test_prefs` fixture, so **every test errors in setup** — exactly what was reported (`tests/test_db_extra.py EEE ... PermissionError: [WinError 32] ... pytest_fly_basetemp\test_compute_per_test_coverage2\coverage\tests_test_a.py.coverage`).

The default pytest temp scheme never hit this because it creates a **fresh numbered dir per run**, so a locked file in an old dir never blocks a new run. The thing #134 fixed was only a *cosmetic* "Exception ignored in atexit callback" message that didn't affect results. Trading that for a hard, full-session failure is a clear regression, so this restores the default behavior.

## Effect

- Reverts the conftest change from #134 (30 lines, including the `sys`/`tempfile` imports it added).
- The benign atexit symlink-cleanup warning returns, but the suite runs normally again.

## Verification

- `pytest tests/test_db_extra.py tests/test_coverage_tracker.py` — 8 passed (these were erroring before the revert).
- Also cleaned the stale `…\Temp\pytest_fly_basetemp` directory locally.

## Follow-up (separate, optional)

If the cosmetic atexit warning is worth addressing, a **safe** approach is to remove the `pytest-current` symlink at session end with the correct API (`rmdir`), which silences it **without** wiping any shared directory — avoiding the lock-on-wipe failure this PR reverts. Happy to do that as its own PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
