### PR TITLE
Add the ability to cancel a pending Stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ pip install pytest-fly
 ## Features
 
 - Real-time monitoring of test execution in a GUI with six tabs:
-  - **Run** — start/stop controls, parallelism and run-mode selectors (Restart or Resume; Resume
+  - **Run** — run/stop controls (**Stop** waits for the running tests to finish and, while
+    pending, becomes **Cancel Stop** so the stop can be called off and the queued tests keep
+    running; **Force Stop** terminates immediately), parallelism and run-mode selectors (Restart or Resume; Resume
     behaves as Check unless the Configuration tab's *Resume Without Program Check* is set), and
     several panels: a Status panel (completion percentage, pass rate, per-state counts, elapsed
     time, average parallelism, coverage, and estimated time remaining), a System Performance
@@ -45,7 +47,9 @@ pip install pytest-fly
 - Three run modes — **Restart** (rerun all tests), **Resume** (skip already-passed tests and
   only re-run failed or unrun tests), and **Check** (resume if the program under test has not
   changed, otherwise restart).
-- Graceful interruption — stop the test suite and resume where it left off.
+- Graceful interruption — stop the test suite and resume where it left off. A pending stop can
+be canceled (**Cancel Stop**) at any point until the last running test finishes, resuming the
+remaining queued tests without losing any progress.
 - Per-process resource monitoring — tracks peak CPU and memory usage for each test module.
 - Estimated time remaining based on prior run durations, accounting for parallelism.
 - Code coverage tracking — each test writes its own coverage data, combined automatically as tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.25"
+version = "0.4.26"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/db/db.py
+++ b/src/pytest_fly/db/db.py
@@ -195,8 +195,8 @@ class PytestProcessInfoDB(MSQLite):
         """Return the set of test node_ids that have ever been run, across all runs and PUT versions.
 
         Filters out queued-but-never-started placeholder rows (``pid IS NULL``) — these are
-        written by :class:`PytestRunner` before a test actually spawns and by ``_drain_queue``
-        when a run is stopped, so they do not count as "ever run."
+        written by :class:`PytestRunner` before a test actually spawns and at soft-stop
+        finalization when a run is stopped, so they do not count as "ever run."
 
         :return: Set of test node_ids.  Empty if the table does not yet exist.
         """

--- a/src/pytest_fly/gui/run_tab/control_window.py
+++ b/src/pytest_fly/gui/run_tab/control_window.py
@@ -58,7 +58,7 @@ class ControlWindow(QGroupBox):
         self.stop_button = ControlButton(self, "Stop", False)
         self.stop_button.setToolTip("Wait for the running tests and then stop")
         layout.addWidget(self.stop_button)
-        self.stop_button.clicked.connect(self.soft_stop)
+        self.stop_button.clicked.connect(self._on_stop_clicked)
 
         self.force_stop_button = ControlButton(self, "Force Stop", False)
         self.force_stop_button.setToolTip("Immediately terminate all running tests")
@@ -89,7 +89,13 @@ class ControlWindow(QGroupBox):
 
     def set_fixed_width(self):
         """Calculate and set a fixed width based on the widest child widget."""
-        max_width = max(self.run_button.sizeHint().width(), self.stop_button.sizeHint().width(), self.force_stop_button.sizeHint().width(), self.parallelism_box.sizeHint().width())
+        # Measure the stop button at its widest label so relabeling it "Cancel Stop"
+        # while a soft stop is pending does not reflow the panel.
+        original_stop_text = self.stop_button.text()
+        self.stop_button.setText("Cancel Stop")
+        stop_width = self.stop_button.sizeHint().width()
+        self.stop_button.setText(original_stop_text)
+        max_width = max(self.run_button.sizeHint().width(), stop_width, self.force_stop_button.sizeHint().width(), self.parallelism_box.sizeHint().width())
         # Add some padding
         max_width += 30
         self.setFixedWidth(max_width)
@@ -138,13 +144,24 @@ class ControlWindow(QGroupBox):
             self.force_stop_button.setEnabled(False)
             self._soft_stop_requested = False
         elif self._soft_stop_requested:
+            # Soft stop pending: the stop button stays enabled, relabeled "Cancel Stop".
             self.run_button.setEnabled(False)
-            self.stop_button.setEnabled(False)
+            self.stop_button.setEnabled(True)
             self.force_stop_button.setEnabled(True)
         else:
             self.run_button.setEnabled(False)
             self.stop_button.setEnabled(True)
             self.force_stop_button.setEnabled(True)
+        self._update_stop_button_label()
+
+    def _update_stop_button_label(self):
+        """Relabel the Stop button as Cancel Stop while a soft stop is pending."""
+        if self._soft_stop_requested:
+            self.stop_button.setText("Cancel Stop")
+            self.stop_button.setToolTip("Cancel the pending stop and keep running the queued tests")
+        else:
+            self.stop_button.setText("Stop")
+            self.stop_button.setToolTip("Wait for the running tests and then stop")
 
     def run(self):
         """Discover tests and launch a new :class:`PytestRunner`."""
@@ -292,6 +309,7 @@ class ControlWindow(QGroupBox):
         self.stop_button.setEnabled(True)
         self.force_stop_button.setEnabled(True)
         self._soft_stop_requested = False
+        self._update_stop_button_label()
 
     def _filter_for_resume(self, tests, prior_results, effective_mode):
         """Filter out already-passed tests when running in RESUME mode.
@@ -337,11 +355,28 @@ class ControlWindow(QGroupBox):
         log.info(f"CHECK: PUT fingerprint unchanged ({current_fp!r}), resuming")
         return RunMode.RESUME
 
+    def _on_stop_clicked(self):
+        """Stop-button dispatcher — request a soft stop, or cancel the pending one."""
+        if self._soft_stop_requested:
+            self.cancel_soft_stop()
+        else:
+            self.soft_stop()
+
     def soft_stop(self):
-        """Stop scheduling new tests but let running tests finish."""
+        """Stop scheduling new tests but let running tests finish. Cancelable until the run winds down."""
         self.pytest_runner.soft_stop()
         self._soft_stop_requested = True
-        self.stop_button.setEnabled(False)
+        self._update_stop_button_label()
+
+    def cancel_soft_stop(self):
+        """Cancel a pending soft stop so the remaining queued tests keep running.
+
+        If the runner reports it is too late (the run already wound down), the pending
+        flag is left set and the next :meth:`refresh_button_state` tick settles the UI.
+        """
+        if self.pytest_runner is not None and self.pytest_runner.cancel_soft_stop():
+            self._soft_stop_requested = False
+        self._update_stop_button_label()
 
     def force_stop(self):
         """Force-stop & reset: terminate all running tests and mark the run complete (Part B/D).
@@ -355,4 +390,6 @@ class ControlWindow(QGroupBox):
         self.run_button.setEnabled(True)
         self.stop_button.setEnabled(False)
         self.force_stop_button.setEnabled(False)
+        self._soft_stop_requested = False
+        self._update_stop_button_label()
         self.run_guid = None

--- a/src/pytest_fly/pytest_runner/pytest_runner.py
+++ b/src/pytest_fly/pytest_runner/pytest_runner.py
@@ -179,6 +179,12 @@ class PytestRunner(Thread):
         self._written_to_db = set()
         self._watchdog: _StallWatchdog | None = None
         self._force_stopped = False  # one-way latch: user (or auto-escalation) force-stopped & reset
+        self._stop_requested = False  # hard stop requested; suppresses pool healing and soft-stop cancel
+        # Runner-owned so a pending soft stop can be canceled: workers share this single
+        # event, and the queue is only drained to STOPPED at run finalization (see run()),
+        # not by the first idle worker — that's what keeps the queued tests recoverable.
+        self._soft_stop_event = Event()
+        self._queue_finalized = False  # one-way latch: the run wound down; a soft stop can no longer be canceled
 
         super().__init__()
 
@@ -227,6 +233,27 @@ class PytestRunner(Thread):
             )
             self._watchdog.start()
 
+        # Supervise the pool until the run winds down. This loop is what makes a soft
+        # stop cancelable: workers no longer drain the queue themselves — they simply
+        # exit — so queued tests stay schedulable until every worker has finished, and
+        # only then are they marked STOPPED (the point of no return). The loop also tops
+        # the pool back up if a worker exited on a soft stop that was later canceled
+        # (covers the window where cancel_soft_stop's respawn undercounts a worker that
+        # was still mid-exit) or died unexpectedly while tests remain queued.
+        while True:
+            with self._pool_lock:
+                self._test_runners = {tid: r for tid, r in self._test_runners.items() if r.is_alive()}
+                if not self._test_runners:
+                    if self._soft_stop_event.is_set() and not self._force_stopped:
+                        self._mark_queued_tests_stopped()
+                    self._queue_finalized = True
+                    break
+                if not (self._soft_stop_event.is_set() or self._stop_requested) and not self._test_queue.empty():
+                    active = [r for r in self._test_runners.values() if not r.is_retiring()]
+                    for _ in range(self.number_of_processes - len(active)):
+                        self._spawn_worker_locked()
+            time.sleep(min(self.update_rate, 1.0))
+
     def _spawn_worker_locked(self) -> None:
         """Start one worker thread pulling from the shared queue. Caller holds ``_pool_lock``."""
         test_runner = _TestRunner(
@@ -239,6 +266,7 @@ class PytestRunner(Thread):
             put_fingerprint=self.put_fingerprint,
             controller_pid=self._controller_pid,
             gate_config=self.gate_config,
+            soft_stop_event=self._soft_stop_event,
         )
         test_runner.start()
         self._test_runners[self._next_worker_id] = test_runner
@@ -383,9 +411,13 @@ class PytestRunner(Thread):
             test_runners = list(self._test_runners.values())
         for test_runner in test_runners:
             test_runner.join(timeout_seconds)
-        return all(not test_runner.is_alive() for test_runner in test_runners)
+        # Also join the runner thread itself so soft-stop finalization (marking the
+        # remaining queue STOPPED) is complete when join() returns.
+        Thread.join(self, timeout_seconds)
+        return all(not test_runner.is_alive() for test_runner in test_runners) and not self.is_alive()
 
     def stop(self):
+        self._stop_requested = True
         try:
             with self._pool_lock:
                 test_runners = list(self._test_runners.values())
@@ -395,14 +427,59 @@ class PytestRunner(Thread):
             log.error(f"error stopping pytest runner,{self.run_guid=},{e}", exc_info=True, stack_info=True)
 
     def soft_stop(self):
-        """Signal workers to finish their current test and stop picking up new ones."""
-        try:
-            with self._pool_lock:
-                test_runners = list(self._test_runners.values())
-            for test_runner in test_runners:
-                test_runner.soft_stop()
-        except (OSError, RuntimeError, PermissionError) as e:
-            log.error(f"error soft-stopping pytest runner,{self.run_guid=},{e}", exc_info=True, stack_info=True)
+        """Signal workers to finish their current test and stop picking up new ones.
+
+        Cancelable via :meth:`cancel_soft_stop` until the run winds down (every worker
+        has exited and the still-queued tests have been marked STOPPED).
+        """
+        self._soft_stop_event.set()
+
+    def cancel_soft_stop(self) -> bool:
+        """Cancel a pending soft stop so the still-queued tests keep running.
+
+        Possible until the run finalizes — all workers exited and the remaining queue was
+        drained to STOPPED. Workers that already exited on the soft stop are respawned so
+        the pool returns to its configured size (the supervision loop in :meth:`run` heals
+        any respawn shortfall from a worker caught mid-exit).
+
+        :return: ``True`` if the soft stop was canceled (or none was pending), ``False`` if it was too late.
+        """
+        with self._pool_lock:
+            if self._queue_finalized or self._force_stopped or self._stop_requested:
+                return False
+            if not self._soft_stop_event.is_set():
+                return True  # nothing pending
+            self._soft_stop_event.clear()
+            if self._started_event.is_set():
+                self._test_runners = {tid: r for tid, r in self._test_runners.items() if r.is_alive()}
+                active = [r for r in self._test_runners.values() if not r.is_retiring()]
+                for _ in range(self.number_of_processes - len(active)):
+                    self._spawn_worker_locked()
+            log.info(f"soft stop canceled ({self.run_guid=})")
+        return True
+
+    def _mark_queued_tests_stopped(self) -> None:
+        """Drain the remaining queue and mark those tests STOPPED in the DB (soft-stop finalization)."""
+        test_queue = self._test_queue
+        if test_queue is None:  # run() has not published the queue yet; nothing to drain
+            return
+        with PytestProcessInfoDB(self.data_dir) as db:
+            while True:
+                try:
+                    scheduled_test = test_queue.get(False)
+                except Empty:
+                    break
+                info = PytestProcessInfo(
+                    self.run_guid,
+                    scheduled_test.node_id,
+                    None,
+                    PyTestFlyExitCode.STOPPED,
+                    None,
+                    time_stamp=time.time(),
+                    put_version=self.put_version,
+                    put_fingerprint=self.put_fingerprint,
+                )
+                db.write(info)
 
     def force_stop_test(self, test_name: str) -> None:
         """Terminate a single running test identified by its node_id.
@@ -721,6 +798,7 @@ class _TestRunner(Thread):
         put_fingerprint: str = "",
         controller_pid: int | None = None,
         gate_config: "_AdmissionGateConfig | None" = None,
+        soft_stop_event: Event | None = None,
     ) -> None:
         """
         :param run_guid: GUID identifying the overall test run.
@@ -732,6 +810,8 @@ class _TestRunner(Thread):
         :param controller_pid: PID of the pytest-fly controller process, used by the
             process-count admission gate to measure the descendant tree.
         :param gate_config: Admission-gate configuration (Part C). ``None`` disables both gates.
+        :param soft_stop_event: Runner-owned soft-stop event shared by all workers, so a
+            pending soft stop can be canceled centrally. ``None`` creates a private one.
         """
         super().__init__()
 
@@ -746,7 +826,7 @@ class _TestRunner(Thread):
 
         self.process: Optional[PytestProcess] = None
         self._stop_event = Event()
-        self._soft_stop_event = Event()
+        self._soft_stop_event = soft_stop_event if soft_stop_event is not None else Event()
         self._retire_event = Event()
         self._force_stop_current_event = Event()
 
@@ -917,24 +997,21 @@ class _TestRunner(Thread):
                 else:
                     self._coordinator.release_normal()
 
-        if self._soft_stop_event.is_set() and not self._stop_event.is_set():
-            self._drain_queue()
+        # On soft stop the worker just exits — it does NOT drain the queue. The queued
+        # tests stay schedulable so the soft stop can be canceled; if it isn't, the
+        # runner marks them STOPPED once every worker has exited (soft-stop finalization).
 
     def _handle_not_acquired(self, scheduled_test: ScheduledTest, test: str) -> None:
         """Dispose of a dequeued test when a slot could not be acquired or admission was aborted.
 
         Shared by the admission-gate-abort path and the coordinator-acquire-failure path:
-        on stop, tree-kill the (not-yet-started) current process; on soft-stop, drain the
-        remaining queue to STOPPED; on retire, hand the dequeued test back to a surviving worker.
+        on stop, tree-kill the (not-yet-started) current process; on soft-stop or retire,
+        hand the dequeued test back — on retire a surviving worker runs it, on soft-stop
+        it is either resumed (stop canceled) or marked STOPPED at finalization.
         """
         if self._stop_event.is_set():
             self._handle_stop_request(test)
-        elif self._soft_stop_event.is_set():
-            self._drain_queue()
-        elif self._retire_event.is_set():
-            # Pool was shrunk while we waited. Hand the test we dequeued back so a
-            # surviving worker runs it, then exit without draining — the remaining
-            # queue belongs to the other workers.
+        elif self._soft_stop_event.is_set() or self._retire_event.is_set():
             self.pytest_test_queue.put(scheduled_test)
 
     def _await_admission(self, should_abort) -> bool:
@@ -983,10 +1060,6 @@ class _TestRunner(Thread):
         """Signal all work to stop as soon as possible."""
         self._stop_event.set()
 
-    def soft_stop(self):
-        """Signal the worker to finish its current test and stop picking up new ones."""
-        self._soft_stop_event.set()
-
     def retire(self):
         """Signal the worker to finish its current test, then exit without draining the queue.
 
@@ -1002,23 +1075,3 @@ class _TestRunner(Thread):
     def force_stop_current(self):
         """Signal this worker to terminate its currently running test."""
         self._force_stop_current_event.set()
-
-    def _drain_queue(self):
-        """Drain remaining tests from the queue and mark them as STOPPED in the DB."""
-        with PytestProcessInfoDB(self.data_dir) as db:
-            while True:
-                try:
-                    scheduled_test = self.pytest_test_queue.get(False)
-                except Empty:
-                    break
-                info = PytestProcessInfo(
-                    self.run_guid,
-                    scheduled_test.node_id,
-                    None,
-                    PyTestFlyExitCode.STOPPED,
-                    None,
-                    time_stamp=time.time(),
-                    put_version=self.put_version,
-                    put_fingerprint=self.put_fingerprint,
-                )
-                db.write(info)

--- a/tests/test_control_window.py
+++ b/tests/test_control_window.py
@@ -11,6 +11,8 @@ class _FakeRunner:
     def __init__(self):
         self.soft_stopped = False
         self.stopped = False
+        self.cancel_calls = 0
+        self.cancel_result = True
         self._running = True
         self._user_complete = False
 
@@ -22,6 +24,10 @@ class _FakeRunner:
 
     def soft_stop(self):
         self.soft_stopped = True
+
+    def cancel_soft_stop(self):
+        self.cancel_calls += 1
+        return self.cancel_result
 
     def stop(self):
         self.stopped = True
@@ -55,12 +61,56 @@ def test_button_states_running_and_stops(app):
     cw.soft_stop()
     assert runner.soft_stopped is True
     assert cw._soft_stop_requested is True
+    assert cw.stop_button.text() == "Cancel Stop"
 
-    cw.refresh_button_state()  # soft-stop-requested branch
-    assert not cw.stop_button.isEnabled()
+    cw.refresh_button_state()  # soft-stop-requested branch: stop button stays enabled as Cancel Stop
+    assert cw.stop_button.isEnabled()
+    assert cw.stop_button.text() == "Cancel Stop"
     assert cw.force_stop_button.isEnabled()
 
     cw.force_stop()
     assert runner.stopped is True
     assert cw.run_button.isEnabled()
+    assert cw.stop_button.text() == "Stop"
     assert cw.run_guid is None
+
+
+def test_cancel_soft_stop(app):
+    """Clicking the stop button while a soft stop is pending cancels it and restores the Stop label."""
+    cw = ControlWindow(None, get_temp_dir("control_cancel"))
+    runner = _FakeRunner()
+    cw.pytest_runner = runner
+
+    cw.soft_stop()
+    assert cw.stop_button.text() == "Cancel Stop"
+
+    cw._on_stop_clicked()  # acts as Cancel Stop while a soft stop is pending
+    assert runner.cancel_calls == 1
+    assert cw._soft_stop_requested is False
+    assert cw.stop_button.text() == "Stop"
+
+    cw.refresh_button_state()  # back to the plain running state
+    assert cw.stop_button.isEnabled()
+    assert cw.stop_button.text() == "Stop"
+
+    cw._on_stop_clicked()  # acts as Stop again
+    assert cw._soft_stop_requested is True
+
+
+def test_cancel_soft_stop_too_late(app):
+    """If the runner reports the cancel came too late, the pending state is left for refresh to settle."""
+    cw = ControlWindow(None, get_temp_dir("control_cancel_late"))
+    runner = _FakeRunner()
+    runner.cancel_result = False
+    cw.pytest_runner = runner
+
+    cw.soft_stop()
+    cw.cancel_soft_stop()
+    assert runner.cancel_calls == 1
+    assert cw._soft_stop_requested is True  # cancel refused; refresh_button_state settles once the run completes
+
+    runner._user_complete = True
+    cw.refresh_button_state()
+    assert cw.run_button.isEnabled()
+    assert cw._soft_stop_requested is False
+    assert cw.stop_button.text() == "Stop"

--- a/tests/test_pytest_runner/test_pytest_runner_cancel_soft_stop.py
+++ b/tests/test_pytest_runner/test_pytest_runner_cancel_soft_stop.py
@@ -1,0 +1,61 @@
+import time
+
+from pytest_fly.db import PytestProcessInfoDB
+from pytest_fly.guid import generate_uuid
+from pytest_fly.interfaces import PyTestFlyExitCode, ScheduledTest
+from pytest_fly.pytest_runner import PytestRunner
+
+from ..paths import get_temp_dir
+
+
+def test_pytest_runner_cancel_soft_stop(app):
+    """Canceling a soft stop resumes the queued tests and the run completes normally."""
+
+    test_name = "test_pytest_runner_cancel_soft_stop"
+
+    data_dir = get_temp_dir(test_name)
+    run_guid = generate_uuid()
+
+    # Schedule a 3-second test first, then an instant test.
+    # With 1 worker process, the second test stays queued while the first runs,
+    # leaving a window to soft-stop and then cancel before the first test finishes.
+    scheduled_tests = [
+        ScheduledTest(node_id="tests/test_3_sec_operation.py", singleton=False, duration=None, coverage=None),
+        ScheduledTest(node_id="tests/test_no_operation.py", singleton=False, duration=None, coverage=None),
+    ]
+
+    runner = PytestRunner(run_guid, scheduled_tests, number_of_processes=1, data_dir=data_dir, update_rate=1.0)
+    runner.start()
+    time.sleep(1.0)  # wait for the first test to start running
+    runner.soft_stop()
+    assert runner.cancel_soft_stop() is True  # cancel while the first test is still running
+    runner.join(60.0)
+
+    assert not runner.is_running()
+
+    with PytestProcessInfoDB(data_dir) as db:
+        results = db.query(run_guid)
+
+    # Both tests should have completed normally — the canceled soft stop must not
+    # have marked the queued test STOPPED.
+    for name in ("tests/test_3_sec_operation.py", "tests/test_no_operation.py"):
+        test_results = [r for r in results if r.name == name]
+        assert test_results, f"no records for {name}"
+        assert test_results[-1].exit_code == PyTestFlyExitCode.OK, name
+
+
+def test_pytest_runner_cancel_soft_stop_too_late(app):
+    """Once a run has wound down, cancel_soft_stop reports it is too late."""
+
+    test_name = "test_pytest_runner_cancel_soft_stop_too_late"
+
+    data_dir = get_temp_dir(test_name)
+    run_guid = generate_uuid()
+
+    scheduled_tests = [ScheduledTest(node_id="tests/test_no_operation.py", singleton=False, duration=None, coverage=None)]
+
+    runner = PytestRunner(run_guid, scheduled_tests, number_of_processes=1, data_dir=data_dir, update_rate=0.5)
+    runner.start()
+    assert runner.join(60.0)
+
+    assert runner.cancel_soft_stop() is False


### PR DESCRIPTION
## Summary

Clicking **Stop** now relabels the button **Cancel Stop**; clicking it again resumes the run, rescheduling the still-queued tests. Force Stop remains available throughout.

Previously cancellation was impossible by construction: the first worker to go idle after a soft stop immediately drained the entire queue to STOPPED, so by the time a user could second-guess the stop there was nothing left to resume.

## How

- **Soft-stop ownership moves up to `PytestRunner`.** All workers share one runner-owned soft-stop event. On soft stop a worker now simply exits (a worker that had already dequeued a test hands it back to the queue) — it no longer drains the queue itself.
- **Finalization is the point of no return.** A supervision loop in `PytestRunner.run()` marks the still-queued tests STOPPED only once every worker has exited. Until then, `cancel_soft_stop()` can clear the event and respawn workers to the configured pool size; the supervision loop also heals any pool shortfall (e.g. a worker caught mid-exit during cancel) and worker crashes while tests remain queued.
- **`PytestRunner.join()` now also joins the runner thread** so soft-stop finalization is complete when `join()` returns.
- **GUI:** the Stop button toggles between "Stop" and "Cancel Stop" while a stop is pending; the control panel width is pre-measured for the wider label so nothing reflows. A cancel that arrives too late (run already wound down) is refused by the runner and the next refresh tick settles the buttons.

Uncanceled soft-stop behavior is unchanged: the in-flight tests finish and everything still queued is recorded STOPPED.

## Testing

- New runner tests: cancel while the first test is running → both tests complete with real pass/fail results; cancel after the run wound down → refused (`False`).
- New/updated ControlWindow tests: Stop↔Cancel Stop toggling, too-late cancel settling via `refresh_button_state`.
- Full suite: 394 passed.
- Verified end-to-end by driving the real GUI in-process against the demo suite (modeled on `scripts/capture_assets.py`): Run → Stop → Cancel Stop (including a rapid toggle probe) → run completes with no STOPPED records; and Run → Stop uncanceled → the 2 queued modules are marked STOPPED while the in-flight module finishes naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
