### PR TITLE
Fix window position drift on restore (saveGeometry/restoreGeometry)

### DIFF
--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -12,7 +12,7 @@ from dataclasses import replace
 from pathlib import Path
 from queue import Empty
 
-from PySide6.QtCore import QCoreApplication, QRect, QTimer
+from PySide6.QtCore import QByteArray, QCoreApplication, QRect, QTimer
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
     QApplication,
@@ -135,19 +135,20 @@ class FlyAppMainWindow(QMainWindow):
         if space_dimension.width() != wide_character_dimension.width():
             log.warning(f"monospace font not used (font={font})")
 
-        # restore window size and position
+        # Restore window geometry. saveGeometry/restoreGeometry round-trips the exact frame
+        # position, size, and maximized/fullscreen state (and clamps to the available screens),
+        # which a manual frame-rect save + setGeometry restore cannot — setGeometry sets the
+        # client area while frameGeometry includes the frame, so that pairing drifted the window
+        # by the frame thickness on every reopen.
         pref = get_pref()
-        # ensure window is not off the screen
-        screen = QApplication.primaryScreen()
-        screen_geometry = screen.availableGeometry()
-        restore_rect = QRect(int(float(pref.window_x)), int(float(pref.window_y)), int(float(pref.window_width)), int(float(pref.window_height)))
-        if not screen_geometry.contains(restore_rect):
-            padding = 0.1  # when resizing, leave a little padding on each side
+        restored = bool(pref.window_geometry) and self.restoreGeometry(QByteArray.fromHex(pref.window_geometry.encode("ascii")))
+        if not restored:
+            # First run (or unreadable geometry): size to a padded fraction of the primary screen.
+            screen_geometry = QApplication.primaryScreen().availableGeometry()
+            padding = 0.1  # leave a little padding on each side
             screen_width = screen_geometry.width()
             screen_height = screen_geometry.height()
-            restore_rect = QRect(int(padding * screen_width), int(padding * screen_height), int((1.0 - 2 * padding) * screen_width), int((1.0 - 2 * padding) * screen_height))
-            log.info(f"window is off the screen, moving to {restore_rect=}")
-        self.setGeometry(restore_rect)
+            self.setGeometry(QRect(int(padding * screen_width), int(padding * screen_height), int((1.0 - 2 * padding) * screen_width), int((1.0 - 2 * padding) * screen_height)))
 
         self.setWindowTitle(application_name)
 
@@ -207,12 +208,10 @@ class FlyAppMainWindow(QMainWindow):
 
         pref = get_pref()
 
-        # save window size and position using frameGeometry (includes window frame)
-        frame = self.frameGeometry()
-        pref.window_x = frame.x()
-        pref.window_y = frame.y()
-        pref.window_width = frame.width()
-        pref.window_height = frame.height()
+        # Save window geometry via Qt's own serialization (frame, size, and maximized state), so
+        # restoreGeometry() on next launch returns to the exact prior placement. Matches the hex
+        # persistence used for the Run-tab splitters.
+        pref.window_geometry = self.saveGeometry().toHex().data().decode("ascii")
 
         if (pytest_runner := self.run_tab.control_window.pytest_runner) is not None and pytest_runner.is_running():
             pytest_runner.stop()

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -105,10 +105,10 @@ def _ensure_preferences_dir() -> None:
 class FlyPreferences(Pref):
     """Persistent per-PUT user preferences backed by a local SQLite file."""
 
-    window_x: int = attrib(default=-1)
-    window_y: int = attrib(default=-1)
-    window_width: int = attrib(default=-1)
-    window_height: int = attrib(default=-1)
+    # Main-window geometry (position, size, and maximized/fullscreen state) as QWidget.saveGeometry()
+    # hex-encoded. Using Qt's own (de)serialization round-trips the exact frame and screen placement
+    # across multi-monitor / maximized cases; empty = first run.
+    window_geometry: str = attrib(default="")
 
     verbose: bool = attrib(default=False)
     refresh_rate: float = attrib(default=refresh_rate_default)  # display minimum refresh rate in seconds

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -2,7 +2,7 @@
 
 import time
 
-from PySide6.QtCore import QSize
+from PySide6.QtCore import QRect, QSize
 
 from pytest_fly.gui.coverage_tab import CoverageTab
 from pytest_fly.gui.gui_main import FlyAppMainWindow, build_tick_data
@@ -14,6 +14,7 @@ from pytest_fly.interfaces import (
     RunMode,
     ScheduledTest,
 )
+from pytest_fly.preferences import get_pref
 from pytest_fly.pytest_runner.system_monitor import SystemMonitorSample
 
 from .paths import get_temp_dir
@@ -245,3 +246,37 @@ def test_fly_app_main_window_constructs(app):
         # Delete the widget directly — avoids qtbot's close() which would invoke
         # closeEvent (persisting preferences and potentially blocking on cleanup).
         window.deleteLater()
+
+
+def test_window_geometry_round_trips_without_drift(app):
+    """Reopening the app restores to a stable geometry — no per-launch drift.
+
+    Regression for the frameGeometry-save vs setGeometry-restore mismatch (one set the outer
+    frame, the other the client area), which shifted and grew the window on every relaunch.
+    Exercises the real save (closeEvent) and restore (__init__) paths; geometry serialization
+    converges after the first reopen, so two successive reopens must produce identical geometry.
+    """
+    data_dir = get_temp_dir("test_window_geometry_drift")
+
+    class _Event:
+        def accept(self):
+            pass
+
+    def open_and_close(set_rect: QRect | None = None) -> str:
+        window = FlyAppMainWindow(data_dir)
+        window.timer.stop()
+        if set_rect is not None:
+            window.setGeometry(set_rect)
+        window.closeEvent(_Event())  # persists window_geometry and stops the system monitor
+        if window._system_monitor.is_alive():
+            window._system_monitor.terminate()
+            window._system_monitor.join(5.0)
+        window.deleteLater()
+        return get_pref().window_geometry
+
+    open_and_close(QRect(140, 110, 900, 600))  # first launch: set + save a known geometry
+    geometry_after_first_reopen = open_and_close()  # restore it, then re-save
+    geometry_after_second_reopen = open_and_close()  # restore again, re-save
+
+    assert geometry_after_first_reopen != ""
+    assert geometry_after_first_reopen == geometry_after_second_reopen  # stable: no drift


### PR DESCRIPTION
## Problem

When the app reopens, the window doesn't return to exactly its prior position — it drifts (and grows) a little each launch.

**Root cause: a save/restore coordinate-system mismatch.**
- Save (`closeEvent`) used `self.frameGeometry()` — the **outer frame**, including the title bar and borders.
- Restore (`__init__`) used `self.setGeometry()` — which sets the **client area**, excluding the frame.

So each close→reopen shifted the window up-left by the border/title-bar thickness and grew it by the frame size. The int-based scheme also couldn't restore a **maximized/fullscreen** window (a second reason it didn't come back to the same place).

## Fix

Use Qt's own `QWidget.saveGeometry()` / `restoreGeometry()`, which round-trips the exact frame position, size, and maximized/fullscreen state — and clamps to the available screens. Geometry is persisted as a hex string, matching the pattern already used for the Run-tab splitter state (`run_tab.py`).

Per the project's preference for an elegant rewrite over migration shims, the four `window_x/y/width/height` int prefs are replaced by a single `window_geometry` string. A padded-screen default still applies on first run or unreadable data.

- `src/pytest_fly/gui/gui_main.py` — restore in `__init__`, save in `closeEvent`.
- `src/pytest_fly/preferences.py` — `window_geometry: str` replaces the four int fields.

## Test

`tests/test_gui_widgets.py::test_window_geometry_round_trips_without_drift` drives the real `closeEvent` (save) + `__init__` (restore) paths and asserts the persisted geometry is **identical across successive reopens** (no drift). Qt's serialization converges after the first reopen, so two successive reopens must match — verified empirically before writing the assertion.

## Verification

- Full suite **373 passed** (run with the project `.venv`: random order + benchmark/xdist/rerunfailures/etc.).
- `ruff check` / `ruff format --check` clean; `ty` unchanged at baseline (37 diagnostics, all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
