### PR TITLE
Always-on commit status line with peak charge and pagefile breakdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.22"
+version = "0.4.23"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/system_metrics_window.py
+++ b/src/pytest_fly/gui/run_tab/system_metrics_window.py
@@ -17,13 +17,14 @@ from collections import deque
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QPainter, QPen
 from PySide6.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QLabel, QPushButton, QSizePolicy, QWidget
 
 from ...colors import COMMIT_LINE_COLOR, COMMIT_WARN_COLOR, CPU_LINE_COLOR, DISK_READ_COLOR, DISK_WRITE_COLOR, GRID_LINE_COLOR, MEMORY_LINE_COLOR, NET_RECV_COLOR, NET_SENT_COLOR
 from ...interfaces import PytestRunnerState
 from ...preferences import get_pref
-from ...pytest_runner.commit_memory import commit_warning_active
+from ...pytest_runner.commit_memory import PageFileInfo, commit_warning_active, pagefile_breakdown
 from ...pytest_runner.system_monitor import SystemMonitorSample
 from ...tick_data import TickData
 from ..graph_tab.time_axis import TimeAxisMapping, compute_grid_ticks, format_elapsed_label
@@ -329,26 +330,42 @@ class SystemMetricsWindow(QGroupBox):
         layout.addWidget(self._network_chart, 1, 1)
         layout.addWidget(self._activity_chart, 2, 1)
 
-        # Warning banner — latched: raised once commit charge crosses the threshold and held (banner +
-        # orange Commit chart) until the user clicks "Clear", so a transient spike that has already
-        # dropped back below the threshold is not missed. Spans the full width beneath the chart grid so
-        # it never steals a chart cell, with the "Clear" button pinned to the right.
+        # Commit status line — always visible beneath the chart grid (spans the full width so it never
+        # steals a chart cell). It shows the all-time peak commit charge and the pagefile breakdown
+        # (the discs + sizes that, with physical RAM, make up the commit limit). When the commit charge
+        # crosses the configured threshold the warning latches: it is prepended in orange and the Commit
+        # chart turns orange, and both hold (even after a transient spike subsides) until the user resets.
+        self._samples: deque[SystemMonitorSample] = deque()
+        self._activity_samples: deque[_ActivitySample] = deque()
+
         self._commit_warning_latched = False
-        self._commit_warning_label = QLabel("")
-        self._commit_warning_label.setWordWrap(True)
-        self._commit_warning_label.setStyleSheet("color: #b25400;")  # warning orange (matches the Configuration-tab restart notice)
+        # All-time peak commit charge, tracked across the whole run (not just the visible window) and
+        # held until reset. 0.0 total means "no commit signal yet / unavailable".
+        self._commit_peak_percent = 0.0
+        self._commit_peak_used_gb = 0.0
+        self._commit_peak_total_gb = 0.0
+        # Configured pagefiles — read once (a cheap registry read) and refreshed on reset.
+        self._pagefiles: list[PageFileInfo] = pagefile_breakdown()
 
-        self._commit_warning_clear_button = QPushButton("Clear")
-        self._commit_warning_clear_button.setToolTip("Dismiss the commit-charge warning. It reappears if the commit charge crosses the threshold again.")
-        self._commit_warning_clear_button.clicked.connect(self._clear_commit_warning)
+        self._commit_status_label = QLabel("")
+        self._commit_status_label.setWordWrap(False)  # keep the status to a single line
+        self._commit_status_label.setTextFormat(Qt.TextFormat.RichText)
 
-        self._commit_warning_widget = QWidget()
-        warning_layout = QHBoxLayout(self._commit_warning_widget)
-        warning_layout.setContentsMargins(0, 0, 0, 0)
-        warning_layout.addWidget(self._commit_warning_label, 1)
-        warning_layout.addWidget(self._commit_warning_clear_button, 0)
-        self._commit_warning_widget.setVisible(False)
-        layout.addWidget(self._commit_warning_widget, 3, 0, 1, 2)
+        self._commit_reset_button = QPushButton("Reset")
+        self._commit_reset_button.setToolTip("Reset the all-time peak commit charge, refresh the pagefile breakdown, and clear any commit-charge warning.")
+        self._commit_reset_button.clicked.connect(self._reset_commit_stats)
+
+        self._commit_status_widget = QWidget()
+        status_layout = QHBoxLayout(self._commit_status_widget)
+        status_layout.setContentsMargins(0, 0, 0, 0)
+        # Status text takes only its natural width and the "Reset" button sits directly after it (a
+        # trailing stretch absorbs the remaining space), so the button stays next to the text rather
+        # than drifting to the far right edge where it is easy to miss.
+        status_layout.addWidget(self._commit_status_label, 0)
+        status_layout.addWidget(self._commit_reset_button, 0)
+        status_layout.addStretch(1)
+        layout.addWidget(self._commit_status_widget, 3, 0, 1, 2)
+        self._commit_status_label.setText(self._build_commit_status_text())
 
         layout.setRowStretch(0, 1)
         layout.setRowStretch(1, 1)
@@ -357,13 +374,18 @@ class SystemMetricsWindow(QGroupBox):
         layout.setColumnStretch(0, 1)
         layout.setColumnStretch(1, 1)
 
-        self._samples: deque[SystemMonitorSample] = deque()
-        self._activity_samples: deque[_ActivitySample] = deque()
-
     def ingest_samples(self, samples: Iterable[SystemMonitorSample]) -> None:
-        """Append new samples to the ring buffer (called once per GUI tick)."""
+        """Append new samples to the ring buffer (called once per GUI tick).
+
+        The all-time peak commit charge is updated here (not from the pruned window) so it survives
+        samples scrolling out of the visible time window; it is only cleared by an explicit reset.
+        """
         for sample in samples:
             self._samples.append(sample)
+            if sample.commit_total_gb > 0 and sample.commit_percent > self._commit_peak_percent:
+                self._commit_peak_percent = sample.commit_percent
+                self._commit_peak_used_gb = sample.commit_used_gb
+                self._commit_peak_total_gb = sample.commit_total_gb
 
     def update_tick(self, tick: TickData | None = None) -> None:
         """Prune stale samples, repaint all sub-charts, and append/repaint the activity chart."""
@@ -387,17 +409,13 @@ class SystemMetricsWindow(QGroupBox):
         samples_list = list(self._samples)
 
         # Commit-charge warning: evaluate the latest sample against the configured threshold. The warning
-        # latches — once raised it stays (banner + orange Commit chart) until the user clicks "Clear", so
-        # a transient spike that has already dropped back below the threshold is not missed.
+        # latches — once raised it stays (orange status line + orange Commit chart) until the user clicks
+        # "Reset", so a transient spike that has already dropped back below the threshold is not missed.
         latest = samples_list[-1] if samples_list else None
         if latest is not None and commit_warning_active(latest.commit_percent, latest.commit_total_gb, get_pref().commit_warning_threshold):
             self._commit_warning_latched = True
-            self._commit_warning_label.setText(
-                f"⚠ System commit charge near limit ({latest.commit_used_gb:.1f}/{latest.commit_total_gb:.1f} GB, {latest.commit_percent:.0f}%)"
-                " — risk of paging-file failures / crashed workers."
-            )
         commit_warn = self._commit_warning_latched
-        self._commit_warning_widget.setVisible(commit_warn)
+        self._commit_status_label.setText(self._build_commit_status_text())
 
         self._cpu_chart.update_data(samples_list, min_ts, max_ts)
         self._memory_chart.update_data(samples_list, min_ts, max_ts)
@@ -409,16 +427,68 @@ class SystemMetricsWindow(QGroupBox):
         activity_stalled = bool(activity_list and activity_list[-1].stalled)
         self._activity_chart.update_data(activity_list, min_ts, max_ts, warn=activity_stalled)
 
-    def _clear_commit_warning(self) -> None:
-        """Dismiss the latched commit-charge warning (banner + orange Commit chart).
+    def _reset_commit_stats(self) -> None:
+        """Reset the all-time peak commit charge, refresh the pagefile breakdown, and clear the warning.
 
-        The latch re-arms on the next tick whose sample is still over the threshold, so clearing while
-        the commit charge remains high simply re-raises it — the button is meant for acknowledging a
-        spike that has already subsided.
+        The peak is re-seeded from the current sample (so it tracks fresh from "now" rather than
+        snapping back to the still-high reading a moment later). The warning latch re-arms on the next
+        tick whose sample is still over the threshold, so resetting while the commit charge remains high
+        simply re-raises it — the button is meant for acknowledging a spike that has already subsided.
         """
         self._commit_warning_latched = False
-        self._commit_warning_widget.setVisible(False)
+        latest = self._samples[-1] if self._samples else None
+        if latest is not None and latest.commit_total_gb > 0:
+            self._commit_peak_percent = latest.commit_percent
+            self._commit_peak_used_gb = latest.commit_used_gb
+            self._commit_peak_total_gb = latest.commit_total_gb
+        else:
+            self._commit_peak_percent = 0.0
+            self._commit_peak_used_gb = 0.0
+            self._commit_peak_total_gb = 0.0
+        self._pagefiles = pagefile_breakdown()
         self._commit_chart.clear_warn()
+        self._commit_status_label.setText(self._build_commit_status_text())
+
+    def _build_commit_status_text(self) -> str:
+        """Build the always-visible commit status line: peak commit charge + pagefile breakdown,
+        with the latched warning prepended in orange when active."""
+        if self._commit_peak_total_gb > 0:
+            peak = f"Peak commit: {self._commit_peak_used_gb:.1f}/{self._commit_peak_total_gb:.1f} GB ({self._commit_peak_percent:.0f}%)"
+        else:
+            peak = "Peak commit: --"
+        parts = [peak, self._pagefile_summary()]
+        status = "&nbsp;&nbsp;·&nbsp;&nbsp;".join(parts)
+
+        latest = self._samples[-1] if self._samples else None
+        if self._commit_warning_latched and latest is not None:
+            warning = (
+                f"⚠ System commit charge near limit ({latest.commit_used_gb:.1f}/{latest.commit_total_gb:.1f} GB, {latest.commit_percent:.0f}%)"
+                " — risk of paging-file failures / crashed workers."
+            )
+            # Warning orange (matches the Configuration-tab restart notice and the Commit chart accent).
+            # Kept on the same line as the status so the whole strip stays a single row.
+            return f'<span style="color: #b25400;">{warning}</span>&nbsp;&nbsp;·&nbsp;&nbsp;{status}'
+        return status
+
+    def _pagefile_summary(self) -> str:
+        """Summarize the pagefiles that make up the commit limit: which discs and their sizes, plus the
+        live total pagefile (commit limit minus physical RAM, both from the latest sample)."""
+        latest = self._samples[-1] if self._samples else None
+        total_suffix = ""
+        if latest is not None and latest.commit_total_gb > 0 and latest.memory_total_gb > 0:
+            total_gb = max(latest.commit_total_gb - latest.memory_total_gb, 0.0)
+            total_suffix = f" (total {total_gb:.1f} GB)"
+
+        if not self._pagefiles:
+            return "Pagefile: n/a" + total_suffix
+
+        entries = []
+        for pf in self._pagefiles:
+            if pf.system_managed:
+                entries.append(f"{pf.drive} auto")
+            else:
+                entries.append(f"{pf.drive} {pf.maximum_mb / 1024.0:.1f} GB")
+        return "Pagefile: " + ", ".join(entries) + total_suffix
 
     @staticmethod
     def _build_activity_sample(tick: TickData, now: float) -> "_ActivitySample":

--- a/src/pytest_fly/pytest_runner/commit_memory.py
+++ b/src/pytest_fly/pytest_runner/commit_memory.py
@@ -15,6 +15,7 @@ bad memory reading never breaks the GUI or a test run.
 """
 
 import sys
+from dataclasses import dataclass
 
 import psutil
 
@@ -25,6 +26,25 @@ log = get_logger()
 # Log a failed/unsupported read only once — the system monitor calls this ~1 Hz and we
 # do not want to spam the log.
 _warned_once = False
+# Same one-shot guard for the pagefile-config read.
+_pagefile_warned_once = False
+
+
+@dataclass(frozen=True)
+class PageFileInfo:
+    """One configured Windows paging file (a component of the system commit limit).
+
+    Sizes are the *configured* values from the registry (what the Windows "Virtual Memory"
+    dialog shows).  ``system_managed`` entries have ``initial_mb == maximum_mb == 0`` — Windows
+    sizes them automatically, so the configured numbers are zero and the live size is only
+    knowable from the commit limit (RAM + actual pagefile).
+    """
+
+    path: str  # full path, e.g. r"C:\pagefile.sys"
+    drive: str  # drive the pagefile lives on, e.g. "C:"
+    initial_mb: int  # configured initial size in MB (0 when system-managed)
+    maximum_mb: int  # configured maximum size in MB (0 when system-managed)
+    system_managed: bool  # True when Windows manages the size automatically
 
 
 def commit_charge_and_limit() -> tuple[int, int] | None:
@@ -75,6 +95,57 @@ def commit_charge_and_limit() -> tuple[int, int] | None:
             log.warning(f"could not read system commit charge ({e}); commit indicator disabled")
             _warned_once = True
         return None
+
+
+def pagefile_breakdown() -> list[PageFileInfo]:
+    """Return the configured Windows paging files (the discs + sizes that, with physical RAM,
+    make up the system commit limit).
+
+    Read from ``HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Memory Management``'s
+    ``PagingFiles`` value — the same source the Windows "Virtual Memory" dialog uses, so it needs
+    no extra dependency and never blocks (a plain registry read).  Returns ``[]`` on non-Windows
+    platforms and on any error (fail-open) so a bad read never breaks the GUI.
+    """
+    global _pagefile_warned_once
+
+    if sys.platform != "win32":
+        return []
+
+    try:
+        import os
+        import winreg
+
+        system_drive = os.environ.get("SystemDrive", "C:")
+        key_path = r"SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management"
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, key_path) as key:
+            raw, _value_type = winreg.QueryValueEx(key, "PagingFiles")
+
+        # PagingFiles is a REG_MULTI_SZ (list of strings); each line is "<path> <initial> <max>".
+        lines = list(raw) if isinstance(raw, (list, tuple)) else str(raw).splitlines()
+        entries: list[PageFileInfo] = []
+        for line in lines:
+            line = (line or "").strip()
+            if not line:
+                continue
+            parts = line.split()
+            path = parts[0]
+            # System-managed pagefiles on the system drive are recorded as "?:\pagefile.sys".
+            drive = os.path.splitdrive(path)[0] or path[:2]
+            if drive.startswith("?"):
+                drive = system_drive
+            try:
+                initial_mb = int(parts[1]) if len(parts) > 1 else 0
+                maximum_mb = int(parts[2]) if len(parts) > 2 else 0
+            except ValueError:
+                initial_mb = maximum_mb = 0
+            system_managed = initial_mb == 0 and maximum_mb == 0
+            entries.append(PageFileInfo(path=path, drive=drive.upper(), initial_mb=initial_mb, maximum_mb=maximum_mb, system_managed=system_managed))
+        return entries
+    except Exception as e:
+        if not _pagefile_warned_once:
+            log.warning(f"could not read pagefile configuration ({e}); pagefile breakdown disabled")
+            _pagefile_warned_once = True
+        return []
 
 
 def subtree_commit(pid: int) -> int:

--- a/tests/test_commit_memory.py
+++ b/tests/test_commit_memory.py
@@ -6,7 +6,7 @@ import sys
 import pytest
 
 from pytest_fly.pytest_runner import commit_memory
-from pytest_fly.pytest_runner.commit_memory import commit_charge_and_limit, commit_warning_active, subtree_commit
+from pytest_fly.pytest_runner.commit_memory import PageFileInfo, commit_charge_and_limit, commit_warning_active, pagefile_breakdown, subtree_commit
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="commit charge read is Windows-only in v1")
@@ -50,6 +50,40 @@ def test_subtree_commit_current_process():
 def test_subtree_commit_missing_pid_fails_open():
     # A PID that cannot exist degrades to 0 rather than raising.
     assert subtree_commit(-1) == 0
+
+
+def test_pagefile_breakdown_windows():
+    """On Windows the read returns a list of PageFileInfo (typically at least one pagefile)."""
+    result = pagefile_breakdown()
+    assert isinstance(result, list)
+    for pf in result:
+        assert isinstance(pf, PageFileInfo)
+        assert pf.drive  # a drive was parsed
+        assert pf.initial_mb >= 0 and pf.maximum_mb >= 0
+        # system_managed entries have both configured sizes at zero.
+        assert pf.system_managed == (pf.initial_mb == 0 and pf.maximum_mb == 0)
+
+
+def test_pagefile_breakdown_non_windows(monkeypatch):
+    """On non-Windows platforms the read returns [] rather than raising."""
+    monkeypatch.setattr(commit_memory.sys, "platform", "linux")
+    assert pagefile_breakdown() == []
+
+
+def test_pagefile_breakdown_fails_open(monkeypatch):
+    """Any error during the read degrades to [] (fail-open), never an exception."""
+    monkeypatch.setattr(commit_memory.sys, "platform", "win32")
+    monkeypatch.setattr(commit_memory, "_pagefile_warned_once", False)
+
+    real_import = __import__
+
+    def boom(name, *args, **kwargs):
+        if name == "winreg":
+            raise OSError("simulated failure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", boom)
+    assert pagefile_breakdown() == []  # no exception propagates
 
 
 def test_commit_warning_active():

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -140,8 +140,41 @@ def test_activity_chart_y_labels_are_distinct_integers(qtbot):
         assert ticks[-1] == float(y_max), f"top tick should equal y_max for {y_max=}: {ticks}"
 
 
-def test_commit_warning_latches_until_cleared(qtbot):
-    """The commit-charge warning persists after the charge drops back, until the user clears it."""
+def test_commit_status_line_always_visible(qtbot):
+    """The commit status line is always shown — even with no samples it displays peak + pagefile text."""
+    window = SystemMetricsWindow(None)
+    qtbot.addWidget(window)
+
+    assert window._commit_status_widget.isHidden() is False
+    text = window._commit_status_label.text()
+    assert "Peak commit" in text
+    assert "Pagefile" in text
+
+
+def test_commit_peak_tracks_and_resets(qtbot):
+    """The status line reports the all-time peak commit charge and holds it until reset."""
+    window = SystemMetricsWindow(None)
+    qtbot.addWidget(window)
+
+    def _commit_sample(time_stamp: float, commit_percent: float) -> SystemMonitorSample:
+        base = _make_samples(1, now=time_stamp + 0.5)[0]
+        return dataclasses.replace(base, time_stamp=time_stamp, commit_used_gb=commit_percent / 100.0 * 32.0, commit_total_gb=32.0, commit_percent=commit_percent)
+
+    now = time.time()
+    # A high reading sets the peak; a later low reading must not lower it.
+    window.ingest_samples([_commit_sample(now, 80.0)])
+    window.ingest_samples([_commit_sample(now + 0.5, 20.0)])
+    window.update_tick()
+    assert window._commit_peak_percent == 80.0
+    assert "80%" in window._commit_status_label.text()
+
+    # Reset re-seeds the peak from the current (low) sample.
+    window._reset_commit_stats()
+    assert window._commit_peak_percent == 20.0
+
+
+def test_commit_warning_latches_until_reset(qtbot):
+    """The commit-charge warning persists after the charge drops back, until the user resets it."""
     window = SystemMetricsWindow(None)
     qtbot.addWidget(window)
 
@@ -154,27 +187,27 @@ def test_commit_warning_latches_until_cleared(qtbot):
     over = _commit_sample(now, (threshold + 0.05) * 100.0)
     under = _commit_sample(now + 0.5, 10.0)
 
-    # Cross the threshold → warning raised.
+    # Cross the threshold → warning raised (status line carries the warning markup).
     window.ingest_samples([over])
     window.update_tick()
     assert window._commit_warning_latched is True
-    assert window._commit_warning_widget.isHidden() is False
+    assert "near limit" in window._commit_status_label.text()
 
-    # Charge drops back below the threshold → warning latches (stays visible).
+    # Charge drops back below the threshold → warning latches (stays raised).
     window.ingest_samples([under])
     window.update_tick()
     assert window._commit_warning_latched is True
-    assert window._commit_warning_widget.isHidden() is False
+    assert "near limit" in window._commit_status_label.text()
 
-    # User clears → dismissed, and it stays dismissed while the charge remains low.
-    window._clear_commit_warning()
+    # User resets → warning dismissed, and it stays dismissed while the charge remains low.
+    window._reset_commit_stats()
     assert window._commit_warning_latched is False
-    assert window._commit_warning_widget.isHidden() is True
+    assert "near limit" not in window._commit_status_label.text()
 
     window.ingest_samples([_commit_sample(now + 1.0, 10.0)])
     window.update_tick()
     assert window._commit_warning_latched is False
-    assert window._commit_warning_widget.isHidden() is True
+    assert "near limit" not in window._commit_status_label.text()
 
 
 def test_coverage_tab_paint_forced(qtbot):


### PR DESCRIPTION
## Summary

The System Performance **Commit** chart's status line was only shown while a commit-charge warning was latched. This makes it **always visible** and adds two new readouts:

- **All-time peak commit charge** — tracked across the whole run (not just the visible window), held until reset.
- **Pagefile breakdown** — the discs that host pagefiles and their sizes (or `auto` for system-managed), plus the live total pagefile (commit limit − physical RAM).

The latched warning is now prepended in orange on the **same line**. The former **"Clear"** button becomes **"Reset"**: it resets the peak (re-seeded from the current sample), refreshes the pagefile read, and clears the warning latch. The button sits directly after the status text, and the whole strip is kept to a single line.

Pagefile config is read from the registry via `winreg` — no subprocess, fail-open to empty on non-Windows / on error.

Version bumped to `0.4.23`.

## Test plan

- `pytest tests/` — all pass (390)
- New tests: `pagefile_breakdown` (Windows / non-Windows / fail-open); status line always visible; peak tracking + reset; warning latch-until-reset
- `ruff check` / `ruff format` clean; `ty` shows no new diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
