### PR TITLE
Workspace-local storage, configurable PUT, and guided recovery for a missing target path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install pytest-fly
   - **Coverage** — line chart of combined code coverage over time with covered/total line counts
   - **Configuration** — Resume-vs-Check toggle, a reorderable test-ordering aspect list, process
     count, refresh rate, utilization thresholds, tooltip line limit, system-metrics chart window,
-    Progress Graph font size, target project path (restart required to switch projects),
+    Progress Graph font size, target project path (applies on the next run),
     test-results DB directory, and an Expert group (verbose logging, UI performance logging)
   - **About** — system and project information
 - Parallel test execution at the module level with configurable process count.
@@ -51,10 +51,13 @@ complete. The Coverage tab plots coverage over time, and the Table shows per-tes
 Coverage persists across restarts so previously-passed tests contribute to the total.
 - Singleton test support via `@pytest.mark.singleton` — singleton tests run exclusively with no other tests
 executing concurrently.
-- Per-project preferences — each program under test gets its own settings at
-`<project>/.pytest-fly/preferences.db`, so parallelism, run mode, and ordering choices follow the
-project rather than the user. Select the project at startup with `--target <path>` (the last
-selection is remembered across launches) or change it from the Configuration tab and relaunch.
+- Workspace-local storage — pytest-fly keeps everything it produces (preferences, logs, and the
+test-results DB) under `<workspace>/.pytest-fly/`, where the *workspace* is the directory
+pytest-fly is launched from. Nothing is written to per-user "appdir" space, so settings, logs, and
+results follow the project rather than the user.
+- Configurable program under test (PUT) — the project whose tests are collected and run is set
+with `--target <path>` at startup or from the Configuration tab's *Target Project Path* field, and
+takes effect on the next run (no relaunch). See [Choosing Which Tests Run](#choosing-which-tests-run).
 
 # Screenshots
 
@@ -127,6 +130,30 @@ All aspects apply in every run mode, including Restart — prior-run data shapes
 not *which* tests run. Tests missing the data an aspect needs tie for last under that aspect.
 `singleton` tests always run last, regardless of these settings, to maximize parallel throughput
 before exclusive execution begins.
+
+## Choosing Which Tests Run
+
+`pytest-fly` discovers tests by running `pytest --collect-only` against the **Target Project Path**
+(the program under test) and collecting *every* test under that path, recursively. So the simplest
+way to control which tests run is to point the Target Project Path at the directory you want — for
+example, set it to `<project>/tests` to run only the tests there and skip sibling directories such
+as example or demo code.
+
+Set it with `--target <path>` at startup, or in the Configuration tab's **Target Project Path**
+field (Browse… to pick a directory). Changes apply on the next run. Your project-root `pytest.ini`
+/ `pyproject.toml` is still located normally, so `pythonpath`, markers, and other settings keep
+working — only the *collection scope* narrows to the chosen path.
+
+> **Note:** pytest's `testpaths` setting is **not** honored under pytest-fly. pytest-fly passes the
+> Target Project Path to pytest as an explicit positional argument, and an explicit path overrides
+> `testpaths` (which pytest only consults when invoked with no path arguments). To scope collection,
+> use the Target Project Path, or — if you need the Target Project Path to stay at the project root
+> (e.g. for whole-project coverage) — exclude directories with a root `conftest.py`:
+>
+> ```python
+> # conftest.py (project root)
+> collect_ignore_glob = ["fly_demo/*"]
+> ```
 
 # What's Up With The Name?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.18"
+version = "0.4.19"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/scripts/capture_assets.py
+++ b/scripts/capture_assets.py
@@ -36,7 +36,7 @@ from PySide6.QtWidgets import QApplication  # noqa: E402
 
 from demo.demo import generate_tests  # noqa: E402
 from pytest_fly.gui.gui_main import FlyAppMainWindow  # noqa: E402
-from pytest_fly.preferences import init_preferences_for_put  # noqa: E402
+from pytest_fly.paths import init_workspace  # noqa: E402
 
 WINDOW_SIZE = (1700, 900)
 GIF_SAMPLE_INTERVAL_MS = 600
@@ -172,9 +172,9 @@ def main():
     print(f"capture data dir: {data_dir}")
     print(f"target project: {fly_demo_dir}")
 
-    # Bind preference storage to the demo PUT — per-PUT prefs live alongside the demo dir,
-    # so there's nothing to restore on exit.
-    init_preferences_for_put(fly_demo_dir)
+    # Bind the workspace to the demo dir — prefs/logs live in its .pytest-fly/ and the PUT
+    # defaults to it, so there's nothing to restore on exit.
+    init_workspace(fly_demo_dir)
 
     app = QApplication.instance() or QApplication([])
     window = FlyAppMainWindow(data_dir)

--- a/src/pytest_fly/const.py
+++ b/src/pytest_fly/const.py
@@ -1,4 +1,9 @@
 """Application-wide constants."""
 
-# Environment variable that overrides the default data directory.
+# Environment variable that overrides the default test-results DB directory.
 PYTEST_FLY_DATA_DIR_STRING = "PYTEST_FLY_DATA_DIR"
+
+# Environment variable carrying the workspace directory (the directory pytest-fly was launched
+# from) into spawned child processes, which re-import modules fresh and so lose the in-process
+# binding established by paths.init_workspace().
+PYTEST_FLY_WORKSPACE_STRING = "PYTEST_FLY_WORKSPACE"

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -4,6 +4,7 @@ parallelism, refresh rate, and utilization thresholds.
 """
 
 from collections.abc import Callable
+from pathlib import Path
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QDoubleValidator, QIntValidator, QValidator
@@ -45,6 +46,7 @@ from pytest_fly.preferences import (
     graph_font_size_default,
     max_descendant_processes_default,
     refresh_rate_default,
+    set_active_put_path,
     set_ordering_aspects_ordered,
     stall_kill_value_default,
     stall_warn_value_default,
@@ -426,22 +428,26 @@ class Configuration(QWidget):
 
         layout.addWidget(QLabel(""))  # space
 
-        # Target project path (PUT). The PUT is always the directory pytest-fly was launched
-        # from (or an explicit --target); it is not user-configurable here. Per-PUT preferences
-        # live under <PUT>/.pytest-fly/, so changing it requires relaunching from that directory.
+        # Target project path (PUT). Stored as a preference (independent of where pytest-fly keeps
+        # its own data), so it is freely editable here and takes effect on the next test run.
         self._active_put_path = str(get_active_put_path())
         layout.addWidget(QLabel("Target Project Path (program under test)"))
+        target_path_row = QHBoxLayout()
         self.target_project_path_lineedit = QLineEdit()
         self.target_project_path_lineedit.setText(self._active_put_path)
-        self.target_project_path_lineedit.setReadOnly(True)
-        layout.addWidget(self.target_project_path_lineedit)
-        target_path_hint = QLabel("Set by the launch directory or --target. Relaunch pytest-fly from another project to change it.")
+        self.target_project_path_lineedit.editingFinished.connect(self._commit_target_project_path)
+        target_path_row.addWidget(self.target_project_path_lineedit)
+        self.target_project_path_browse = QPushButton("Browse…")
+        self.target_project_path_browse.clicked.connect(self._browse_target_project_path)
+        target_path_row.addWidget(self.target_project_path_browse)
+        layout.addLayout(target_path_row)
+        target_path_hint = QLabel("The project whose tests are run. Applies on the next run; empty resolves to the launch directory.")
         target_path_hint.setStyleSheet("color: gray;")
         layout.addWidget(target_path_hint)
 
         layout.addWidget(QLabel(""))  # space
 
-        # Test results DB directory — empty means use the platform default (platformdirs user data dir).
+        # Test results DB directory — empty means use the workspace-local default (<workspace>/.pytest-fly/).
         default_results_dir = str(get_default_data_dir())
         layout.addWidget(QLabel(f"Test Results DB Directory (empty = default: {default_results_dir})"))
         results_dir_row = QHBoxLayout()
@@ -757,8 +763,32 @@ class Configuration(QWidget):
         if value.isnumeric():
             pref.graph_font_size = max(int(value), minimum_graph_font_size)
 
+    def _commit_target_project_path(self):
+        """Persist the edited target-project (PUT) path; empty input falls back to the workspace dir."""
+        new_value = self.target_project_path_lineedit.text().strip()
+        if not new_value:
+            # Empty means "use the launch directory" — clear the stored override and reflect the resolved path.
+            get_pref().put_path = ""
+            self._active_put_path = str(get_active_put_path())
+            self.target_project_path_lineedit.setText(self._active_put_path)
+            return
+        new_path = Path(new_value).resolve()
+        if str(new_path) == self._active_put_path:
+            return  # no change
+        set_active_put_path(new_path)
+        self._active_put_path = str(new_path)
+        self.target_project_path_lineedit.setText(self._active_put_path)
+
+    def _browse_target_project_path(self):
+        """Open a directory picker to choose the target project (PUT) path."""
+        start = self.target_project_path_lineedit.text().strip() or self._active_put_path
+        selected = QFileDialog.getExistingDirectory(self, "Select target project directory", start)
+        if selected:
+            self.target_project_path_lineedit.setText(selected)
+            self._commit_target_project_path()
+
     def update_test_results_db_dir(self, value: str):
-        """Persist the test-results DB directory override (empty = platform default)."""
+        """Persist the test-results DB directory override (empty = workspace-local default)."""
         pref = get_pref()
         pref.test_results_db_dir = value.strip()
 

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -435,6 +435,12 @@ class Configuration(QWidget):
         target_path_row = QHBoxLayout()
         self.target_project_path_lineedit = QLineEdit()
         self.target_project_path_lineedit.setText(self._active_put_path)
+        self.target_project_path_lineedit.setToolTip(
+            "Tests are collected recursively from this path. To run only a subset (e.g. just your\n"
+            "'tests' directory), point this at that subdirectory.\n\n"
+            "Note: pytest's testpaths setting is not used — pytest-fly passes this path to pytest\n"
+            "explicitly, which overrides testpaths."
+        )
         self.target_project_path_lineedit.editingFinished.connect(self._commit_target_project_path)
         target_path_row.addWidget(self.target_project_path_lineedit)
         self.target_project_path_browse = QPushButton("Browse…")
@@ -786,6 +792,20 @@ class Configuration(QWidget):
         if selected:
             self.target_project_path_lineedit.setText(selected)
             self._commit_target_project_path()
+
+    def refresh_target_project_path(self):
+        """Re-read the configured PUT into the field (e.g. after the missing-path dialog set it)."""
+        self._active_put_path = str(get_active_put_path())
+        self.target_project_path_lineedit.setText(self._active_put_path)
+
+    def showEvent(self, event):
+        """Refresh the PUT field on each show so it always reflects the current preference.
+
+        The missing-path dialog (run-time or startup) can change the PUT out from under this tab;
+        refreshing on show keeps the field current and avoids re-committing a stale path.
+        """
+        self.refresh_target_project_path()
+        super().showEvent(event)
 
     def update_test_results_db_dir(self, value: str):
         """Persist the test-results DB directory override (empty = workspace-local default)."""

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -38,6 +38,7 @@ from .graph_tab import GraphTab
 from .gui_util import PhaseTimer, compute_average_parallelism, compute_time_window, get_font, get_text_dimensions, group_process_infos_by_name
 from .run_tab import RunTab
 from .table_tab import TableTab
+from .target_path_dialog import ensure_valid_target_project_path
 
 log = get_logger()
 
@@ -333,6 +334,13 @@ def fly_main(data_dir: Path, *, auto_start: bool = False, auto_quit_on_done: boo
     app = QApplication([])
     fly_app = FlyAppMainWindow(data_dir)
     fly_app.show()
+
+    # If the configured target project path is missing, guide the user to a valid one right away
+    # rather than letting them discover an empty run later. Skipped under automation (auto_start),
+    # where a modal would block and the path is controlled by the caller.
+    if not auto_start:
+        if ensure_valid_target_project_path(fly_app) is not None:
+            fly_app.configuration.refresh_target_project_path()
 
     if auto_start:
         # Give the window one paint cycle so test discovery has a populated UI to render into.

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -18,12 +18,13 @@ from ...db import PytestProcessInfoDB
 from ...guid import generate_uuid
 from ...interfaces import OrderingAspect, PutVersionInfo, PyTestFlyExitCode, RunMode, ScheduledTest
 from ...logger import get_logger
-from ...preferences import ParallelismControl, duration_to_seconds, get_active_put_path, get_ordering_aspects_ordered, get_pref
+from ...preferences import ParallelismControl, duration_to_seconds, get_ordering_aspects_ordered, get_pref
 from ...put_version import detect_put_version
 from ...pytest_runner.coverage import compute_per_test_coverage
 from ...pytest_runner.ordering import OrderingContext, apply_ordering_aspects
 from ...pytest_runner.pytest_runner import PytestRunner, _AdmissionGateConfig, _StallConfig
 from ...pytest_runner.test_list import GetTests
+from ..target_path_dialog import ensure_valid_target_project_path
 from .control_pushbutton import ControlButton
 from .parallelism_control_box import ParallelismControlBox
 from .run_mode_control_box import RunModeControlBox
@@ -149,9 +150,13 @@ class ControlWindow(QGroupBox):
         """Discover tests and launch a new :class:`PytestRunner`."""
         pref = get_pref()
 
-        # Resolve the PUT path bound at app startup so test discovery and PUT-version
-        # detection use the same root the rest of the app sees.
-        project_root = get_active_put_path()
+        # Resolve the configured PUT for test discovery and PUT-version detection. If it points at
+        # a directory that no longer exists, guide the user to a valid one before discovering;
+        # abort the run if they cancel rather than collecting from a missing path.
+        project_root = ensure_valid_target_project_path(self)
+        if project_root is None:
+            log.info("Run aborted: target project path is not set to an existing directory.")
+            return
         self.put_version_info = detect_put_version(project_root)
         log.info(f"PUT detected: {self.put_version_info}")
 

--- a/src/pytest_fly/gui/target_path_dialog.py
+++ b/src/pytest_fly/gui/target_path_dialog.py
@@ -1,0 +1,117 @@
+"""Modal dialog that guides the user to set a valid Target Project Path (the program under test).
+
+The PUT path is a stored preference, so it can point at a directory that no longer exists — a
+moved or deleted project, or a mistyped ``--target``.  pytest-fly collects the tests it runs from
+this path, so an invalid one would otherwise yield a silent, empty, confusing run.  This dialog
+surfaces the problem and walks the user through choosing a real directory before any run proceeds.
+"""
+
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..logger import get_logger
+from ..preferences import get_active_put_path, set_active_put_path
+
+log = get_logger()
+
+
+class TargetProjectPathDialog(QDialog):
+    """Prompt for an existing directory to use as the Target Project Path.
+
+    The OK button stays disabled until the entered/browsed path is an existing directory, so the
+    dialog can only resolve to a usable PUT.  Accepting persists the choice via
+    :func:`set_active_put_path`.
+    """
+
+    def __init__(self, missing_path: Path, parent: QWidget | None = None):
+        super().__init__(parent)
+        self.setWindowTitle("Target Project Path Not Found")
+        self.setModal(True)
+        self._selected_path: Path | None = None
+
+        layout = QVBoxLayout(self)
+
+        message = QLabel(
+            f"The configured target project path does not exist:\n\n{missing_path}\n\n"
+            "pytest-fly runs the tests found in this directory. Choose the project directory "
+            "(or a subdirectory such as 'tests') whose tests you want to run."
+        )
+        message.setWordWrap(True)
+        layout.addWidget(message)
+
+        row = QHBoxLayout()
+        self.path_lineedit = QLineEdit(str(missing_path))
+        self.path_lineedit.textChanged.connect(self._validate)
+        row.addWidget(self.path_lineedit)
+        self.browse_button = QPushButton("Browse…")
+        self.browse_button.clicked.connect(self._browse)
+        row.addWidget(self.browse_button)
+        layout.addLayout(row)
+
+        self.validation_label = QLabel("")
+        self.validation_label.setStyleSheet("color: #b22222;")
+        layout.addWidget(self.validation_label)
+
+        self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        self.button_box.accepted.connect(self._on_accept)
+        self.button_box.rejected.connect(self.reject)
+        layout.addWidget(self.button_box)
+
+        self._validate(self.path_lineedit.text())
+
+    def _browse(self):
+        """Open a directory picker, seeded from the current text (or the user's home)."""
+        start = self.path_lineedit.text().strip() or str(Path.home())
+        selected = QFileDialog.getExistingDirectory(self, "Select target project directory", start)
+        if selected:
+            self.path_lineedit.setText(selected)
+
+    def _validate(self, text: str) -> bool:
+        """Enable OK only for an existing directory; show a hint otherwise."""
+        candidate = text.strip()
+        ok = bool(candidate) and Path(candidate).is_dir()
+        self.validation_label.setText("" if ok else "Enter or browse to an existing directory.")
+        self.button_box.button(QDialogButtonBox.StandardButton.Ok).setEnabled(ok)
+        return ok
+
+    def _on_accept(self):
+        """Persist the chosen path and close, if it is a valid directory."""
+        text = self.path_lineedit.text().strip()
+        if not self._validate(text):
+            return
+        self._selected_path = Path(text).resolve()
+        set_active_put_path(self._selected_path)
+        log.info(f"target project path set to: {self._selected_path}")
+        self.accept()
+
+    def selected_path(self) -> Path | None:
+        """Return the persisted path after an accepted dialog, else ``None``."""
+        return self._selected_path
+
+
+def ensure_valid_target_project_path(parent: QWidget | None = None) -> Path | None:
+    """Return a usable Target Project Path, prompting the user if the configured one is missing.
+
+    When the configured PUT is an existing directory it is returned directly (no dialog).
+    Otherwise a guided :class:`TargetProjectPathDialog` is shown; this returns the newly chosen
+    (and persisted) path, or ``None`` if the user cancels.
+    """
+    put_path = get_active_put_path()
+    if put_path.is_dir():
+        return put_path
+    log.warning(f"configured target project path does not exist: {put_path}")
+    dialog = TargetProjectPathDialog(put_path, parent)
+    if dialog.exec() == QDialog.DialogCode.Accepted:
+        return dialog.selected_path()
+    return None

--- a/src/pytest_fly/logger.py
+++ b/src/pytest_fly/logger.py
@@ -14,9 +14,8 @@ from logging import Formatter, Logger
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
-from platformdirs import user_log_dir
-
-from pytest_fly.__version__ import application_name, author
+from pytest_fly.__version__ import application_name
+from pytest_fly.paths import get_log_dir
 
 _LOG_FORMAT = "%(asctime)s %(process)d %(name)s %(levelname)s %(message)s"
 _MAX_BYTES = 10 * 1024 * 1024
@@ -26,10 +25,13 @@ _log_directory: Path | None = None
 
 
 def _resolve_log_directory() -> Path:
-    """Deterministic log directory, shared by parent and spawn children."""
-    log_dir = Path(user_log_dir(application_name, author))
-    log_dir.mkdir(parents=True, exist_ok=True)
-    return log_dir
+    """Workspace-local log directory (``<workspace>/.pytest-fly/logs/``), shared by parent and spawn children.
+
+    Spawn children re-import this module without the parent's in-process workspace binding,
+    but :func:`pytest_fly.paths.get_log_dir` falls back to the inherited ``PYTEST_FLY_WORKSPACE``
+    environment variable, so they resolve the same directory.
+    """
+    return get_log_dir()
 
 
 def _purge_process_monitor_logs(log_dir: Path) -> None:

--- a/src/pytest_fly/main.py
+++ b/src/pytest_fly/main.py
@@ -8,8 +8,8 @@ from .__version__ import application_name
 from .gui import fly_main
 from .gui.about_tab.project_info import get_project_info
 from .logger import get_logger, init_parent_logger
-from .paths import get_default_data_dir
-from .preferences import get_pref, init_preferences_for_put
+from .paths import get_default_data_dir, get_workspace_dir, init_workspace
+from .preferences import get_active_put_path, get_pref, set_active_put_path
 from .put_version import detect_put_version
 
 log = get_logger(application_name)
@@ -17,7 +17,12 @@ log = get_logger(application_name)
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog=application_name, description="pytest-fly: pytest runner and observer GUI")
-    parser.add_argument("--target", type=Path, default=None, help="Target project directory (the program under test). Defaults to the current working directory.")
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=None,
+        help="Target project directory (the program under test). Persisted as the configured PUT; defaults to the last configured value, else the launch directory.",
+    )
     parser.add_argument("--data-dir", type=Path, default=None, help="Override the test-results DB directory for this run. Takes precedence over the saved preference and the platform default.")
     parser.add_argument("--auto-start", action="store_true", help="Automatically click the Run button shortly after the window appears.")
     parser.add_argument("--auto-quit-on-done", action="store_true", help="Close the window once the active test run finishes. Pair with --auto-start for unattended runs.")
@@ -37,21 +42,27 @@ def app_main(argv: list[str] | None = None):
 
     args = _parse_args(argv)
 
-    # Resolve the PUT first; per-PUT preferences live under <PUT>/.pytest-fly/, so every
-    # subsequent pref access (including verbose-flag-driven log init) needs this bound.
-    # Precedence: explicit --target > current working directory. The PUT is always local
-    # to where pytest-fly is launched; there is no global "remembered target" pointer.
-    put_path = args.target.resolve() if args.target is not None else Path.cwd()
-    init_preferences_for_put(put_path)
-    log.info(f"program under test path: {put_path}")
+    # Bind the workspace first: pytest-fly's storage (preferences, logs, results DB) all lives
+    # under <workspace>/.pytest-fly/, where the workspace is the launch directory. Every
+    # subsequent pref/log access depends on this binding.
+    init_workspace(Path.cwd())
 
     pref = get_pref()
+    # The PUT (program under test) is a stored preference, independent of the workspace.
+    # An explicit --target persists as the new configured PUT; otherwise the stored value
+    # (or the workspace dir, when unset) is used.
+    if args.target is not None:
+        set_active_put_path(args.target.resolve())
+    put_path = get_active_put_path()
+
     init_parent_logger(verbose=pref.verbose)
+    log.info(f"workspace: {get_workspace_dir()}")
+    log.info(f"program under test path: {put_path}")
 
     project_info = get_project_info()
     log.info(f"{project_info.application_name} version {project_info.version}")
 
-    # Precedence: --data-dir CLI > pref.test_results_db_dir > platform default.
+    # Precedence: --data-dir CLI > pref.test_results_db_dir > workspace-local default.
     if args.data_dir is not None:
         data_dir = args.data_dir.resolve()
     elif pref.test_results_db_dir:

--- a/src/pytest_fly/paths.py
+++ b/src/pytest_fly/paths.py
@@ -1,27 +1,82 @@
-"""Resolve the application data directory.
+"""Resolve pytest-fly's local storage paths.
 
-The program-under-test (PUT) is always the directory pytest-fly is launched from
-(or an explicit ``--target``); there is no global "remembered target" pointer, so
-configuration stays local to each project rather than persisting per-user.
+pytest-fly keeps everything it produces — preferences, logs, and the test-results
+database — under ``<workspace>/.pytest-fly/``, where the *workspace* is the directory
+pytest-fly was launched from.  Nothing lives in the per-user "appdir" space.
+
+The program-under-test (PUT) — the project whose tests are run — is a separate,
+user-configurable preference (see :func:`pytest_fly.preferences.get_active_put_path`)
+and does *not* affect where this storage lives.  Decoupling the two means the PUT can be
+changed freely without moving the preference DB or needing a global "remembered target"
+pointer.
 """
 
 import os
-from functools import cache
 from pathlib import Path
 
-from platformdirs import user_data_dir
+from .__version__ import application_name
+from .const import PYTEST_FLY_DATA_DIR_STRING, PYTEST_FLY_WORKSPACE_STRING
 
-from .__version__ import application_name, author
-from .const import PYTEST_FLY_DATA_DIR_STRING
+fly_dir_name = f".{application_name}"  # ".pytest-fly" — hidden storage dir inside the workspace
+preferences_file_name = "preferences.db"
+_log_subdir_name = "logs"
+
+_workspace_dir: Path | None = None
 
 
-@cache
-def get_default_data_dir() -> Path:
-    """Return the application data directory, creating it if necessary.
+def init_workspace(workspace_dir: Path) -> None:
+    """Bind pytest-fly's storage root to *workspace_dir* (the launch directory).
 
-    Checks the ``PYTEST_FLY_DATA_DIR`` environment variable first; falls back
-    to the platform-standard user data directory (via ``platformdirs``).
+    Also exported via the ``PYTEST_FLY_WORKSPACE`` environment variable so spawned child
+    processes — which re-import this module with no in-process binding — resolve the same
+    storage paths (e.g. for their per-child log files).
     """
-    data_dir = Path(os.environ.get(PYTEST_FLY_DATA_DIR_STRING, Path(user_data_dir(application_name, author))))
+    global _workspace_dir
+    _workspace_dir = workspace_dir.resolve()
+    os.environ[PYTEST_FLY_WORKSPACE_STRING] = str(_workspace_dir)
+
+
+def get_workspace_dir() -> Path:
+    """Return the workspace directory bound via :func:`init_workspace`.
+
+    In a spawned child the in-process binding is absent, so fall back to the
+    ``PYTEST_FLY_WORKSPACE`` environment variable inherited from the parent.
+    """
+    global _workspace_dir
+    if _workspace_dir is None:
+        env = os.environ.get(PYTEST_FLY_WORKSPACE_STRING)
+        if not env:
+            raise RuntimeError("init_workspace() must be called before resolving storage paths")
+        _workspace_dir = Path(env)
+    return _workspace_dir
+
+
+def get_fly_data_dir() -> Path:
+    """Return ``<workspace>/.pytest-fly/`` — the root for preferences, logs, and the results DB."""
+    fly_dir = Path(get_workspace_dir(), fly_dir_name)
+    fly_dir.mkdir(parents=True, exist_ok=True)
+    return fly_dir
+
+
+def get_preferences_db_path() -> Path:
+    """Return the path to the workspace-local preferences DB."""
+    return Path(get_fly_data_dir(), preferences_file_name)
+
+
+def get_log_dir() -> Path:
+    """Return ``<workspace>/.pytest-fly/logs/`` — shared by the parent and spawn children."""
+    log_dir = Path(get_fly_data_dir(), _log_subdir_name)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir
+
+
+def get_default_data_dir() -> Path:
+    """Return the default directory for the test-results DB, creating it if necessary.
+
+    The ``PYTEST_FLY_DATA_DIR`` environment variable overrides it (used by tests / CI);
+    otherwise it lives under ``<workspace>/.pytest-fly/`` like everything else.
+    """
+    env = os.environ.get(PYTEST_FLY_DATA_DIR_STRING)
+    data_dir = Path(env) if env else get_fly_data_dir()
     data_dir.mkdir(parents=True, exist_ok=True)
     return data_dir

--- a/src/pytest_fly/preferences.py
+++ b/src/pytest_fly/preferences.py
@@ -1,11 +1,10 @@
 """
-Persistent user preferences backed by a per-PUT SQLite file via the *pref* library.
+Persistent user preferences backed by a workspace-local SQLite file via the *pref* library.
 
-Each program under test (PUT) gets its own preferences DB at
-``<PUT>/.pytest-fly/preferences.db``.  The PUT path is established at
-application startup via :func:`init_preferences_for_put`; every preference
-accessor downstream — including :class:`FlyPreferences` and the ordering-aspect
-:class:`PrefOrderedSet` — resolves storage relative to that path.
+Preferences live at ``<workspace>/.pytest-fly/preferences.db`` — the *workspace* is the
+directory pytest-fly was launched from (see :mod:`pytest_fly.paths`).  The program-under-test
+(PUT) — the project whose tests are run — is itself one of these preferences (:attr:`put_path`),
+so it can be reconfigured at runtime without moving the preference DB.
 """
 
 from enum import IntEnum
@@ -16,10 +15,9 @@ from pref import Pref, PrefOrderedSet
 
 from .__version__ import application_name, author
 from .interfaces import OrderingAspect, RunMode
+from .paths import get_preferences_db_path, get_workspace_dir, preferences_file_name
 from .platform import get_performance_core_count
 
-preferences_file_name = "preferences.db"
-preferences_dir_name = f".{application_name}"  # ".pytest-fly" — hidden dir inside the PUT root
 _ordering_aspects_table = "ordering_aspects"
 _default_ordering_aspect_seed: list[OrderingAspect] = [OrderingAspect.FAILED_FIRST, OrderingAspect.NEVER_RUN_FIRST]
 
@@ -66,39 +64,23 @@ class ParallelismControl(IntEnum):
     DYNAMIC = 2  # automatically dynamically determine max number of processes to run in parallel, while trying to avoid high utilization thresholds (see utilization_high_threshold)
 
 
-_active_put_path: Path | None = None
-
-
-def init_preferences_for_put(put_path: Path) -> None:
-    """Bind preference storage to ``put_path`` for the current process.
-
-    Must be called once at startup before any :func:`get_pref` or
-    :func:`get_ordering_aspects_set` call — the PUT path drives the SQLite
-    location for both :class:`FlyPreferences` and the ordering-aspect
-    :class:`PrefOrderedSet`.  Calling again with a different path invalidates
-    the cached pref instance so the next access reopens against the new PUT.
-    """
-    global _active_put_path
-    resolved = put_path.resolve()
-    if _active_put_path != resolved:
-        _active_put_path = resolved
-        reset_pref_cache()
-
-
 def get_active_put_path() -> Path:
-    """Return the PUT path bound via :func:`init_preferences_for_put`."""
-    if _active_put_path is None:
-        raise RuntimeError("init_preferences_for_put() must be called before accessing preferences")
-    return _active_put_path
+    """Return the configured program-under-test path.
+
+    The PUT is stored in :attr:`FlyPreferences.put_path`; an empty value (the default)
+    means "use the workspace directory", so a freshly launched project tests itself.
+    """
+    put = get_pref().put_path
+    return Path(put).resolve() if put else get_workspace_dir()
 
 
-def get_preferences_db_path() -> Path:
-    """Return the path to the per-PUT preferences DB."""
-    return Path(get_active_put_path(), preferences_dir_name, preferences_file_name)
+def set_active_put_path(put_path: Path) -> None:
+    """Persist *put_path* as the configured program-under-test.
 
-
-def _ensure_preferences_dir() -> None:
-    get_preferences_db_path().parent.mkdir(parents=True, exist_ok=True)
+    Takes effect on the next test run — :meth:`ControlWindow.run` reads
+    :func:`get_active_put_path` afresh — so no application restart is required.
+    """
+    get_pref().put_path = str(put_path.resolve())
 
 
 @attrs
@@ -109,6 +91,10 @@ class FlyPreferences(Pref):
     # hex-encoded. Using Qt's own (de)serialization round-trips the exact frame and screen placement
     # across multi-monitor / maximized cases; empty = first run.
     window_geometry: str = attrib(default="")
+
+    # Program-under-test directory (the project whose tests are run). Empty = use the workspace
+    # dir (the launch directory). Editable in the Configuration tab; resolve via get_active_put_path().
+    put_path: str = attrib(default="")
 
     verbose: bool = attrib(default=False)
     refresh_rate: float = attrib(default=refresh_rate_default)  # display minimum refresh rate in seconds
@@ -151,7 +137,7 @@ class FlyPreferences(Pref):
     run_tab_splitter_state: str = attrib(default="")  # Run-tab top-vs-failed-tests splitter (QSplitter.saveState() hex-encoded)
     run_tab_bottom_splitter_state: str = attrib(default="")  # Run-tab bottom pane: failed-tests-vs-live-output splitter (QSplitter.saveState() hex-encoded)
 
-    test_results_db_dir: str = attrib(default="")  # override directory for the test-results SQLite DB; empty means use the platform default
+    test_results_db_dir: str = attrib(default="")  # override directory for the test-results SQLite DB; empty means use the workspace-local default
 
     perf_logging: bool = attrib(default=False)  # log per-tick phase timings (db query, build_tick_data, each tab update) to diagnose UI lag
 
@@ -160,14 +146,14 @@ class FlyPreferences(Pref):
     last_run_start: float = attrib(default=0.0)
 
     def get_sqlite_path(self) -> Path:
-        # Override pref's default appdirs-based resolution so storage lives under the active PUT.
+        # Override pref's default appdirs-based resolution so storage lives in the workspace.
         path = get_preferences_db_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         return path
 
 
 class FlyOrderedSet(PrefOrderedSet):
-    """:class:`PrefOrderedSet` with per-PUT SQLite storage."""
+    """:class:`PrefOrderedSet` with workspace-local SQLite storage."""
 
     def get_sqlite_path(self) -> Path:
         path = get_preferences_db_path()
@@ -182,9 +168,9 @@ _cached_pref_path: Path | None = None
 def get_pref() -> FlyPreferences:
     """Return a :class:`FlyPreferences` instance (reads from / auto-saves to disk).
 
-    The instance is cached process-wide and keyed on the resolved per-PUT
-    storage path, so switching PUT via :func:`init_preferences_for_put` will
-    transparently reopen the right DB on the next access.  Constructing
+    The instance is cached process-wide and keyed on the resolved workspace
+    storage path, so rebinding the workspace via :func:`pytest_fly.paths.init_workspace`
+    transparently reopens the right DB on the next access.  Constructing
     ``FlyPreferences`` issues one SELECT per attribute, so caching matters for
     UI tick performance.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from PySide6.QtWidgets import QApplication
 
-from pytest_fly.preferences import init_preferences_for_put
+from pytest_fly.paths import init_workspace
 
 # Force the 'spawn' multiprocessing start method on all platforms. pytest-fly's controller is
 # multi-threaded (a worker pool plus the stall watchdog) and starts test subprocesses; on POSIX
@@ -27,13 +27,14 @@ pytest_plugins = "pytester"
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _bind_test_prefs(tmp_path_factory):
-    """Bind pref storage to a session-scoped tmp PUT so tests never touch the user's real prefs.
+def _bind_test_workspace(tmp_path_factory):
+    """Bind the workspace to a session-scoped tmp dir so tests never touch the user's real storage.
 
-    Per-test fixtures (e.g. the ordering-aspects suite) can call
-    :func:`init_preferences_for_put` again to redirect into their own tmp dirs.
+    All pytest-fly storage (preferences, logs, results DB) resolves under this workspace.
+    Per-test fixtures (e.g. the ordering-aspects suite) can call :func:`init_workspace`
+    again to redirect into their own tmp dirs.
     """
-    init_preferences_for_put(tmp_path_factory.mktemp("pytest_fly_test_prefs"))
+    init_workspace(tmp_path_factory.mktemp("pytest_fly_test_workspace"))
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,18 +1,21 @@
 """Tests for the Configuration tab preference-editing logic."""
 
+from pathlib import Path
+
 import pytest
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QFileDialog
 
 from pytest_fly.gui.configuration_tab.configuration import Configuration, OrderingAspectsWidget
 from pytest_fly.interfaces import RunMode
-from pytest_fly.preferences import get_pref, init_preferences_for_put
+from pytest_fly.paths import get_workspace_dir, init_workspace
+from pytest_fly.preferences import get_active_put_path, get_pref
 
 
 @pytest.fixture(autouse=True)
-def _isolated_prefs(tmp_path):
-    """Rebind preferences to a per-test tmp dir so edits never touch shared state."""
-    init_preferences_for_put(tmp_path)
+def _isolated_workspace(tmp_path):
+    """Rebind the workspace to a per-test tmp dir so edits never touch shared state."""
+    init_workspace(tmp_path)
 
 
 def test_update_checkbox_prefs(app):
@@ -101,15 +104,40 @@ def test_test_results_db_dir_update(app):
     assert get_pref().test_results_db_dir == "/some/dir"
 
 
-def test_target_project_path_is_read_only(app):
-    """The PUT is set by the launch directory / --target, so the field is display-only."""
+def test_target_project_path_defaults_to_workspace(app):
+    """With no stored PUT, the field shows the workspace dir (empty pref resolves to it)."""
     cfg = Configuration()
-    assert cfg.target_project_path_lineedit.isReadOnly()
-    assert cfg.target_project_path_lineedit.text() == cfg._active_put_path
+    assert get_pref().put_path == ""
+    assert cfg.target_project_path_lineedit.text() == str(get_workspace_dir())
+
+
+def test_commit_target_project_path_persists(app, tmp_path):
+    """Editing the field persists the PUT preference, applied on the next run."""
+    new_dir = tmp_path / "new_target"
+    new_dir.mkdir()
+
+    cfg = Configuration()
+    cfg.target_project_path_lineedit.setText(str(new_dir))
+    cfg._commit_target_project_path()
+
+    assert get_pref().put_path == str(new_dir.resolve())
+    assert get_active_put_path() == new_dir.resolve()
+
+
+def test_commit_empty_target_falls_back_to_workspace(app, tmp_path):
+    """Clearing the field clears the stored PUT and restores the workspace dir."""
+    cfg = Configuration()
+    get_pref().put_path = str(tmp_path / "stale")
+
+    cfg.target_project_path_lineedit.setText("   ")
+    cfg._commit_target_project_path()
+
+    assert get_pref().put_path == ""
+    assert cfg.target_project_path_lineedit.text() == str(get_workspace_dir())
 
 
 def test_browse_dialogs(app, tmp_path, monkeypatch):
-    """The Browse button feeds the picked directory into the results-DB line edit."""
+    """The Browse buttons feed the picked directory into their line edits."""
     picked = str(tmp_path / "picked")
     (tmp_path / "picked").mkdir()
     monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *a, **k: picked)
@@ -117,6 +145,10 @@ def test_browse_dialogs(app, tmp_path, monkeypatch):
     cfg = Configuration()
     cfg._browse_test_results_db_dir()
     assert cfg.test_results_db_dir_lineedit.text() == picked
+
+    cfg._browse_target_project_path()
+    assert cfg.target_project_path_lineedit.text() == picked
+    assert get_pref().put_path == str(Path(picked).resolve())
 
 
 def test_ordering_widget_move_and_toggle(app):

--- a/tests/test_main_app.py
+++ b/tests/test_main_app.py
@@ -1,9 +1,33 @@
 """Tests for the application bootstrap in :mod:`pytest_fly.main`."""
 
+import os
 from pathlib import Path
 
+import pytest
+
+import pytest_fly.paths as paths_module
 from pytest_fly import main as main_module
+from pytest_fly.const import PYTEST_FLY_WORKSPACE_STRING
 from pytest_fly.main import _parse_args, app_main
+from pytest_fly.preferences import reset_pref_cache
+
+
+@pytest.fixture(autouse=True)
+def _restore_workspace_binding():
+    """app_main rebinds the workspace to cwd; restore the session binding afterward.
+
+    Without this, these tests would leave paths._workspace_dir pointing at a deleted tmp dir
+    and break later tests that rely on the session-scoped workspace.
+    """
+    saved_dir = paths_module._workspace_dir
+    saved_env = os.environ.get(PYTEST_FLY_WORKSPACE_STRING)
+    yield
+    paths_module._workspace_dir = saved_dir
+    if saved_env is None:
+        os.environ.pop(PYTEST_FLY_WORKSPACE_STRING, None)
+    else:
+        os.environ[PYTEST_FLY_WORKSPACE_STRING] = saved_env
+    reset_pref_cache()
 
 
 def test_parse_args_defaults():
@@ -24,8 +48,8 @@ def test_parse_args_all_options():
     assert args.auto_quit_on_done is True
 
 
-def test_app_main_resolves_target_and_launches(tmp_path, monkeypatch):
-    """app_main wires the resolved PUT/data dirs into fly_main and creates the data dir."""
+def test_app_main_persists_target_and_launches(tmp_path, monkeypatch):
+    """--target persists as the configured PUT; the workspace roots at the launch dir."""
     captured = {}
 
     def fake_fly_main(data_dir, *, auto_start=False, auto_quit_on_done=False):
@@ -37,33 +61,37 @@ def test_app_main_resolves_target_and_launches(tmp_path, monkeypatch):
     monkeypatch.setattr(main_module, "fly_main", fake_fly_main)
     monkeypatch.setattr(main_module, "init_parent_logger", lambda verbose: None)
 
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
     target = tmp_path / "put"
     target.mkdir()
     data_dir = tmp_path / "results"
 
     app_main(["--target", str(target), "--data-dir", str(data_dir), "--auto-start"])
 
+    assert main_module.get_workspace_dir() == workspace.resolve()  # storage rooted at the launch dir
+    assert main_module.get_active_put_path() == target.resolve()  # --target persisted as the PUT
     assert captured["data_dir"] == data_dir.resolve()
     assert captured["auto_start"] is True
     assert captured["auto_quit_on_done"] is False
     assert data_dir.exists()  # app_main creates the data dir
 
 
-def test_app_main_uses_cwd_when_no_target_arg(tmp_path, monkeypatch):
-    """With no --target, app_main resolves the PUT to the current working directory."""
+def test_app_main_put_defaults_to_workspace_when_no_target(tmp_path, monkeypatch):
+    """With no --target and no stored PUT, the PUT resolves to the workspace (launch) dir."""
     captured = {}
 
     monkeypatch.setattr(main_module, "fly_main", lambda data_dir, **kw: captured.setdefault("data_dir", data_dir))
     monkeypatch.setattr(main_module, "init_parent_logger", lambda verbose: None)
-    monkeypatch.setattr(main_module, "init_preferences_for_put", lambda put_path: captured.setdefault("put_path", put_path))
 
-    cwd = tmp_path / "cwd_put"
-    cwd.mkdir()
-    monkeypatch.chdir(cwd)
+    workspace = tmp_path / "workspace2"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
 
     data_dir = tmp_path / "results2"
     app_main(["--data-dir", str(data_dir)])
 
-    # The PUT is the cwd; nothing global was consulted.
-    assert captured["put_path"].resolve() == cwd.resolve()
+    assert main_module.get_active_put_path() == workspace.resolve()
     assert captured["data_dir"] == data_dir.resolve()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,28 +1,59 @@
-"""Tests for paths.get_default_data_dir."""
+"""Tests for workspace-rooted storage paths in :mod:`pytest_fly.paths`."""
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
-from pytest_fly.const import PYTEST_FLY_DATA_DIR_STRING
-from pytest_fly.paths import get_default_data_dir
-
-
-def test_env_var_overrides_default(monkeypatch):
-    with TemporaryDirectory() as tmp:
-        override = Path(tmp, "custom_data")
-        monkeypatch.setenv(PYTEST_FLY_DATA_DIR_STRING, str(override))
-        get_default_data_dir.cache_clear()
-
-        result = get_default_data_dir()
-
-        assert result == override
-        assert result.is_dir()
+from pytest_fly.const import PYTEST_FLY_DATA_DIR_STRING, PYTEST_FLY_WORKSPACE_STRING
+from pytest_fly.paths import (
+    fly_dir_name,
+    get_default_data_dir,
+    get_fly_data_dir,
+    get_log_dir,
+    get_preferences_db_path,
+    get_workspace_dir,
+    init_workspace,
+)
 
 
-def test_default_when_env_var_missing(monkeypatch):
+def test_storage_paths_root_under_workspace(tmp_path):
+    """Prefs, logs, and the data dir all live under <workspace>/.pytest-fly/."""
+    init_workspace(tmp_path)
+
+    fly_dir = get_fly_data_dir()
+    assert fly_dir == tmp_path.resolve() / fly_dir_name
+    assert fly_dir.is_dir()
+    assert get_preferences_db_path() == fly_dir / "preferences.db"
+    assert get_log_dir() == fly_dir / "logs"
+    assert get_log_dir().is_dir()
+
+
+def test_default_data_dir_is_workspace_local(tmp_path, monkeypatch):
+    """With no env override, the test-results DB dir is the workspace's .pytest-fly dir."""
     monkeypatch.delenv(PYTEST_FLY_DATA_DIR_STRING, raising=False)
-    get_default_data_dir.cache_clear()
+    init_workspace(tmp_path)
 
     result = get_default_data_dir()
 
+    assert result == tmp_path.resolve() / fly_dir_name
     assert result.is_dir()
+
+
+def test_env_var_overrides_default_data_dir(tmp_path, monkeypatch):
+    """PYTEST_FLY_DATA_DIR takes precedence over the workspace-local default."""
+    override = tmp_path / "custom_data"
+    monkeypatch.setenv(PYTEST_FLY_DATA_DIR_STRING, str(override))
+    init_workspace(tmp_path)
+
+    result = get_default_data_dir()
+
+    assert result == override
+    assert result.is_dir()
+
+
+def test_workspace_falls_back_to_env_var(tmp_path, monkeypatch):
+    """A child with no in-process binding resolves the workspace from PYTEST_FLY_WORKSPACE."""
+    import pytest_fly.paths as paths_module
+
+    monkeypatch.setattr(paths_module, "_workspace_dir", None)
+    monkeypatch.setenv(PYTEST_FLY_WORKSPACE_STRING, str(tmp_path))
+
+    assert get_workspace_dir() == Path(tmp_path)

--- a/tests/test_preferences_ordering_aspects.py
+++ b/tests/test_preferences_ordering_aspects.py
@@ -3,12 +3,12 @@
 import pytest
 
 from pytest_fly.interfaces import OrderingAspect
+from pytest_fly.paths import init_workspace
 from pytest_fly.preferences import (
     _default_ordering_aspect_seed,
     get_ordering_aspects_ordered,
     get_ordering_aspects_set,
     get_pref,
-    init_preferences_for_put,
     reset_pref_cache,
     set_ordering_aspects_ordered,
 )
@@ -16,12 +16,12 @@ from pytest_fly.preferences import (
 
 @pytest.fixture
 def isolated_prefs(tmp_path):
-    """Bind preference storage to a unique tmp PUT dir for each test.
+    """Bind the workspace to a unique tmp dir for each test.
 
-    Per-PUT preferences live at ``<PUT>/.pytest-fly/preferences.db``; pointing
-    the PUT at ``tmp_path`` gives each test a fresh, isolated DB.
+    All preferences live at ``<workspace>/.pytest-fly/preferences.db``; pointing
+    the workspace at ``tmp_path`` gives each test a fresh, isolated DB.
     """
-    init_preferences_for_put(tmp_path)
+    init_workspace(tmp_path)
     yield tmp_path
     reset_pref_cache()
 

--- a/tests/test_target_path_dialog.py
+++ b/tests/test_target_path_dialog.py
@@ -1,0 +1,91 @@
+"""Tests for the missing-target-project-path guidance dialog."""
+
+import pytest
+from PySide6.QtWidgets import QDialog, QDialogButtonBox, QFileDialog
+
+from pytest_fly.gui.target_path_dialog import TargetProjectPathDialog, ensure_valid_target_project_path
+from pytest_fly.paths import init_workspace
+from pytest_fly.preferences import get_pref
+
+
+@pytest.fixture(autouse=True)
+def _isolated_workspace(tmp_path):
+    """Per-test workspace so the configured PUT (a pref) is isolated."""
+    init_workspace(tmp_path)
+
+
+def test_ensure_returns_existing_put_without_dialog(app, tmp_path, monkeypatch):
+    """A valid configured PUT short-circuits — the dialog is never constructed."""
+    target = tmp_path / "proj"
+    target.mkdir()
+    get_pref().put_path = str(target)
+
+    def _boom(*a, **k):
+        raise AssertionError("dialog should not be shown when the PUT is valid")
+
+    monkeypatch.setattr("pytest_fly.gui.target_path_dialog.TargetProjectPathDialog", _boom)
+
+    assert ensure_valid_target_project_path() == target.resolve()
+
+
+def test_ensure_prompts_and_persists_when_put_missing(app, tmp_path, monkeypatch):
+    """A missing PUT triggers the dialog; an accepted choice is returned and persisted."""
+    get_pref().put_path = str(tmp_path / "gone")
+    chosen = tmp_path / "chosen"
+    chosen.mkdir()
+
+    def fake_exec(self):
+        # Simulate the user picking a valid directory and accepting.
+        self.path_lineedit.setText(str(chosen))
+        self._on_accept()
+        return QDialog.DialogCode.Accepted
+
+    monkeypatch.setattr(TargetProjectPathDialog, "exec", fake_exec)
+
+    result = ensure_valid_target_project_path()
+    assert result == chosen.resolve()
+    assert get_pref().put_path == str(chosen.resolve())
+
+
+def test_ensure_returns_none_when_cancelled(app, tmp_path, monkeypatch):
+    """Cancelling the dialog yields None so callers can abort."""
+    get_pref().put_path = str(tmp_path / "gone")
+    monkeypatch.setattr(TargetProjectPathDialog, "exec", lambda self: QDialog.DialogCode.Rejected)
+    assert ensure_valid_target_project_path() is None
+
+
+def test_dialog_validation_toggles_ok(app, tmp_path):
+    """OK is enabled only while the entered path is an existing directory."""
+    good = tmp_path / "good"
+    good.mkdir()
+    dialog = TargetProjectPathDialog(tmp_path / "missing")
+    ok_button = dialog.button_box.button(QDialogButtonBox.StandardButton.Ok)
+
+    assert not ok_button.isEnabled()  # prefilled missing path
+    dialog.path_lineedit.setText(str(good))
+    assert ok_button.isEnabled()
+    dialog.path_lineedit.setText(str(tmp_path / "nope"))
+    assert not ok_button.isEnabled()
+
+
+def test_dialog_accept_persists_selected_path(app, tmp_path):
+    """Accepting with a valid directory persists it and exposes it via selected_path()."""
+    good = tmp_path / "good"
+    good.mkdir()
+    dialog = TargetProjectPathDialog(tmp_path / "missing")
+    dialog.path_lineedit.setText(str(good))
+    dialog._on_accept()
+
+    assert dialog.selected_path() == good.resolve()
+    assert get_pref().put_path == str(good.resolve())
+
+
+def test_dialog_browse_sets_text(app, tmp_path, monkeypatch):
+    """Browse feeds the picked directory into the line edit."""
+    picked = tmp_path / "picked"
+    picked.mkdir()
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *a, **k: str(picked))
+
+    dialog = TargetProjectPathDialog(tmp_path / "missing")
+    dialog._browse()
+    assert dialog.path_lineedit.text() == str(picked)


### PR DESCRIPTION
@
## Summary

Two related changes that decouple "where pytest-fly stores its data" from "which project it tests", make the target project (PUT) configurable again, and recover gracefully when that path is missing.

### Workspace-local storage + configurable PUT
- New **workspace** concept (`paths.init_workspace`, bound to the launch directory). All pytest-fly storage now lives under `<workspace>/.pytest-fly/`: `preferences.db`, `logs/`, and the test-results DB. Previously logs went to `user_log_dir` and the results DB defaulted to `user_data_dir` (appdir) — nothing lives in appdir space anymore.
- The **PUT** is now an ordinary preference (`FlyPreferences.put_path`, default = workspace dir), editable again in the Configuration tab via a field + **Browse**. Changes apply on the next run — no relaunch, no global "remembered target" pointer (the preference DB no longer lives inside the PUT). `--target` persists as the configured PUT.
- Spawn children inherit the workspace via a `PYTEST_FLY_WORKSPACE` env var, so per-child log files land in the same `logs/` dir.

### Guided recovery for a missing target path
- New `gui/target_path_dialog.py`: `TargetProjectPathDialog` + `ensure_valid_target_project_path()`. When the configured PUT no longer exists (moved/deleted project, mistyped `--target`), the user is guided to a valid directory instead of getting a silent empty run.
- Hooked at startup (skipped under `--auto-start` automation) and before test discovery (`control_window.run()` aborts if cancelled).
- Configuration tab refreshes its path field on `showEvent` so a dialog-set path cannot be clobbered back to the stale value; added a tooltip explaining recursive collection and that `testpaths` is overridden.

### Docs
- New README "Choosing Which Tests Run" section (collection is recursive from the Target Project Path; point it at e.g. `tests/` to scope; `testpaths` is not honored, with a `collect_ignore_glob` alternative). Corrected now-stale feature bullets to match the new model.

Version bumped 0.4.18 → 0.4.19.

## Test plan
- New `tests/test_paths.py` (workspace-rooted resolution, env override, child env fallback), `tests/test_target_path_dialog.py` (6 tests), updated `tests/test_configuration.py` / `tests/test_main_app.py` / `tests/test_preferences_ordering_aspects.py` / `conftest.py`.
- Full suite green locally: **381 passed**. ruff lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@