### PR TITLE
Force Stop clears stale Running rows; header double-click no longer selects column — v0.4.27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.26"
+version = "0.4.27"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/db/db.py
+++ b/src/pytest_fly/db/db.py
@@ -6,6 +6,7 @@ and derives the table schema automatically from the dataclass fields.
 """
 
 import sqlite3
+import time
 from dataclasses import asdict
 from enum import IntEnum, StrEnum
 from pathlib import Path
@@ -148,6 +149,39 @@ class PytestProcessInfoDB(MSQLite):
             rows = [row for row in rows if row.run_guid == run_guid]
 
         return rows
+
+    @typechecked()
+    def mark_test_terminated_if_stale(self, run_guid: str | None, test_name: str) -> bool:
+        """Write a TERMINATED record for *test_name* if its latest record is non-terminal.
+
+        Used to clear a stale "Running" row — a test whose process died (or was lost, e.g.
+        across an app restart) without ever writing a terminal record.  Guarded so a test
+        that actually finished is never clobbered: if the latest record already carries a
+        terminal exit code, nothing is written.
+
+        :param run_guid: The run to search, or ``None`` for the most recent run (matching
+            what the GUI displays when no run is active).
+        :param test_name: The test node_id to mark.
+        :return: ``True`` if a TERMINATED record was written, ``False`` otherwise.
+        """
+        infos = [info for info in self.query(run_guid) if info.name == test_name]
+        if not infos:
+            return False
+        latest = max(infos, key=lambda info: info.time_stamp)
+        if latest.exit_code != PyTestFlyExitCode.NONE:
+            return False  # already terminal — a real result must not be overwritten
+        info = PytestProcessInfo(
+            latest.run_guid,
+            test_name,
+            None,
+            PyTestFlyExitCode.TERMINATED,
+            None,
+            time_stamp=time.time(),
+            put_version=latest.put_version,
+            put_fingerprint=latest.put_fingerprint,
+        )
+        self.write(info)
+        return True
 
     def query_last_pass(self) -> dict[str, tuple[float, float]]:
         """

--- a/src/pytest_fly/gui/gui_main.py
+++ b/src/pytest_fly/gui/gui_main.py
@@ -246,10 +246,19 @@ class FlyAppMainWindow(QMainWindow):
         event.accept()
 
     def _force_stop_single_test(self, test_name: str):
-        """Handle request to terminate a single running test from the table tab."""
+        """Handle request to terminate a single running test from the table tab.
+
+        If no worker is currently running the test — a stale "Running" row whose process
+        died without writing a terminal record, or a run that is no longer active — write
+        a TERMINATED record directly so the row clears instead of showing Running forever.
+        """
         control = self.run_tab.control_window
-        if control.pytest_runner is not None and control.pytest_runner.is_running():
-            control.pytest_runner.force_stop_test(test_name)
+        runner = control.pytest_runner
+        if runner is not None and runner.is_running() and runner.force_stop_test(test_name):
+            return
+        with PytestProcessInfoDB(self.data_dir) as db:
+            if db.mark_test_terminated_if_stale(control.run_guid, test_name):
+                log.info(f'force stop: cleared stale running row for "{test_name}"')
 
     def _drain_system_monitor(self) -> None:
         """Drain queued system-resource samples into the Run tab's metrics widget."""

--- a/src/pytest_fly/gui/table_tab/table_tab.py
+++ b/src/pytest_fly/gui/table_tab/table_tab.py
@@ -114,6 +114,9 @@ class TableTab(QGroupBox):
         self.table_widget.setHorizontalHeaderLabels(["Name", "State", "CPU", "Memory", "Commit", "Runtime", "Coverage", "Last Pass Start", "Last Pass Duration", ""])
         self.table_widget.horizontalHeader().setStretchLastSection(True)
         self.table_widget.horizontalHeader().setSortIndicatorShown(True)
+        # Non-clickable sections still emit sectionDoubleClicked but no longer select the
+        # whole column on (double-)click — the header is a sort control, not a selector.
+        self.table_widget.horizontalHeader().setSectionsClickable(False)
         self.table_widget.horizontalHeader().sectionDoubleClicked.connect(self._on_header_double_clicked)
         self.table_widget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.table_widget.customContextMenuRequested.connect(self.show_context_menu)

--- a/src/pytest_fly/pytest_runner/pytest_runner.py
+++ b/src/pytest_fly/pytest_runner/pytest_runner.py
@@ -481,13 +481,16 @@ class PytestRunner(Thread):
                 )
                 db.write(info)
 
-    def force_stop_test(self, test_name: str) -> None:
+    def force_stop_test(self, test_name: str) -> bool:
         """Terminate a single running test identified by its node_id.
 
         Iterates worker threads and signals the one currently running the
         given test to terminate its process.  Other workers are unaffected.
 
         :param test_name: The test node_id to terminate.
+        :return: ``True`` if a worker was signaled, ``False`` if no worker is currently
+            running the test (e.g. a stale "Running" row whose process is already gone —
+            the caller is expected to clear it in the DB).
         """
         with self._pool_lock:
             test_runners = list(self._test_runners.values())
@@ -496,8 +499,9 @@ class PytestRunner(Thread):
             if proc is not None and proc.name == test_name:
                 test_runner.force_stop_current()
                 log.info(f'force stop requested for test "{test_name}" ({self.run_guid=})')
-                return
+                return True
         log.warning(f'force stop: no running process found for test "{test_name}" ({self.run_guid=})')
+        return False
 
 
 class _StallWatchdog(Thread):

--- a/tests/test_gui_widgets.py
+++ b/tests/test_gui_widgets.py
@@ -319,6 +319,47 @@ def test_fly_app_main_window_constructs(app):
         window.deleteLater()
 
 
+def test_force_stop_clears_stale_running_row(app):
+    """Force Stop on a stale "Running" row (no live process, no active runner) writes TERMINATED.
+
+    Regression for Force Stop being a silent no-op on tests whose process died without
+    writing a terminal record — the row showed Running forever and right-click → Force
+    Stop did nothing.
+    """
+    from pytest_fly.db import PytestProcessInfoDB
+
+    data_dir = get_temp_dir("test_force_stop_stale_row")
+    now = time.time()
+    guid = "stale-run"
+    with PytestProcessInfoDB(data_dir) as db:
+        db.write(PytestProcessInfo(run_guid=guid, name="tests/test_wedged.py", pid=None, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now - 10))
+        db.write(PytestProcessInfo(run_guid=guid, name="tests/test_wedged.py", pid=99999, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now - 9))
+        db.write(PytestProcessInfo(run_guid=guid, name="tests/test_done.py", pid=100, exit_code=PyTestFlyExitCode.OK, output="passed", time_stamp=now - 8))
+
+    window = FlyAppMainWindow(data_dir)
+    try:
+        window.timer.stop()
+        assert window.run_tab.control_window.pytest_runner is None  # no active run
+
+        window._force_stop_single_test("tests/test_wedged.py")  # stale row -> cleared
+        window._force_stop_single_test("tests/test_done.py")  # terminal row -> untouched
+
+        with PytestProcessInfoDB(data_dir) as db:
+            rows = db.query(guid)
+        latest_wedged = max((r for r in rows if r.name == "tests/test_wedged.py"), key=lambda r: r.time_stamp)
+        assert latest_wedged.exit_code == PyTestFlyExitCode.TERMINATED
+        latest_done = max((r for r in rows if r.name == "tests/test_done.py"), key=lambda r: r.time_stamp)
+        assert latest_done.exit_code == PyTestFlyExitCode.OK
+    finally:
+        window.timer.stop()
+        window._system_monitor.request_stop()
+        window._system_monitor.join(5.0)
+        if window._system_monitor.is_alive():
+            window._system_monitor.terminate()
+            window._system_monitor.join(5.0)
+        window.deleteLater()
+
+
 def test_window_geometry_round_trips_without_drift(app):
     """Reopening the app restores to a stable geometry — no per-launch drift.
 

--- a/tests/test_pytest_process_info_db.py
+++ b/tests/test_pytest_process_info_db.py
@@ -85,6 +85,69 @@ def test_pytest_process_info_db_query_most_recent():
         assert rows[0].run_guid == guid_new
 
 
+def test_mark_test_terminated_if_stale():
+    """A stale running row (latest record non-terminal) gets a TERMINATED record appended."""
+
+    db_dir = get_temp_dir("test_mark_test_terminated_if_stale")
+    now = time.time()
+    guid = generate_uuid()
+
+    with PytestProcessInfoDB(db_dir) as db:
+        db.write(PytestProcessInfo(run_guid=guid, name="test_stale", pid=None, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now - 10))
+        db.write(PytestProcessInfo(run_guid=guid, name="test_stale", pid=100, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now - 9, put_version="v1", put_fingerprint="fp1"))
+
+        assert db.mark_test_terminated_if_stale(guid, "test_stale")
+
+        rows = [r for r in db.query(guid) if r.name == "test_stale"]
+        assert len(rows) == 3
+        latest = max(rows, key=lambda r: r.time_stamp)
+        assert latest.exit_code == PyTestFlyExitCode.TERMINATED
+        assert latest.pid is None
+        # PUT metadata carries over from the stale record
+        assert latest.put_version == "v1"
+        assert latest.put_fingerprint == "fp1"
+
+
+def test_mark_test_terminated_if_stale_does_not_clobber_terminal():
+    """A test whose latest record is terminal (e.g. passed) is left untouched."""
+
+    db_dir = get_temp_dir("test_mark_stale_no_clobber")
+    now = time.time()
+    guid = generate_uuid()
+
+    with PytestProcessInfoDB(db_dir) as db:
+        db.write(PytestProcessInfo(run_guid=guid, name="test_done", pid=100, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now - 5))
+        db.write(PytestProcessInfo(run_guid=guid, name="test_done", pid=100, exit_code=PyTestFlyExitCode.OK, output="passed", time_stamp=now - 1))
+
+        assert not db.mark_test_terminated_if_stale(guid, "test_done")
+        assert not db.mark_test_terminated_if_stale(guid, "test_never_existed")
+
+        rows = [r for r in db.query(guid) if r.name == "test_done"]
+        assert len(rows) == 2  # nothing was written
+        assert max(rows, key=lambda r: r.time_stamp).exit_code == PyTestFlyExitCode.OK
+
+
+def test_mark_test_terminated_if_stale_run_guid_none():
+    """run_guid None resolves to the most recent run, matching what the GUI displays."""
+
+    db_dir = get_temp_dir("test_mark_stale_guid_none")
+    now = time.time()
+
+    with PytestProcessInfoDB(db_dir) as db:
+        # older run: same test name, stale — must NOT be touched
+        db.write(PytestProcessInfo(run_guid="aaa-old", name="test_x", pid=100, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now - 100))
+        # most recent run: stale running row
+        db.write(PytestProcessInfo(run_guid="zzz-new", name="test_x", pid=200, exit_code=PyTestFlyExitCode.NONE, output=None, time_stamp=now - 5))
+
+        assert db.mark_test_terminated_if_stale(None, "test_x")
+
+        new_rows = db.query("zzz-new")
+        assert max(new_rows, key=lambda r: r.time_stamp).exit_code == PyTestFlyExitCode.TERMINATED
+        old_rows = db.query("aaa-old")
+        assert len(old_rows) == 1  # untouched
+        assert old_rows[0].exit_code == PyTestFlyExitCode.NONE
+
+
 def test_query_last_pass():
     """query_last_pass returns data from the most recent passing run, even if a later run failed."""
 


### PR DESCRIPTION
## Problem

A test whose subprocess dies without writing a terminal record shows **Running** forever in the Tests table, and right-click → **Force Stop** on such a row was a silent no-op: `PytestRunner.force_stop_test` found no live worker process matching the name, logged a warning, and gave up — and with no active run, the GUI handler returned without doing anything at all. (Diagnosed from a live app showing 3 stale "Running" rows, one a singleton, where Force Stop appeared dead.)

## Fix

When Force Stop finds no live process to signal, write a **TERMINATED** record directly so the stale row clears:

- `PytestProcessInfoDB.mark_test_terminated_if_stale()` — guarded clear: writes TERMINATED only if the test's latest record is non-terminal, so a test that actually finished (e.g. passed just before the click) is never clobbered. `run_guid=None` resolves to the most recent run, matching what the GUI displays when no run is active.
- `PytestRunner.force_stop_test()` now returns whether a worker was signaled.
- `FlyAppMainWindow._force_stop_single_test()` falls through to the DB clear when no live process was signaled — covering both a stale row mid-run and a wedged run left over after an app restart.

## Also

The Tests table header no longer selects the whole column on (double-)click: `setSectionsClickable(False)`. `sectionDoubleClicked` still fires with sections non-clickable (verified empirically), so double-click sorting is unaffected.

## Testing

- New DB tests: stale row cleared; terminal row and unknown name untouched; `run_guid=None` targets only the most recent run.
- New GUI regression test: `_force_stop_single_test` on a stale row with no active runner writes TERMINATED; a passed test is untouched.
- Full suite: 398 passed. Verified separately end-to-end (live `PytestRunner` + `TableTab`) that the normal Force Stop path still terminates a running test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
