### PR TITLE
Bump version to 0.4.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.20"
+version = "0.4.21"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/interfaces.py
+++ b/src/pytest_fly/interfaces.py
@@ -88,7 +88,8 @@ class PyTestFlyExitCode(IntEnum):
     INTERNAL_ERROR = ExitCode.INTERNAL_ERROR
     USAGE_ERROR = ExitCode.USAGE_ERROR
     NO_TESTS_COLLECTED = ExitCode.NO_TESTS_COLLECTED
-    assert len(ExitCode) == 6  # Number of entries above. Check in case PyTest adds more exit codes.
+    MAX_WARNINGS_ERROR = ExitCode.MAX_WARNINGS_ERROR
+    assert len(ExitCode) == 7  # Number of entries above. Check in case PyTest adds more exit codes.
     MAX_PYTEST_EXIT_CODE = max(item.value for item in ExitCode)
 
     # pytest-fly specific exit codes


### PR DESCRIPTION
## Summary
- Bump version to 0.4.21
- Add `MAX_WARNINGS_ERROR` to `PyTestFlyExitCode` and update the pytest exit-code count assertion from 6 to 7

## Test plan
- CI (ruff, ty, tox matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)