### PR TITLE
Clean up safe pre-existing ty diagnostics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.24"
+version = "0.4.25"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/about_tab/about.py
+++ b/src/pytest_fly/gui/about_tab/about.py
@@ -104,16 +104,17 @@ class About(QWidget):
         vertical_layout.addWidget(self.about_box)
 
         self.worker = AboutDataWorker(data_dir)
-        self.thread = QThread()
-        self.worker.moveToThread(self.thread)
+        # Named with a leading underscore so it does not shadow QObject.thread().
+        self._thread = QThread()
+        self.worker.moveToThread(self._thread)
         self.worker.data_ready.connect(self.update_about_box)
-        self.thread.started.connect(self.worker.run)
-        self.thread.start()
+        self._thread.started.connect(self.worker.run)
+        self._thread.start()
 
     def update_about_box(self, text):
         """
         Update the About box with the given text.
         """
         self.about_box.set_text(text)
-        self.thread.quit()
-        self.thread.wait()
+        self._thread.quit()
+        self._thread.wait()

--- a/src/pytest_fly/gui/configuration_tab/configuration.py
+++ b/src/pytest_fly/gui/configuration_tab/configuration.py
@@ -304,7 +304,7 @@ def _add_labeled_duration(
     """
     label = QLabel(label_text)
     row = QHBoxLayout()
-    row.setAlignment(Qt.AlignLeft)
+    row.setAlignment(Qt.AlignmentFlag.AlignLeft)
     lineedit = QLineEdit()
     lineedit.setText(_format_number(value))
     lineedit.setValidator(QDoubleValidator())
@@ -350,15 +350,15 @@ class Configuration(QWidget):
         # Two columns: general options on the left, the (tall) Liveness / Recovery group on the
         # right. Horizontal room is plentiful; vertical is not, so spread out sideways.
         columns_layout = QHBoxLayout()
-        columns_layout.setAlignment(Qt.AlignTop | Qt.AlignLeft)
+        columns_layout.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
         content.setLayout(columns_layout)
 
         layout = QVBoxLayout()
-        layout.setAlignment(Qt.AlignTop | Qt.AlignLeft)
+        layout.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
         columns_layout.addLayout(layout)
 
         right_column = QVBoxLayout()
-        right_column.setAlignment(Qt.AlignTop | Qt.AlignLeft)
+        right_column.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
         columns_layout.addLayout(right_column)
 
         pref = get_pref()

--- a/src/pytest_fly/gui/coverage_tab/coverage_tab.py
+++ b/src/pytest_fly/gui/coverage_tab/coverage_tab.py
@@ -53,7 +53,7 @@ class _CoverageChart(QWidget):
 
     def paintEvent(self, event):
         painter = QPainter(self)
-        painter.setRenderHint(QPainter.Antialiasing)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
         w = self.width()
         h = self.height()
@@ -126,7 +126,7 @@ class _CoverageChart(QWidget):
             # close the polygon along the bottom
             fill_points.append(QPointF(points[-1][0], margin_top + chart_h))
             fill_points.append(QPointF(points[0][0], margin_top + chart_h))
-            painter.setPen(Qt.NoPen)
+            painter.setPen(Qt.PenStyle.NoPen)
             painter.setBrush(QBrush(COVERAGE_FILL_COLOR))
             painter.drawPolygon(QPolygonF(fill_points))
 

--- a/src/pytest_fly/gui/graph_tab/progress_bar.py
+++ b/src/pytest_fly/gui/graph_tab/progress_bar.py
@@ -128,7 +128,7 @@ class PytestProgressBar(QWidget):
             pytest_run_state = self._run_state
 
             painter = QPainter(self)
-            painter.setRenderHint(QPainter.Antialiasing)
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
             # Draw vertical grid lines (behind the bar)
             grid_ticks = compute_grid_ticks(self.min_time_stamp, self.max_time_stamp, self.width())

--- a/src/pytest_fly/gui/graph_tab/time_axis.py
+++ b/src/pytest_fly/gui/graph_tab/time_axis.py
@@ -157,7 +157,7 @@ class TimeAxisWidget(QWidget):
             return
 
         painter = QPainter(self)
-        painter.setRenderHint(QPainter.Antialiasing)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
         h = self.height()
         tick_height = 5  # short tick mark at the bottom of the axis

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -210,7 +210,7 @@ class FlyAppMainWindow(QMainWindow):
 
     def closeEvent(self, event, /):
 
-        log.info(f"{__class__.__name__}.closeEvent() - entering")
+        log.info(f"{self.__class__.__name__}.closeEvent() - entering")
 
         # If a run is in progress, confirm with the user before tearing it down. Skipped under
         # automation, where a modal prompt would block the programmatic close.
@@ -224,7 +224,7 @@ class FlyAppMainWindow(QMainWindow):
                 QMessageBox.StandardButton.No,
             )
             if response != QMessageBox.StandardButton.Yes:
-                log.info(f"{__class__.__name__}.closeEvent() - cancelled by user")
+                log.info(f"{self.__class__.__name__}.closeEvent() - cancelled by user")
                 event.ignore()
                 return
 

--- a/src/pytest_fly/gui/gui_util.py
+++ b/src/pytest_fly/gui/gui_util.py
@@ -258,7 +258,7 @@ def compute_average_parallelism(infos_by_name: dict[str, list[PytestProcessInfo]
 
 def window_text_color(widget: QWidget) -> QColor:
     """Return the palette's foreground text color for *widget* (respects light/dark themes)."""
-    return widget.palette().color(QPalette.WindowText)
+    return widget.palette().color(QPalette.ColorRole.WindowText)
 
 
 # Per-line width cap. Pytest tracebacks and captured-output lines are often 200+ chars

--- a/src/pytest_fly/gui/run_tab/system_metrics_window.py
+++ b/src/pytest_fly/gui/run_tab/system_metrics_window.py
@@ -14,8 +14,9 @@ Chart style follows ``coverage_tab._CoverageChart`` — custom ``QPainter`` with
 import math
 import time
 from collections import deque
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QPainter, QPen
@@ -44,8 +45,10 @@ class _Series:
 
     label: str
     color: QColor
-    getter: Callable[[object], float]
-    legend_formatter: Callable[[object], str] | None = None
+    # The getter/formatter read attributes off a duck-typed sample — either a SystemMonitorSample
+    # or an _ActivitySample — so the parameter is typed Any rather than a single concrete class.
+    getter: Callable[[Any], float]
+    legend_formatter: Callable[[Any], str] | None = None
 
 
 @dataclass(frozen=True)
@@ -56,6 +59,11 @@ class _ActivitySample:
     running: int  # tests in the RUNNING state
     idle: int  # running tests whose subtree CPU is below the idle epsilon
     stalled: bool  # the watchdog has flagged the run as stalled
+
+
+# A chart renders either system-resource samples or activity samples; both expose ``time_stamp``
+# and the per-series attributes are read through the duck-typed ``_Series.getter``.
+_ChartSample = SystemMonitorSample | _ActivitySample
 
 
 class _MetricChart(QWidget):
@@ -81,14 +89,14 @@ class _MetricChart(QWidget):
         self._y_max_fixed = y_max_fixed
         self._integer_y = integer_y
 
-        self._samples: list[SystemMonitorSample] = []
+        self._samples: Sequence[_ChartSample] = []
         self._min_ts: float | None = None
         self._max_ts: float | None = None
         # When True, series are painted in the warning color (used by the Commit chart
         # when commit charge crosses the configured threshold).
         self._warn = False
 
-    def update_data(self, samples: list[SystemMonitorSample], min_ts: float | None, max_ts: float | None, warn: bool = False):
+    def update_data(self, samples: Sequence[_ChartSample], min_ts: float | None, max_ts: float | None, warn: bool = False):
         self._samples = samples
         self._min_ts = min_ts
         self._max_ts = max_ts
@@ -141,7 +149,7 @@ class _MetricChart(QWidget):
 
     def paintEvent(self, event):
         painter = QPainter(self)
-        painter.setRenderHint(QPainter.Antialiasing)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
         w = self.width()
         h = self.height()

--- a/tests/test_gui_display.py
+++ b/tests/test_gui_display.py
@@ -522,7 +522,7 @@ def test_about(qtbot, tmp_path):
     """About tab should load project and platform info in background."""
     about = About(None, tmp_path)
     qtbot.addWidget(about)
-    qtbot.waitUntil(lambda: not about.thread.isRunning(), timeout=10000)
+    qtbot.waitUntil(lambda: not about._thread.isRunning(), timeout=10000)
     text = about.about_box.toPlainText()
     assert len(text) > 10
 


### PR DESCRIPTION
## Summary

Clears the safe, low-risk subset of `ty`'s pre-existing diagnostics — **53 → 16** — with **no behavioral change**. (`ty` runs as an informational, non-blocking pre-commit hook.)

## Changes

- **Scoped Qt enums** (10 diagnostics): replace deprecated unscoped aliases the PySide6 stubs no longer declare — `Qt.AlignmentFlag.AlignLeft/AlignTop`, `Qt.PenStyle.NoPen`, `QPainter.RenderHint.Antialiasing`, `QPalette.ColorRole.WindowText`.
- **`system_metrics_window` sample typing** (18 diagnostics): type `_Series.getter`/`legend_formatter` as `Callable[[Any], ...]` (they read attributes off duck-typed samples), and widen `_MetricChart` to a covariant `Sequence[_ChartSample]` (`SystemMonitorSample | _ActivitySample`) so both sample kinds type-check.
- **`About.thread` → `About._thread`** (3 diagnostics): stop shadowing the inherited `QObject.thread()` method.
- **`self.__class__.__name__`** in `FlyAppMainWindow.closeEvent` logging (2 diagnostics).

## Deferred (the remaining 16)

Intentionally left for a separate, more careful pass:
- Optional-narrowing in the runner/process layer (`Queue | None`, `pid: int | None`, `_SingletonCoordinator | None`, `proc_name: str | None`).
- `PytestRunner.join` LSP override (returns `bool` vs base `None`).
- `PytestProgressBar` `min/max_time_stamp: float | None` call-site guard.
- Third-party stub limitations: `memoryview.decode`, `pref`'s `file_name` kwarg, `QApplication.instance()` nullability.

## Test plan

- `ty check src` → 16 diagnostics (down from 53), all in the deferred set, no regressions.
- `ruff check src` → passes.
- Smoke-import of all touched GUI modules succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
