### PR TITLE
Include terminated tests in the Failed Tests list — v0.4.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pytest-fly"
 description = "pytest runner and observer"
-version = "0.4.27"
+version = "0.4.28"
 readme = "README.md"
 requires-python = ">=3.12"
 authors = [

--- a/src/pytest_fly/gui/run_tab/failed_tests_window.py
+++ b/src/pytest_fly/gui/run_tab/failed_tests_window.py
@@ -1,4 +1,4 @@
-"""Failed tests pane — lists test names that have failed in the current run, with clipboard copy and click-to-inspect support."""
+"""Failed tests pane — lists test names that have failed (or been terminated) in the current run, with clipboard copy and click-to-inspect support."""
 
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QListWidget, QListWidgetItem, QPushButton, QSizePolicy, QVBoxLayout
@@ -6,9 +6,12 @@ from PySide6.QtWidgets import QGroupBox, QHBoxLayout, QListWidget, QListWidgetIt
 from ...interfaces import PytestRunnerState
 from ...tick_data import TickData
 
+# States listed in the pane: a terminated test never completed, so it is treated as a failure.
+_FAILED_STATES = frozenset({PytestRunnerState.FAIL, PytestRunnerState.TERMINATED})
+
 
 class FailedTestsWindow(QGroupBox):
-    """Displays a clickable list of failed test names, with a button to copy them to the clipboard.
+    """Displays a clickable list of failed (or terminated) test names, with a button to copy them to the clipboard.
 
     Selecting a test emits :attr:`failed_test_selected` so a sibling pane can show that test's
     captured output; clearing the selection (clicking the selected row again) emits ``None``.
@@ -45,7 +48,7 @@ class FailedTestsWindow(QGroupBox):
 
     def update_tick(self, tick: TickData):
         """Rebuild the failed test list from pre-computed tick data, preserving selection by name."""
-        failed_names = [test_name for test_name, run_state in tick.run_states.items() if run_state.get_state() == PytestRunnerState.FAIL]
+        failed_names = [test_name for test_name, run_state in tick.run_states.items() if run_state.get_state() in _FAILED_STATES]
 
         if failed_names == self._failed_names:
             return

--- a/tests/test_gui_run_windows.py
+++ b/tests/test_gui_run_windows.py
@@ -57,6 +57,25 @@ def test_failed_tests_window_lists_failures(app):
     assert window._copy_button.isEnabled()
 
 
+def test_failed_tests_window_lists_terminated(app):
+    """A terminated test is listed alongside failed tests; a stopped (never-ran) test is not."""
+    now = time.time()
+    infos = [
+        _info("tests/test_a.py", 1, PyTestFlyExitCode.NONE, now - 5),
+        _info("tests/test_a.py", 1, PyTestFlyExitCode.TERMINATED, now - 1),
+        _info("tests/test_b.py", 2, PyTestFlyExitCode.NONE, now - 5),
+        _info("tests/test_b.py", 2, PyTestFlyExitCode.TESTS_FAILED, now - 1),
+        _info("tests/test_c.py", None, PyTestFlyExitCode.STOPPED, now - 1),
+    ]
+    window = FailedTestsWindow(None)
+    window.update_tick(build_tick_data(infos))
+    names = _failed_item_names(window)
+    assert "tests/test_a.py" in names  # terminated counts as failed
+    assert "tests/test_b.py" in names
+    assert "tests/test_c.py" not in names  # stopped (never ran) is not a failure
+    assert window._copy_button.isEnabled()
+
+
 def test_failed_tests_window_click_toggles_selection(app):
     """Clicking a failed test emits its name; clicking it again toggles off (emits None)."""
     window = FailedTestsWindow(None)


### PR DESCRIPTION
## Summary

The run tab's Failed Tests pane only listed tests in the `FAIL` state, so a test whose process was forcefully terminated silently disappeared from the pane. Terminated tests never completed, so they are now treated as failures:

- They appear in the Failed Tests list alongside failing tests.
- They are included in Copy to Clipboard.
- They can be clicked/pinned to inspect their captured output.

`STOPPED` (queued but never ran) tests remain excluded — they were never attempted, so they aren't failures.

## Changes

- `failed_tests_window.py`: filter on a `_FAILED_STATES` set (`FAIL`, `TERMINATED`) instead of `FAIL` alone.
- `test_gui_run_windows.py`: new test verifying a terminated test is listed, a stopped one is not.
- Version bump to 0.4.28.

## Testing

- Full suite: 399 passed.
- `ruff check` / `ruff format --check`: clean.
- `ty check src`: only pre-existing diagnostics in unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
