### PR TITLE
Latch commit-charge warning until cleared; show absolute GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ pip install pytest-fly
     behaves as Check unless the Configuration tab's *Resume Without Program Check* is set), and
     several panels: a Status panel (completion percentage, pass rate, per-state counts, elapsed
     time, average parallelism, coverage, and estimated time remaining), a System Performance
-    panel (live CPU, memory, disk I/O, and network I/O charts, with memory shown as used/total GB
-    alongside percent), a
+    panel (live CPU, memory, commit-charge, disk I/O, and network I/O charts, with memory and
+    commit charge shown as used/total GB alongside percent; the commit-charge warning latches when
+    the charge crosses the configured threshold — showing both the absolute GB and percent — and
+    stays until dismissed with its **Clear** button), a
     Failed Tests panel with clipboard copy, a Live Output panel streaming pytest output from the
     running tests with elapsed time, last successful run duration, and a progress bar tracking
     progress against the last successful run, and program-under-test version/dirty-git indicators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.19"
+version = "0.4.20"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/system_metrics_window.py
+++ b/src/pytest_fly/gui/run_tab/system_metrics_window.py
@@ -18,7 +18,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
 from PySide6.QtGui import QColor, QPainter, QPen
-from PySide6.QtWidgets import QGridLayout, QGroupBox, QLabel, QSizePolicy, QWidget
+from PySide6.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QLabel, QPushButton, QSizePolicy, QWidget
 
 from ...colors import COMMIT_LINE_COLOR, COMMIT_WARN_COLOR, CPU_LINE_COLOR, DISK_READ_COLOR, DISK_WRITE_COLOR, GRID_LINE_COLOR, MEMORY_LINE_COLOR, NET_RECV_COLOR, NET_SENT_COLOR
 from ...interfaces import PytestRunnerState
@@ -92,6 +92,11 @@ class _MetricChart(QWidget):
         self._min_ts = min_ts
         self._max_ts = max_ts
         self._warn = warn
+        self.update()
+
+    def clear_warn(self) -> None:
+        """Drop the warning color and repaint immediately (used when a latched warning is cleared)."""
+        self._warn = False
         self.update()
 
     def _current_y_max(self) -> float:
@@ -324,13 +329,26 @@ class SystemMetricsWindow(QGroupBox):
         layout.addWidget(self._network_chart, 1, 1)
         layout.addWidget(self._activity_chart, 2, 1)
 
-        # Warning banner — shown only when commit charge crosses the threshold. Spans the full width
-        # beneath the chart grid so it never steals a chart cell.
+        # Warning banner — latched: raised once commit charge crosses the threshold and held (banner +
+        # orange Commit chart) until the user clicks "Clear", so a transient spike that has already
+        # dropped back below the threshold is not missed. Spans the full width beneath the chart grid so
+        # it never steals a chart cell, with the "Clear" button pinned to the right.
+        self._commit_warning_latched = False
         self._commit_warning_label = QLabel("")
         self._commit_warning_label.setWordWrap(True)
         self._commit_warning_label.setStyleSheet("color: #b25400;")  # warning orange (matches the Configuration-tab restart notice)
-        self._commit_warning_label.setVisible(False)
-        layout.addWidget(self._commit_warning_label, 3, 0, 1, 2)
+
+        self._commit_warning_clear_button = QPushButton("Clear")
+        self._commit_warning_clear_button.setToolTip("Dismiss the commit-charge warning. It reappears if the commit charge crosses the threshold again.")
+        self._commit_warning_clear_button.clicked.connect(self._clear_commit_warning)
+
+        self._commit_warning_widget = QWidget()
+        warning_layout = QHBoxLayout(self._commit_warning_widget)
+        warning_layout.setContentsMargins(0, 0, 0, 0)
+        warning_layout.addWidget(self._commit_warning_label, 1)
+        warning_layout.addWidget(self._commit_warning_clear_button, 0)
+        self._commit_warning_widget.setVisible(False)
+        layout.addWidget(self._commit_warning_widget, 3, 0, 1, 2)
 
         layout.setRowStretch(0, 1)
         layout.setRowStretch(1, 1)
@@ -368,14 +386,15 @@ class SystemMetricsWindow(QGroupBox):
         max_ts = now
         samples_list = list(self._samples)
 
-        # Commit-charge warning: evaluate the latest sample against the configured threshold.
+        # Commit-charge warning: evaluate the latest sample against the configured threshold. The warning
+        # latches — once raised it stays (banner + orange Commit chart) until the user clicks "Clear", so
+        # a transient spike that has already dropped back below the threshold is not missed.
         latest = samples_list[-1] if samples_list else None
         if latest is not None and commit_warning_active(latest.commit_percent, latest.commit_total_gb, get_pref().commit_warning_threshold):
-            commit_warn = True
+            self._commit_warning_latched = True
             self._commit_warning_label.setText(f"⚠ System commit charge near limit ({latest.commit_percent:.0f}%) — risk of paging-file failures / crashed workers.")
-        else:
-            commit_warn = False
-        self._commit_warning_label.setVisible(commit_warn)
+        commit_warn = self._commit_warning_latched
+        self._commit_warning_widget.setVisible(commit_warn)
 
         self._cpu_chart.update_data(samples_list, min_ts, max_ts)
         self._memory_chart.update_data(samples_list, min_ts, max_ts)
@@ -386,6 +405,17 @@ class SystemMetricsWindow(QGroupBox):
         activity_list = list(self._activity_samples)
         activity_stalled = bool(activity_list and activity_list[-1].stalled)
         self._activity_chart.update_data(activity_list, min_ts, max_ts, warn=activity_stalled)
+
+    def _clear_commit_warning(self) -> None:
+        """Dismiss the latched commit-charge warning (banner + orange Commit chart).
+
+        The latch re-arms on the next tick whose sample is still over the threshold, so clearing while
+        the commit charge remains high simply re-raises it — the button is meant for acknowledging a
+        spike that has already subsided.
+        """
+        self._commit_warning_latched = False
+        self._commit_warning_widget.setVisible(False)
+        self._commit_chart.clear_warn()
 
     @staticmethod
     def _build_activity_sample(tick: TickData, now: float) -> "_ActivitySample":

--- a/src/pytest_fly/gui/run_tab/system_metrics_window.py
+++ b/src/pytest_fly/gui/run_tab/system_metrics_window.py
@@ -392,7 +392,10 @@ class SystemMetricsWindow(QGroupBox):
         latest = samples_list[-1] if samples_list else None
         if latest is not None and commit_warning_active(latest.commit_percent, latest.commit_total_gb, get_pref().commit_warning_threshold):
             self._commit_warning_latched = True
-            self._commit_warning_label.setText(f"⚠ System commit charge near limit ({latest.commit_percent:.0f}%) — risk of paging-file failures / crashed workers.")
+            self._commit_warning_label.setText(
+                f"⚠ System commit charge near limit ({latest.commit_used_gb:.1f}/{latest.commit_total_gb:.1f} GB, {latest.commit_percent:.0f}%)"
+                " — risk of paging-file failures / crashed workers."
+            )
         commit_warn = self._commit_warning_latched
         self._commit_warning_widget.setVisible(commit_warn)
 

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -1,5 +1,6 @@
 """Additional widget tests targeting paint paths and integration points."""
 
+import dataclasses
 import time
 
 from PySide6.QtCore import QRect, QSize
@@ -137,6 +138,43 @@ def test_activity_chart_y_labels_are_distinct_integers(qtbot):
         assert len(labels) == len(set(labels)), f"duplicate y labels for {y_max=}: {labels}"
         assert all("." not in label for label in labels), f"non-integer y label for {y_max=}: {labels}"
         assert ticks[-1] == float(y_max), f"top tick should equal y_max for {y_max=}: {ticks}"
+
+
+def test_commit_warning_latches_until_cleared(qtbot):
+    """The commit-charge warning persists after the charge drops back, until the user clears it."""
+    window = SystemMetricsWindow(None)
+    qtbot.addWidget(window)
+
+    def _commit_sample(time_stamp: float, commit_percent: float) -> SystemMonitorSample:
+        base = _make_samples(1, now=time_stamp + 0.5)[0]
+        return dataclasses.replace(base, time_stamp=time_stamp, commit_total_gb=32.0, commit_percent=commit_percent)
+
+    threshold = get_pref().commit_warning_threshold
+    now = time.time()
+    over = _commit_sample(now, (threshold + 0.05) * 100.0)
+    under = _commit_sample(now + 0.5, 10.0)
+
+    # Cross the threshold → warning raised.
+    window.ingest_samples([over])
+    window.update_tick()
+    assert window._commit_warning_latched is True
+    assert window._commit_warning_widget.isHidden() is False
+
+    # Charge drops back below the threshold → warning latches (stays visible).
+    window.ingest_samples([under])
+    window.update_tick()
+    assert window._commit_warning_latched is True
+    assert window._commit_warning_widget.isHidden() is False
+
+    # User clears → dismissed, and it stays dismissed while the charge remains low.
+    window._clear_commit_warning()
+    assert window._commit_warning_latched is False
+    assert window._commit_warning_widget.isHidden() is True
+
+    window.ingest_samples([_commit_sample(now + 1.0, 10.0)])
+    window.update_tick()
+    assert window._commit_warning_latched is False
+    assert window._commit_warning_widget.isHidden() is True
 
 
 def test_coverage_tab_paint_forced(qtbot):


### PR DESCRIPTION
## Summary

Make the **System Performance → Commit Charge** warning persist until the user explicitly dismisses it, and include the absolute commit charge (GB) in the message.

### Changes

- **Latched warning** — the commit-charge warning previously cleared itself the instant the latest sample dropped back below the configured threshold, so a transient spike between GUI ticks could be missed. It now latches: once raised, the banner and orange Commit chart are held until dismissed.
- **Clear button** — a new **Clear** button on the warning row dismisses the latched warning. The latch re-arms on the next over-threshold sample, so clearing while the charge is still high simply re-raises it.
- **Absolute GB in the message** — the banner now reads e.g. `30.4/32.0 GB, 95%` instead of just the percentage, matching the Commit chart legend.
- README updated and version bumped to 0.4.20.

### Testing

- Added `test_commit_warning_latches_until_cleared` covering raise → latch-after-drop → clear → stays-cleared.
- Full `tests/test_gui_widgets.py` suite passes; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
